### PR TITLE
fix(navigation): redirect after destructive context changes

### DIFF
--- a/app/Http/Controllers/Posts/PostController.php
+++ b/app/Http/Controllers/Posts/PostController.php
@@ -122,7 +122,7 @@ class PostController extends Controller
         if (! $hadBeenPublished) {
             $post->delete();
 
-            return back()->with('success', 'Post deleted.');
+            return redirect()->route('posts.index')->with('success', 'Post deleted.');
         }
 
         $post->targets
@@ -134,6 +134,6 @@ class PostController extends Controller
             'deleted_at' => now(),
         ])->save();
 
-        return back()->with('success', 'Post deleted from connected accounts where possible.');
+        return redirect()->route('posts.index')->with('success', 'Post deleted from connected accounts where possible.');
     }
 }

--- a/app/Http/Controllers/WorkspaceController.php
+++ b/app/Http/Controllers/WorkspaceController.php
@@ -58,7 +58,7 @@ class WorkspaceController extends Controller
 
         $user->forceFill(['current_workspace_id' => $request->input('workspace_id')])->save();
 
-        return back()->with('success', 'Workspace switched.');
+        return redirect()->route('dashboard')->with('success', 'Workspace switched.');
     }
 
     public function leave(Request $request, Workspace $workspace): RedirectResponse

--- a/tests/Feature/Posts/PostDeleteTest.php
+++ b/tests/Feature/Posts/PostDeleteTest.php
@@ -61,6 +61,21 @@ it('hard-deletes a scheduled post and dispatches no remote-delete job', function
     Queue::assertNothingPushed();
 });
 
+it('redirects to the posts index after deleting the post currently being viewed', function (): void {
+    Queue::fake();
+    [$user, $workspace] = deleteTestMember();
+    $post = Post::factory()->for($workspace)->create([
+        'author_id' => $user->id, 'status' => PostStatus::Draft->value,
+    ]);
+
+    $this->actingAs($user)
+        ->from(route('posts.show', $post))
+        ->delete(route('posts.destroy', $post))
+        ->assertRedirect(route('posts.index'));
+
+    expect(Post::query()->whereKey($post->id)->exists())->toBeFalse();
+});
+
 it('soft-deletes a published post and dispatches remote delete per target with a remote id', function (): void {
     Queue::fake();
     [$user, $workspace] = deleteTestMember();

--- a/tests/Feature/Workspace/WorkspaceStoreSwitchTest.php
+++ b/tests/Feature/Workspace/WorkspaceStoreSwitchTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\WorkspaceRole;
+use App\Models\Post;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Models\WorkspaceMembership;
@@ -35,4 +36,21 @@ test('user can switch to their workspace', function () {
         ->assertRedirect();
 
     $this->assertSame($workspace->id, $user->fresh()->current_workspace_id);
+});
+
+test('switching workspace redirects away from workspace-scoped detail pages', function () {
+    $user = User::factory()->create();
+    $current = Workspace::factory()->create();
+    $next = Workspace::factory()->create();
+    WorkspaceMembership::factory()->create(['workspace_id' => $current->id, 'user_id' => $user->id]);
+    WorkspaceMembership::factory()->create(['workspace_id' => $next->id, 'user_id' => $user->id]);
+    $user->forceFill(['current_workspace_id' => $current->id])->save();
+    $post = Post::factory()->for($current)->create(['author_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->from(route('posts.show', $post))
+        ->post(route('workspaces.switch'), ['workspace_id' => $next->id])
+        ->assertRedirect(route('dashboard'));
+
+    $this->assertSame($next->id, $user->fresh()->current_workspace_id);
 });


### PR DESCRIPTION
## Summary
- Redirect deleted posts to the posts index instead of returning to a stale post detail page.
- Redirect workspace switches to the dashboard so users do not remain on workspace-scoped detail pages from the previous workspace.
- Add coverage for post-delete and workspace-switch redirect behavior.