### PR TITLE
fix(posts): redirect after Inertia reschedule

### DIFF
--- a/app/Http/Controllers/Posts/PostScheduleController.php
+++ b/app/Http/Controllers/Posts/PostScheduleController.php
@@ -10,10 +10,11 @@ use App\Http\Requests\Post\SchedulePostRequest;
 use App\Models\Post;
 use App\Support\PostView;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 
 class PostScheduleController extends Controller
 {
-    public function update(SchedulePostRequest $request, Post $post): JsonResponse
+    public function update(SchedulePostRequest $request, Post $post): JsonResponse|RedirectResponse
     {
         $scheduledAt = $request->validated('scheduled_at');
 
@@ -26,6 +27,10 @@ class PostScheduleController extends Controller
         }
 
         $post->save();
+
+        if ($request->headers->has('X-Inertia')) {
+            return back();
+        }
 
         return response()->json(['post' => PostView::make($post->fresh(['targets.account', 'media']))]);
     }

--- a/app/Http/Controllers/Posts/PostTargetRetryController.php
+++ b/app/Http/Controllers/Posts/PostTargetRetryController.php
@@ -12,11 +12,12 @@ use App\Models\PostTarget;
 use App\Services\Publishing\PostStatusRollup;
 use App\Support\PostView;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class PostTargetRetryController extends Controller
 {
-    public function store(Request $request, Post $post, PostTarget $target): JsonResponse
+    public function store(Request $request, Post $post, PostTarget $target): JsonResponse|RedirectResponse
     {
         abort_unless($request->user()->can('update', $post), 403);
         abort_unless($target->status === PostTargetStatus::Failed, 409);
@@ -32,6 +33,10 @@ class PostTargetRetryController extends Controller
 
         // Reflect the in-flight retry on the post status immediately.
         app(PostStatusRollup::class)->recompute($post);
+
+        if ($request->headers->has('X-Inertia')) {
+            return back();
+        }
 
         return response()->json(['post' => PostView::make($post->fresh(['targets.account', 'media']))]);
     }

--- a/tests/Feature/Posts/ScheduleApiTest.php
+++ b/tests/Feature/Posts/ScheduleApiTest.php
@@ -95,6 +95,28 @@ test('PUT /posts/{post}/schedule reschedules a missed post back to scheduled', f
     expect($post->scheduled_at->toIso8601String())->toBe('2030-01-01T09:00:00+00:00');
 });
 
+test('PUT /posts/{post}/schedule redirects after an Inertia reschedule request', function () {
+    [$user, $workspace] = schedulingMember();
+    $post = Post::factory()->create([
+        'workspace_id' => $workspace->id,
+        'status' => PostStatus::Scheduled,
+        'scheduled_at' => now()->addDay(),
+    ]);
+
+    test()->from('/dashboard')
+        ->put("/posts/{$post->id}/schedule", [
+            'scheduled_at' => '2030-01-01T09:00:00+00:00',
+        ], [
+            'X-Inertia' => 'true',
+            'X-Inertia-Version' => 'test',
+        ])
+        ->assertRedirect('/dashboard');
+
+    $post->refresh();
+    expect($post->status)->toBe(PostStatus::Scheduled);
+    expect($post->scheduled_at->toIso8601String())->toBe('2030-01-01T09:00:00+00:00');
+});
+
 test('a member cannot schedule a post in another workspace', function () {
     [$user, $workspace] = schedulingMember();
     $foreign = Post::factory()->create(); // different workspace

--- a/tests/Feature/Publishing/PublishEndpointTest.php
+++ b/tests/Feature/Publishing/PublishEndpointTest.php
@@ -65,6 +65,23 @@ test('per-target retry resets a failed target to pending and dispatches it', fun
     Bus::assertDispatched(PublishPostTarget::class, fn (PublishPostTarget $job): bool => $job->target->is($target));
 });
 
+test('per-target retry redirects after an Inertia retry request', function () {
+    Bus::fake();
+    [$user, $workspace] = publishingMember();
+    $post = Post::factory()->create(['workspace_id' => $workspace->id, 'status' => PostStatus::Failed]);
+    $target = PostTarget::factory()->for($post)->failed()->create();
+
+    test()->from('/dashboard')
+        ->post("/posts/{$post->id}/targets/{$target->id}/retry", [], [
+            'X-Inertia' => 'true',
+            'X-Inertia-Version' => 'test',
+        ])
+        ->assertRedirect('/dashboard');
+
+    expect($target->refresh()->status)->toBe(PostTargetStatus::Pending);
+    Bus::assertDispatched(PublishPostTarget::class, fn (PublishPostTarget $job): bool => $job->target->is($target));
+});
+
 test('retry rejects a non-failed target with 409 and dispatches nothing', function () {
     Bus::fake();
     [$user, $workspace] = publishingMember();


### PR DESCRIPTION
## Summary
- Return a redirect for Inertia post reschedule requests so the client receives the expected navigation response.
- Preserve the existing JSON response for API reschedule calls.
- Add feature coverage for Inertia reschedule requests redirecting back to the originating page.

This was returning the Inertia error.

<img width="1358" height="699" alt="image" src="https://github.com/user-attachments/assets/2c885372-618f-4d9b-af25-cc28bb13317a" />
