### PR TITLE
fix(workspaces): prevent deleting final workspace

### DIFF
--- a/app/Http/Controllers/Settings/WorkspaceSettingsController.php
+++ b/app/Http/Controllers/Settings/WorkspaceSettingsController.php
@@ -42,6 +42,9 @@ class WorkspaceSettingsController extends Controller
             ],
             'canManage' => $user->hasAllPermissions(['workspace.settings.manage'], $workspace->id),
             'isOwner' => $user->isOwnerOfWorkspace($workspace->id),
+            'canDelete' => $user->workspaceMemberships()
+                ->where('workspace_id', '!=', $workspace->id)
+                ->exists(),
             'timezone' => $timezone,
             'timezones' => timezone_identifiers_list(),
         ]);

--- a/app/Http/Controllers/WorkspaceController.php
+++ b/app/Http/Controllers/WorkspaceController.php
@@ -96,6 +96,10 @@ class WorkspaceController extends Controller
             abort(403);
         }
 
+        if (! $user->workspaceMemberships()->where('workspace_id', '!=', $workspace->id)->exists()) {
+            return back()->withErrors(['workspace' => 'Create or join another workspace before deleting this one.']);
+        }
+
         DB::transaction(function () use ($workspace): void {
             // Reassign current workspace for any member who had this as their current,
             // BEFORE the nullOnDelete FK cascade fires, so they land on another of their

--- a/resources/js/components/layout/command-palette.tsx
+++ b/resources/js/components/layout/command-palette.tsx
@@ -33,6 +33,7 @@ import {
     type RecentItem,
 } from '@/lib/command/recents';
 import { usePostSearch } from '@/lib/command/use-post-search';
+import { switchWorkspace } from '@/lib/workspaces/switch-workspace';
 import { dashboard, logout } from '@/routes';
 import { index as accountsRoute } from '@/routes/accounts';
 import {
@@ -40,7 +41,6 @@ import {
     month as calendarMonth,
 } from '@/routes/calendar';
 import { index as postsRoute } from '@/routes/posts';
-import { switchMethod } from '@/routes/workspaces';
 
 import { ComposeDestinationPage } from './command-palette/compose-destination-page';
 import { ConnectPlatformPage } from './command-palette/connect-platform-page';
@@ -363,15 +363,8 @@ export function CommandPalette() {
                                                 key={workspace.id}
                                                 value={`switch workspace ${workspace.name}`}
                                                 onSelect={run(() =>
-                                                    router.post(
-                                                        switchMethod.url(),
-                                                        {
-                                                            workspace_id:
-                                                                workspace.id,
-                                                        },
-                                                        {
-                                                            preserveState: false,
-                                                        },
+                                                    switchWorkspace(
+                                                        workspace.id,
                                                     ),
                                                 )}
                                             >

--- a/resources/js/components/workspace/create-workspace-dialog.tsx
+++ b/resources/js/components/workspace/create-workspace-dialog.tsx
@@ -1,4 +1,4 @@
-import { Form } from '@inertiajs/react';
+import { Form, router } from '@inertiajs/react';
 import { Loader2 } from 'lucide-react';
 
 import WorkspaceController from '@/actions/App/Http/Controllers/WorkspaceController';
@@ -33,8 +33,13 @@ export function CreateWorkspaceDialog({
 
                 <Form
                     {...WorkspaceController.store.form()}
+                    options={{ preserveState: false }}
                     resetOnSuccess={['name']}
-                    onSuccess={() => onOpenChange(false)}
+                    onBefore={() => router.flushAll()}
+                    onSuccess={() => {
+                        router.flushAll();
+                        onOpenChange(false);
+                    }}
                     className="flex flex-col gap-4"
                 >
                     {({ processing, errors }) => (

--- a/resources/js/components/workspace/workspace-selector.tsx
+++ b/resources/js/components/workspace/workspace-selector.tsx
@@ -1,4 +1,4 @@
-import { router, usePage } from '@inertiajs/react';
+import { usePage } from '@inertiajs/react';
 import { Check, ChevronsUpDown, Loader2, Plus, Users } from 'lucide-react';
 import { useState } from 'react';
 
@@ -17,7 +17,7 @@ import {
 import { CreateWorkspaceDialog } from '@/components/workspace/create-workspace-dialog';
 import { useInitials } from '@/hooks/use-initials';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { switchMethod } from '@/routes/workspaces';
+import { switchWorkspace } from '@/lib/workspaces/switch-workspace';
 
 export function WorkspaceSelector() {
     const { workspaces } = usePage().props;
@@ -39,11 +39,7 @@ export function WorkspaceSelector() {
         }
 
         setLoading(true);
-        router.post(
-            switchMethod.url(),
-            { workspace_id: id },
-            { preserveState: false, onFinish: () => setLoading(false) },
-        );
+        switchWorkspace(id, { onFinish: () => setLoading(false) });
     };
 
     return (

--- a/resources/js/lib/workspaces/__tests__/switch-workspace.test.ts
+++ b/resources/js/lib/workspaces/__tests__/switch-workspace.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { switchWorkspace } from '../switch-workspace';
+
+const inertia = vi.hoisted(() => ({
+    flushAll: vi.fn(),
+    post: vi.fn(),
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    router: inertia,
+}));
+
+vi.mock('@/routes/workspaces', () => ({
+    switchMethod: {
+        url: () => '/workspaces/switch',
+    },
+}));
+
+describe('switchWorkspace', () => {
+    beforeEach(() => {
+        inertia.flushAll.mockClear();
+        inertia.post.mockClear();
+    });
+
+    it('flushes prefetched pages before and after switching', () => {
+        switchWorkspace('workspace-2');
+
+        expect(inertia.flushAll).toHaveBeenCalledTimes(1);
+        expect(inertia.post).toHaveBeenCalledWith(
+            '/workspaces/switch',
+            { workspace_id: 'workspace-2' },
+            expect.objectContaining({
+                preserveState: false,
+                onSuccess: expect.any(Function),
+            }),
+        );
+
+        const options = inertia.post.mock.calls[0]?.[2];
+        if (!options) {
+            throw new Error('Expected router.post options');
+        }
+        options.onSuccess?.({} as never);
+
+        expect(inertia.flushAll).toHaveBeenCalledTimes(2);
+    });
+
+    it('passes through the finish callback', () => {
+        const onFinish = vi.fn();
+
+        switchWorkspace('workspace-2', { onFinish });
+
+        const options = inertia.post.mock.calls[0]?.[2];
+        if (!options) {
+            throw new Error('Expected router.post options');
+        }
+        options.onFinish?.({} as never);
+
+        expect(onFinish).toHaveBeenCalledOnce();
+    });
+});

--- a/resources/js/lib/workspaces/switch-workspace.ts
+++ b/resources/js/lib/workspaces/switch-workspace.ts
@@ -1,0 +1,23 @@
+import { router } from '@inertiajs/react';
+
+import { switchMethod } from '@/routes/workspaces';
+
+type SwitchWorkspaceOptions = {
+    onFinish?: () => void;
+};
+
+export function switchWorkspace(
+    workspaceId: string,
+    options: SwitchWorkspaceOptions = {},
+) {
+    router.flushAll();
+    router.post(
+        switchMethod.url(),
+        { workspace_id: workspaceId },
+        {
+            preserveState: false,
+            onSuccess: () => router.flushAll(),
+            onFinish: options.onFinish,
+        },
+    );
+}

--- a/resources/js/pages/settings/workspace/overview.tsx
+++ b/resources/js/pages/settings/workspace/overview.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 
 import WorkspaceSettingsController from '@/actions/App/Http/Controllers/Settings/WorkspaceSettingsController';
 import WorkspaceController from '@/actions/App/Http/Controllers/WorkspaceController';
+import { useConfirm } from '@/components/common/confirm-dialog';
 import Heading from '@/components/common/heading';
 import InputError from '@/components/common/input-error';
 import { Button } from '@/components/ui/button';
@@ -27,6 +28,7 @@ type Props = {
     };
     canManage: boolean;
     isOwner: boolean;
+    canDelete: boolean;
     timezone: string;
     timezones: string[];
 };
@@ -35,9 +37,39 @@ export default function WorkspaceOverview({
     workspace,
     canManage,
     isOwner,
+    canDelete,
     timezone,
     timezones,
 }: Props) {
+    const confirmAction = useConfirm();
+    const [deleting, setDeleting] = useState(false);
+
+    async function deleteWorkspace() {
+        if (!canDelete || deleting) {
+            return;
+        }
+
+        const confirmed = await confirmAction({
+            title: 'Delete workspace?',
+            description:
+                'This permanently deletes the workspace, its members, and its data. This cannot be undone.',
+            actionLabel: 'Delete workspace',
+            destructive: true,
+        });
+
+        if (!confirmed) {
+            return;
+        }
+
+        setDeleting(true);
+        router.flushAll();
+        router.delete(WorkspaceController.destroy(workspace.id).url, {
+            preserveScroll: true,
+            onSuccess: () => router.flushAll(),
+            onFinish: () => setDeleting(false),
+        });
+    }
+
     return (
         <>
             <Head title="Workspace settings" />
@@ -52,6 +84,7 @@ export default function WorkspaceOverview({
                 <Form
                     {...WorkspaceSettingsController.update.form()}
                     options={{ preserveScroll: true }}
+                    onSuccess={() => router.flushAll()}
                     className="space-y-6"
                 >
                     {({ processing, errors, recentlySuccessful }) => (
@@ -112,9 +145,14 @@ export default function WorkspaceOverview({
                                     workspace.id,
                                 )}
                                 options={{ preserveScroll: true }}
-                                onBefore={() =>
-                                    confirm('Leave this workspace?')
-                                }
+                                onBefore={() => {
+                                    if (!confirm('Leave this workspace?')) {
+                                        return false;
+                                    }
+
+                                    router.flushAll();
+                                }}
+                                onSuccess={() => router.flushAll()}
                             >
                                 {({ processing }) => (
                                     <Button
@@ -144,27 +182,23 @@ export default function WorkspaceOverview({
                                     This action cannot be undone.
                                 </p>
                             </div>
-                            <Form
-                                {...WorkspaceController.destroy.form(
-                                    workspace.id,
+                            <div className="flex flex-col items-start gap-2 sm:items-end">
+                                <Button
+                                    type="button"
+                                    variant="destructive"
+                                    disabled={deleting || !canDelete}
+                                    onClick={deleteWorkspace}
+                                >
+                                    {deleting
+                                        ? 'Deleting...'
+                                        : 'Delete workspace'}
+                                </Button>
+                                {!canDelete && (
+                                    <p className="max-w-48 text-xs text-muted-foreground sm:text-right">
+                                        You can’t delete your only workspace.
+                                    </p>
                                 )}
-                                options={{ preserveScroll: true }}
-                                onBefore={() =>
-                                    confirm(
-                                        'Delete this workspace permanently? This cannot be undone.',
-                                    )
-                                }
-                            >
-                                {({ processing }) => (
-                                    <Button
-                                        type="submit"
-                                        variant="destructive"
-                                        disabled={processing}
-                                    >
-                                        Delete workspace
-                                    </Button>
-                                )}
-                            </Form>
+                            </div>
                         </div>
                     </div>
                 )}

--- a/tests/Feature/Workspace/WorkspaceDeleteTest.php
+++ b/tests/Feature/Workspace/WorkspaceDeleteTest.php
@@ -4,16 +4,40 @@ use App\Models\User;
 use App\Models\Workspace;
 use App\Models\WorkspaceMembership;
 
-test('owner can delete workspace and memberships cascade', function () {
+test('owner cannot delete their last workspace', function () {
     $workspace = Workspace::factory()->create();
     $owner = User::factory()->create(['current_workspace_id' => $workspace->id]);
     WorkspaceMembership::factory()->owner()->create(['workspace_id' => $workspace->id, 'user_id' => $owner->id]);
+
+    $this->actingAs($owner)->delete(route('workspaces.destroy', $workspace))->assertSessionHasErrors('workspace');
+
+    $this->assertDatabaseHas('workspaces', ['id' => $workspace->id]);
+    $this->assertSame($workspace->id, $owner->fresh()->current_workspace_id);
+});
+
+test('workspace settings disables deletion for the last workspace', function () {
+    $workspace = Workspace::factory()->create();
+    $owner = User::factory()->create(['current_workspace_id' => $workspace->id]);
+    WorkspaceMembership::factory()->owner()->create(['workspace_id' => $workspace->id, 'user_id' => $owner->id]);
+
+    $this->actingAs($owner)->get(route('settings.workspace'))
+        ->assertInertia(fn ($page) => $page
+            ->where('canDelete', false)
+        );
+});
+
+test('owner can delete workspace and memberships cascade when another workspace remains', function () {
+    $workspace = Workspace::factory()->create();
+    $other = Workspace::factory()->create();
+    $owner = User::factory()->create(['current_workspace_id' => $workspace->id]);
+    WorkspaceMembership::factory()->owner()->create(['workspace_id' => $workspace->id, 'user_id' => $owner->id]);
+    WorkspaceMembership::factory()->create(['workspace_id' => $other->id, 'user_id' => $owner->id]);
 
     $this->actingAs($owner)->delete(route('workspaces.destroy', $workspace))->assertRedirect();
 
     $this->assertDatabaseMissing('workspaces', ['id' => $workspace->id]);
     $this->assertDatabaseMissing('workspace_memberships', ['workspace_id' => $workspace->id]);
-    $this->assertNull($owner->fresh()->current_workspace_id);
+    $this->assertSame($other->id, $owner->fresh()->current_workspace_id);
 });
 
 test('non owner cannot delete workspace', function () {


### PR DESCRIPTION
## Summary
- Prevent workspace owners from deleting their only remaining workspace.
- Disable the delete action in workspace settings when no alternate workspace exists.
- Flush Inertia cached/prefetched pages after workspace create, switch, update, leave, and delete flows so workspace state stays fresh.
- Add coverage for last-workspace deletion guards and workspace switching cache flush behavior.