### PR TITLE
fix(onboarding): require connected account before publishing

### DIFF
--- a/app/Http/Controllers/OnboardingController.php
+++ b/app/Http/Controllers/OnboardingController.php
@@ -29,9 +29,11 @@ class OnboardingController extends Controller
 
     public function dismiss(Request $request): RedirectResponse
     {
-        $this->currentWorkspace($request)
-            ->forceFill(['onboarding_dismissed_at' => now()])
-            ->save();
+        $workspace = $this->currentWorkspace($request);
+
+        abort_unless($workspace->connectedAccounts()->exists(), 409);
+
+        $workspace->forceFill(['onboarding_dismissed_at' => now()])->save();
 
         return back();
     }

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -10,6 +10,7 @@ import {
     composerReducer,
     initialComposerState,
     pickActiveAccount,
+    shouldShowConnectAccountPrompt,
     type ComposerState,
 } from '@/lib/compose/composer-state';
 import { postCapabilities } from '@/lib/posts/capabilities';
@@ -152,6 +153,10 @@ export default function Composer({
     const readOnly = post !== null && !postCapabilities(post).canEdit;
 
     const activeAccount = pickActiveAccount(tabAccounts, state.activeTab);
+    const showConnectAccountPrompt = shouldShowConnectAccountPrompt(
+        accounts,
+        activeAccount,
+    );
     const activeText =
         activeAccount && state.overrideByAccount[activeAccount.id] !== undefined
             ? (state.overrideByAccount[activeAccount.id] as string)
@@ -296,7 +301,7 @@ export default function Composer({
                     sectionTotal={activeSectionTotal}
                     state={severityFor(activeAccount.id)}
                 />
-            ) : (
+            ) : showConnectAccountPrompt ? (
                 <div className="px-4 pb-3.5 sm:px-[26px]">
                     <Link
                         href={accountsRoute().url}
@@ -306,7 +311,7 @@ export default function Composer({
                         Connect an account to publish
                     </Link>
                 </div>
-            )}
+            ) : null}
 
             {/* Toolbar — editing controls when editable; just the attached
                 media when read-only (skipped entirely if there's none). */}

--- a/resources/js/components/onboarding/__tests__/getting-started-card.test.ts
+++ b/resources/js/components/onboarding/__tests__/getting-started-card.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { canDismissOnboarding } from '../getting-started-card';
+
+describe('canDismissOnboarding', () => {
+    it('allows dismissing only after an account is connected', () => {
+        const base = {
+            welcomed: true,
+            dismissed: false,
+            complete: false,
+            steps: [
+                {
+                    key: 'connect_account',
+                    label: 'Connect an account',
+                    done: false,
+                    href: '/accounts',
+                    clickToComplete: false,
+                },
+            ],
+        };
+
+        expect(canDismissOnboarding(base)).toBe(false);
+        expect(
+            canDismissOnboarding({
+                ...base,
+                steps: [{ ...base.steps[0], done: true }],
+            }),
+        ).toBe(true);
+    });
+});

--- a/resources/js/components/onboarding/getting-started-card.tsx
+++ b/resources/js/components/onboarding/getting-started-card.tsx
@@ -62,6 +62,13 @@ function setCollapsed(value: boolean): void {
     collapseListeners.forEach((listener) => listener());
 }
 
+export function canDismissOnboarding(onboarding: OnboardingData): boolean {
+    return (
+        onboarding.steps.find((step) => step.key === 'connect_account')?.done ??
+        false
+    );
+}
+
 export function GettingStartedCard({
     onboarding,
 }: {
@@ -95,6 +102,7 @@ export function GettingStartedCard({
     const done = onboarding.steps.filter((s) => s.done).length;
     const total = onboarding.steps.length;
     const nextKey = onboarding.steps.find((s) => !s.done)?.key;
+    const canDismiss = canDismissOnboarding(onboarding);
 
     return (
         <section className="mb-7 rounded-xl border bg-card p-5 shadow-xs">
@@ -127,14 +135,16 @@ export function GettingStartedCard({
                             )}
                         />
                     </Button>
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={dismiss}
-                        aria-label="Dismiss"
-                    >
-                        <X className="size-4" />
-                    </Button>
+                    {canDismiss && (
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={dismiss}
+                            aria-label="Dismiss"
+                        >
+                            <X className="size-4" />
+                        </Button>
+                    )}
                 </div>
             </div>
 

--- a/resources/js/lib/compose/__tests__/composer-state.test.ts
+++ b/resources/js/lib/compose/__tests__/composer-state.test.ts
@@ -10,6 +10,7 @@ import {
     initialComposerState,
     parseDestinationParam,
     pickActiveAccount,
+    shouldShowConnectAccountPrompt,
 } from '../composer-state';
 
 function account(id: string): Account {
@@ -94,6 +95,18 @@ describe('pickActiveAccount', () => {
 
     it('returns null when there are no accounts (genuine connect-an-account state)', () => {
         expect(pickActiveAccount([], BASE_TAB)).toBeNull();
+    });
+});
+
+describe('shouldShowConnectAccountPrompt', () => {
+    it('shows the nudge only when the workspace has no connected accounts', () => {
+        expect(shouldShowConnectAccountPrompt([], null)).toBe(true);
+        expect(shouldShowConnectAccountPrompt([account('a1')], null)).toBe(
+            false,
+        );
+        expect(
+            shouldShowConnectAccountPrompt([account('a1')], account('a1')),
+        ).toBe(false);
     });
 });
 

--- a/resources/js/lib/compose/composer-state.ts
+++ b/resources/js/lib/compose/composer-state.ts
@@ -75,6 +75,17 @@ export function pickActiveAccount(
 }
 
 /**
+ * The connect-account nudge is a workspace-level empty state. Do not show it
+ * just because the current destination resolves to no active tab/accounts.
+ */
+export function shouldShowConnectAccountPrompt(
+    accounts: Account[],
+    activeAccount: Account | null,
+): boolean {
+    return accounts.length === 0 && activeAccount === null;
+}
+
+/**
  * Build a fresh composer state. When `scheduleAt` (an ISO string) is given, the
  * schedule tray opens pre-set to "Pick time" at that instant — used when the
  * composer is opened from a calendar slot click. When `initialDestination` is

--- a/resources/js/pages/__tests__/dashboard.test.ts
+++ b/resources/js/pages/__tests__/dashboard.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldShowDashboardPublishingSection } from '../dashboard';
+
+describe('shouldShowDashboardPublishingSection', () => {
+    it('hides the composer and recent posts until at least one account is connected', () => {
+        expect(shouldShowDashboardPublishingSection([])).toBe(false);
+        expect(
+            shouldShowDashboardPublishingSection([{ id: 'account-1' }]),
+        ).toBe(true);
+    });
+});

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -16,6 +16,12 @@ type Props = {
     onboarding: OnboardingData | null;
 };
 
+export function shouldShowDashboardPublishingSection(
+    accounts: unknown[],
+): boolean {
+    return accounts.length > 0;
+}
+
 function timeGreeting(): string {
     const hour = new Date().getHours();
     if (hour < 5) {
@@ -35,6 +41,9 @@ export default function Dashboard({ posts, onboarding }: Props) {
     const page = usePage();
     const { auth, shell } = page.props;
     const firstName = (auth.user?.name ?? '').split(/\s+/)[0] || 'there';
+    const showPublishingSection = shouldShowDashboardPublishingSection(
+        shell.accounts,
+    );
 
     // A calendar slot click opens the composer here with a pre-set schedule time.
     const initialScheduleAt = new URL(
@@ -70,18 +79,25 @@ export default function Dashboard({ posts, onboarding }: Props) {
 
                 {onboarding && <GettingStartedCard onboarding={onboarding} />}
 
-                <Composer
-                    post={null}
-                    accounts={shell.accounts}
-                    sets={shell.sets}
-                    limits={shell.limits}
-                    initialScheduleAt={initialScheduleAt}
-                    initialDestination={initialDestination}
-                />
+                {showPublishingSection && (
+                    <>
+                        <Composer
+                            post={null}
+                            accounts={shell.accounts}
+                            sets={shell.sets}
+                            limits={shell.limits}
+                            initialScheduleAt={initialScheduleAt}
+                            initialDestination={initialDestination}
+                        />
 
-                <Deferred data="posts" fallback={<RecentFeedSkeleton />}>
-                    <RecentFeed posts={posts ?? []} />
-                </Deferred>
+                        <Deferred
+                            data="posts"
+                            fallback={<RecentFeedSkeleton />}
+                        >
+                            <RecentFeed posts={posts ?? []} />
+                        </Deferred>
+                    </>
+                )}
             </div>
         </>
     );

--- a/tests/Feature/Onboarding/OnboardingEndpointsTest.php
+++ b/tests/Feature/Onboarding/OnboardingEndpointsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\ConnectedAccount;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Models\WorkspaceMembership;
@@ -32,10 +33,19 @@ test('welcomed endpoint stamps the current workspace', function () {
 
 test('dismiss endpoint stamps the current workspace', function () {
     $user = onboardingActor();
+    ConnectedAccount::factory()->create(['workspace_id' => $user->current_workspace_id]);
 
     $this->actingAs($user)->post(route('onboarding.dismiss'))->assertRedirect();
 
     expect($user->currentWorkspace->fresh()->onboarding_dismissed_at)->not->toBeNull();
+});
+
+test('dismiss endpoint is blocked until an account is connected', function () {
+    $user = onboardingActor();
+
+    $this->actingAs($user)->post(route('onboarding.dismiss'))->assertStatus(409);
+
+    expect($user->currentWorkspace->fresh()->onboarding_dismissed_at)->toBeNull();
 });
 
 test('welcomed with connect redirects to accounts and stamps the workspace', function () {


### PR DESCRIPTION
## Summary
- Hide dashboard publishing and recent posts until the workspace has at least one connected account.
- Show the composer connect-account prompt only for the true no-accounts state.
- Prevent onboarding dismissal before an account is connected, with frontend and endpoint coverage.