### PR TITLE
fix(charts): format follower tooltip dates from payload

### DIFF
--- a/resources/js/components/analytics/__tests__/follower-chart.test.ts
+++ b/resources/js/components/analytics/__tests__/follower-chart.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatFollowerTooltipDate } from '../follower-chart';
+
+describe('follower chart tooltip', () => {
+    it('formats the x-axis date from the tooltip payload', () => {
+        const timestamp = new Date('2026-06-22T12:00:00.000Z').getTime();
+
+        expect(
+            formatFollowerTooltipDate('Andras Bacsai', [
+                { payload: { date: timestamp } },
+            ]),
+        ).toBe('Jun 22, 2026');
+    });
+});

--- a/resources/js/components/analytics/follower-chart.tsx
+++ b/resources/js/components/analytics/follower-chart.tsx
@@ -30,6 +30,27 @@ type FollowerChartProps = {
     posts: AnalyticsPageProps['posts'];
 };
 
+type TooltipPayloadWithDate = readonly {
+    payload?: {
+        date?: Date | number | string | null;
+    };
+}[];
+
+export function formatFollowerTooltipDate(
+    _label: unknown,
+    payload?: TooltipPayloadWithDate,
+): string {
+    const date = payload?.[0]?.payload?.date;
+
+    if (date === undefined || date === null || date === '') {
+        return '';
+    }
+
+    const formattedDate = dayjs(date);
+
+    return formattedDate.isValid() ? formattedDate.format('MMM D, YYYY') : '';
+}
+
 /**
  * The follower-growth line chart. Lives in its own module so recharts (a heavy
  * dependency) is code-split into a lazily-loaded chunk and only fetched when
@@ -109,9 +130,7 @@ export default function FollowerChart({ accounts, posts }: FollowerChartProps) {
                     <ChartTooltip
                         content={
                             <ChartTooltipContent
-                                labelFormatter={(v) =>
-                                    dayjs(v as number).format('MMM D, YYYY')
-                                }
+                                labelFormatter={formatFollowerTooltipDate}
                                 indicator="line"
                             />
                         }

--- a/resources/js/components/ui/__tests__/chart.test.ts
+++ b/resources/js/components/ui/__tests__/chart.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+describe('chart tooltip content', () => {
+    it('keeps space between a series label and its value', () => {
+        const source = readFileSync(
+            resolve(process.cwd(), 'resources/js/components/ui/chart.tsx'),
+            'utf8',
+        );
+
+        expect(source).toContain(
+            'flex flex-1 justify-between gap-2 leading-none',
+        );
+    });
+});

--- a/resources/js/components/ui/chart.tsx
+++ b/resources/js/components/ui/chart.tsx
@@ -240,7 +240,7 @@ function ChartTooltipContent({
                     )}
                     <div
                       className={cn(
-                        "flex flex-1 justify-between leading-none",
+                        "flex flex-1 justify-between gap-2 leading-none",
                         nestLabel ? "items-end" : "items-center"
                       )}
                     >


### PR DESCRIPTION
## Summary
- Fixes follower chart tooltip dates by formatting the date from the chart payload instead of the tooltip label.
- Adds tooltip spacing so series labels and values remain visually separated.
- Adds tests covering follower tooltip date formatting and chart tooltip spacing.