### PR TITLE
feat(auth): add local default login user

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -56,6 +56,7 @@ class FortifyServiceProvider extends ServiceProvider
             'status' => $request->session()->get('status'),
             'providers' => SocialProvider::enabledProvidersWithLabels(),
             'invitation' => $request->query('invitation'),
+            ...$this->defaultLoginCredentials(),
         ]));
 
         Fortify::resetPasswordView(fn (Request $request) => Inertia::render('auth/reset-password', [
@@ -81,6 +82,25 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::twoFactorChallengeView(fn () => Inertia::render('auth/two-factor-challenge'));
 
         Fortify::confirmPasswordView(fn () => Inertia::render('auth/confirm-password'));
+    }
+
+    /**
+     * Get default login credentials for local development.
+     *
+     * @return array<string, array{email: string, password: string}>
+     */
+    private function defaultLoginCredentials(): array
+    {
+        if (! app()->isLocal()) {
+            return [];
+        }
+
+        return [
+            'defaultLogin' => [
+                'email' => 'test@example.com',
+                'password' => 'password',
+            ],
+        ];
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
+            "@php artisan db:seed --class=DefaultUserSeeder --force --no-interaction",
             "bunx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74,#86efac\" \"php artisan serve --host=127.0.0.1\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"bun run dev\" \"php artisan schedule:work\" --names=server,queue,logs,vite,cron --kill-others"
         ],
         "lint": [

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -15,11 +14,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        if (app()->isLocal()) {
+            $this->call(DefaultUserSeeder::class);
+        }
     }
 }

--- a/database/seeders/DefaultUserSeeder.php
+++ b/database/seeders/DefaultUserSeeder.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\WorkspaceRole;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
+use Illuminate\Database\Seeder;
+
+class DefaultUserSeeder extends Seeder
+{
+    /**
+     * Seed the default development user and workspace.
+     */
+    public function run(): void
+    {
+        $user = User::query()->firstOrCreate(
+            ['email' => 'test@example.com'],
+            [
+                'name' => 'Test User',
+                'password' => 'password',
+                'email_verified_at' => now(),
+            ],
+        );
+
+        $workspace = Workspace::query()->firstOrCreate(
+            ['slug' => 'test-workspace'],
+            [
+                'name' => 'Test Workspace',
+                'owner_id' => $user->id,
+                'timezone' => 'UTC',
+            ],
+        );
+
+        WorkspaceMembership::query()->firstOrCreate(
+            [
+                'workspace_id' => $workspace->id,
+                'user_id' => $user->id,
+            ],
+            ['role' => WorkspaceRole::Owner],
+        );
+
+        $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    }
+}

--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -21,6 +21,10 @@ type Props = {
     canResetPassword: boolean;
     providers?: SocialProviderOption[];
     invitation?: string;
+    defaultLogin?: {
+        email: string;
+        password: string;
+    };
 };
 
 export default function Login({
@@ -28,6 +32,7 @@ export default function Login({
     canResetPassword,
     providers = [],
     invitation,
+    defaultLogin,
 }: Props) {
     return (
         <>
@@ -68,6 +73,7 @@ export default function Login({
                                     tabIndex={1}
                                     autoComplete="email"
                                     placeholder="email@example.com"
+                                    defaultValue={defaultLogin?.email}
                                 />
                                 <InputError message={errors.email} />
                             </div>
@@ -92,6 +98,7 @@ export default function Login({
                                     tabIndex={2}
                                     autoComplete="current-password"
                                     placeholder="Password"
+                                    defaultValue={defaultLogin?.password}
                                 />
                                 <InputError message={errors.password} />
                             </div>

--- a/tests/Feature/ComposerDevScriptTest.php
+++ b/tests/Feature/ComposerDevScriptTest.php
@@ -1,0 +1,7 @@
+<?php
+
+it('seeds the default user before starting development services', function (): void {
+    $composer = json_decode(file_get_contents(base_path('composer.json')), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($composer['scripts']['dev'])->toContain('@php artisan db:seed --class=DefaultUserSeeder --force --no-interaction');
+});

--- a/tests/Feature/DefaultDevelopmentUserTest.php
+++ b/tests/Feature/DefaultDevelopmentUserTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Enums\WorkspaceRole;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
+use Database\Seeders\DatabaseSeeder;
+
+it('seeds the default user with a current workspace in development', function (): void {
+    $this->app->detectEnvironment(fn () => 'local');
+
+    $this->seed(DatabaseSeeder::class);
+
+    $user = User::query()->where('email', 'test@example.com')->firstOrFail();
+
+    expect($user->name)->toBe('Test User')
+        ->and($user->current_workspace_id)->not->toBeNull()
+        ->and(Workspace::query()->whereKey($user->current_workspace_id)->exists())->toBeTrue()
+        ->and(WorkspaceMembership::query()
+            ->where('workspace_id', $user->current_workspace_id)
+            ->where('user_id', $user->id)
+            ->where('role', WorkspaceRole::Owner)
+            ->exists())->toBeTrue();
+});
+
+it('does not seed the default user outside development', function (): void {
+    $this->app->detectEnvironment(fn () => 'production');
+
+    $this->artisan('db:seed', [
+        '--class' => DatabaseSeeder::class,
+        '--force' => true,
+    ])->assertExitCode(0);
+
+    expect(User::query()->where('email', 'test@example.com')->exists())->toBeFalse();
+});

--- a/tests/Feature/LoginDevelopmentDefaultsTest.php
+++ b/tests/Feature/LoginDevelopmentDefaultsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Inertia\Testing\AssertableInertia as Assert;
+
+it('prefills the login form with development default credentials in local', function (): void {
+    $this->app->detectEnvironment(fn () => 'local');
+
+    $this->get(route('login'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('auth/login')
+            ->where('defaultLogin.email', 'test@example.com')
+            ->where('defaultLogin.password', 'password'));
+});
+
+it('does not expose development default credentials outside local', function (): void {
+    $this->app->detectEnvironment(fn () => 'production');
+
+    $this->get(route('login'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('auth/login')
+            ->missing('defaultLogin'));
+});


### PR DESCRIPTION
## Summary
- Seed a default local development user with an owned workspace and current workspace assignment.
- Prefill the local login form with the default development credentials while keeping them hidden outside local environments.
- Run the default user seeder before starting local development services.
- Add feature coverage for local-only seeding, login defaults, and the Composer dev script.