### PR TITLE
chore(config): default env example to local social login off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 APP_NAME=Laravel
-APP_ENV=production
+APP_ENV=local
 APP_KEY=
 APP_DEBUG=false
 APP_URL=http://localhost
@@ -88,7 +88,7 @@ WORKSPACES_CAN_CREATE_WORKSPACE=true
 WORKSPACE_INVITATION_TTL_DAYS=7
 
 # Social login (Laravel Socialite)
-SOCIALITE_ENABLED=true
+SOCIALITE_ENABLED=false
 # Comma-separated. Supported: google, x, linkedin. X and LinkedIn reuse the
 # X_*/LINKEDIN_* credentials below (shared with connected accounts) — just also
 # register the login callback (/auth/x/callback, /auth/linkedin/callback) in each


### PR DESCRIPTION
## Summary
- Set the example application environment to `local` instead of `production`.
- Disable Socialite by default in `.env.example` so fresh development setups do not require social login configuration.

This helps contributors to get started. I was confused initially as half of the stuffs wont work as APP_ENV was prod by default.

Socialite is also not needed as it just cause confusion if providers are not filled. 