### PR TITLE
chore(config): enable Socialite during tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -30,6 +30,7 @@
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
+        <env name="SOCIALITE_ENABLED" value="true"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="NIGHTWATCH_ENABLED" value="false"/>


### PR DESCRIPTION
## Summary
- Enables Socialite in the PHPUnit test environment so social login-related tests run with the expected feature flag state.