### PR TITLE
fix(queue): widen add-time select triggers

### DIFF
--- a/resources/js/components/queue/__tests__/add-time-popover.test.ts
+++ b/resources/js/components/queue/__tests__/add-time-popover.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const source = () =>
+    readFileSync(
+        resolve(
+            process.cwd(),
+            'resources/js/components/queue/add-time-popover.tsx',
+        ),
+        'utf8',
+    );
+
+describe('posting queue add-time popover', () => {
+    it('keeps time select triggers wide enough for two-digit values and the chevron', () => {
+        const triggerClass =
+            'className="h-7 w-16 px-2 font-mono text-[12px] tabular-nums"';
+
+        expect(source().split(triggerClass)).toHaveLength(3);
+        expect(source()).not.toContain('className="h-7 w-14 font-mono');
+    });
+});

--- a/resources/js/components/queue/add-time-popover.tsx
+++ b/resources/js/components/queue/add-time-popover.tsx
@@ -60,14 +60,18 @@ export function AddTimePopover({
                     >
                         <SelectTrigger
                             size="sm"
-                            className="h-7 w-14 font-mono text-[12px] tabular-nums"
+                            className="h-7 w-16 px-2 font-mono text-[12px] tabular-nums"
                         >
                             <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
                             {Array.from({ length: 12 }, (_, i) => i + 1).map(
                                 (h) => (
-                                    <SelectItem key={h} value={String(h)}>
+                                    <SelectItem
+                                        key={h}
+                                        value={String(h)}
+                                        className="font-mono tabular-nums"
+                                    >
                                         {String(h).padStart(2, '0')}
                                     </SelectItem>
                                 ),
@@ -81,13 +85,17 @@ export function AddTimePopover({
                     >
                         <SelectTrigger
                             size="sm"
-                            className="h-7 w-14 font-mono text-[12px] tabular-nums"
+                            className="h-7 w-16 px-2 font-mono text-[12px] tabular-nums"
                         >
                             <SelectValue />
                         </SelectTrigger>
                         <SelectContent className="max-h-60">
                             {MINUTES.map((m) => (
-                                <SelectItem key={m} value={String(m)}>
+                                <SelectItem
+                                    key={m}
+                                    value={String(m)}
+                                    className="font-mono tabular-nums"
+                                >
                                     {String(m).padStart(2, '0')}
                                 </SelectItem>
                             ))}


### PR DESCRIPTION
## Summary
- Widen the add-time hour and minute select triggers so two-digit values and the chevron fit cleanly.
- Apply tabular mono styling to time select items for consistent alignment.
- Add coverage to guard against the narrower trigger classes returning.