### PR TITLE
fix(ui): use opaque platform badge backgrounds

### DIFF
--- a/resources/js/components/accounts/account-card.tsx
+++ b/resources/js/components/accounts/account-card.tsx
@@ -25,12 +25,9 @@ import type { Account } from './types';
 
 /** Per-platform brand accent for the glyph tile (encodes which network it is). */
 const PLATFORM_BRAND: Record<string, { tile: string; glyph: string }> = {
-    x: { tile: 'bg-foreground/5', glyph: 'text-foreground' },
-    linkedin: {
-        tile: 'bg-blue-500/10',
-        glyph: 'text-blue-600 dark:text-blue-400',
-    },
-    bluesky: { tile: 'bg-sky-500/10', glyph: 'text-sky-500' },
+    x: { tile: 'bg-white', glyph: 'text-black!' },
+    linkedin: { tile: 'bg-blue-600', glyph: 'text-white!' },
+    bluesky: { tile: 'bg-sky-500', glyph: 'text-white!' },
 };
 
 const PLATFORM_FALLBACK = { tile: 'bg-muted', glyph: 'text-muted-foreground' };
@@ -151,6 +148,7 @@ export function AccountCard({
                             <PlatformGlyph
                                 platform={account.platform as PlatformName}
                                 size={11}
+                                className={brand.glyph}
                             />
                         </span>
                     </div>

--- a/resources/js/components/common/__tests__/platform-brand.test.ts
+++ b/resources/js/components/common/__tests__/platform-brand.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const files = [
+    'resources/js/components/accounts/account-card.tsx',
+    'resources/js/components/compose/destination-selector.tsx',
+    'resources/js/components/compose/platform-tabs.tsx',
+];
+
+const opaquePlatformStyles = [
+    "x: { tile: 'bg-white', glyph: 'text-black!' }",
+    "linkedin: { tile: 'bg-blue-600', glyph: 'text-white!' }",
+    "bluesky: { tile: 'bg-sky-500', glyph: 'text-white!' }",
+];
+
+describe('platform badge styles', () => {
+    it.each(files)('%s gives platform icons opaque backgrounds', (file) => {
+        const source = readFileSync(resolve(process.cwd(), file), 'utf8');
+
+        for (const style of opaquePlatformStyles) {
+            expect(source).toContain(style);
+        }
+
+        expect(source).not.toContain("x: { tile: 'bg-foreground/5'");
+        expect(source).not.toContain("tile: 'bg-blue-500/10'");
+        expect(source).not.toContain("tile: 'bg-sky-500/10'");
+    });
+
+    it('puts the protected glyph color on the SVG, not only the wrapper', () => {
+        const accountCard = readFileSync(
+            resolve(
+                process.cwd(),
+                'resources/js/components/accounts/account-card.tsx',
+            ),
+            'utf8',
+        );
+        const destinationSelector = readFileSync(
+            resolve(
+                process.cwd(),
+                'resources/js/components/compose/destination-selector.tsx',
+            ),
+            'utf8',
+        );
+        const platformTabs = readFileSync(
+            resolve(
+                process.cwd(),
+                'resources/js/components/compose/platform-tabs.tsx',
+            ),
+            'utf8',
+        );
+
+        expect(accountCard).toContain('className={brand.glyph}');
+        expect(destinationSelector).toContain(
+            "className={cn('size-1.5', brand.glyph)}",
+        );
+        expect(platformTabs).toContain('className={brand.glyph}');
+    });
+});

--- a/resources/js/components/compose/destination-selector.tsx
+++ b/resources/js/components/compose/destination-selector.tsx
@@ -16,12 +16,9 @@ import type { Account, AccountSet, Destination } from '@/types/compose';
 
 /** Per-platform brand accent for the glyph badge (mirrors the accounts page). */
 const PLATFORM_BRAND: Record<string, { tile: string; glyph: string }> = {
-    x: { tile: 'bg-foreground/5', glyph: 'text-foreground' },
-    linkedin: {
-        tile: 'bg-blue-500/10',
-        glyph: 'text-blue-600 dark:text-blue-400',
-    },
-    bluesky: { tile: 'bg-sky-500/10', glyph: 'text-sky-500' },
+    x: { tile: 'bg-white', glyph: 'text-black!' },
+    linkedin: { tile: 'bg-blue-600', glyph: 'text-white!' },
+    bluesky: { tile: 'bg-sky-500', glyph: 'text-white!' },
 };
 
 const PLATFORM_FALLBACK = { tile: 'bg-muted', glyph: 'text-muted-foreground' };
@@ -56,7 +53,7 @@ function AccountVisual({ account }: { account: Account }) {
                     class-less svg to size-4 (16px). */}
                 <PlatformGlyph
                     platform={account.platform}
-                    className="size-1.5"
+                    className={cn('size-1.5', brand.glyph)}
                 />
             </span>
         </span>

--- a/resources/js/components/compose/platform-tabs.tsx
+++ b/resources/js/components/compose/platform-tabs.tsx
@@ -2,6 +2,14 @@ import { PlatformGlyph } from '@/components/common/platform-glyph';
 import { cn } from '@/lib/utils';
 import { BASE_TAB, type Account } from '@/types/compose';
 
+const PLATFORM_BRAND: Record<string, { tile: string; glyph: string }> = {
+    x: { tile: 'bg-white', glyph: 'text-black!' },
+    linkedin: { tile: 'bg-blue-600', glyph: 'text-white!' },
+    bluesky: { tile: 'bg-sky-500', glyph: 'text-white!' },
+};
+
+const PLATFORM_FALLBACK = { tile: 'bg-muted', glyph: 'text-muted-foreground' };
+
 type PlatformTabsProps = {
     /** One tab per destination account. Empty → a single generic "Post" tab. */
     accounts: Account[];
@@ -68,6 +76,8 @@ export default function PlatformTabs({
                 const isActive = account.id === activeTab;
                 const severity = stateFor(account.id);
                 const overridden = hasOverride(account.id);
+                const brand =
+                    PLATFORM_BRAND[account.platform] ?? PLATFORM_FALLBACK;
 
                 return (
                     <button
@@ -84,14 +94,14 @@ export default function PlatformTabs({
                         <span
                             className={cn(
                                 'grid size-[18px] place-items-center rounded-[5px]',
-                                isActive
-                                    ? 'bg-foreground text-background'
-                                    : 'bg-muted text-foreground',
+                                brand.tile,
+                                brand.glyph,
                             )}
                         >
                             <PlatformGlyph
                                 platform={account.platform}
                                 size={11}
+                                className={brand.glyph}
                             />
                         </span>
                         <span>{account.handle}</span>


### PR DESCRIPTION
## Summary
- Applies solid brand-colored badge backgrounds for X, LinkedIn, and Bluesky icons across account and compose UI.
- Ensures glyph color is applied directly to platform SVGs so icon contrast remains consistent.
- Adds coverage to guard platform badge styling across account cards, destination selection, and platform tabs.