### PR TITLE
fix(compose): default scheduled time to next hour

### DIFF
--- a/resources/js/components/compose/__tests__/pick-time.test.ts
+++ b/resources/js/components/compose/__tests__/pick-time.test.ts
@@ -1,8 +1,22 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { composePickedAt, partsInTz } from '../pick-time-popover';
+import {
+    composePickedAt,
+    defaultPickedAt,
+    partsInTz,
+} from '../pick-time-popover';
 
 describe('pick-time tz helpers', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('defaults to the next clock hour in the scheduling timezone', () => {
+        vi.setSystemTime(new Date('2026-06-22T08:23:00Z'));
+
+        expect(defaultPickedAt('UTC')).toBe('2026-06-22T09:00:00Z');
+    });
+
     it('composePickedAt interprets wall-clock in the given tz', () => {
         // 09:00 in Asia/Kolkata (UTC+5:30) === 03:30 UTC
         expect(composePickedAt('2026-06-20', 9, 0, 'Asia/Kolkata')).toBe(

--- a/resources/js/components/compose/pick-time-popover.tsx
+++ b/resources/js/components/compose/pick-time-popover.tsx
@@ -30,7 +30,7 @@ type Props = {
 const MINUTE_STEPS = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55];
 
 /**
- * Tomorrow 09:00 in `tz`, as a UTC ISO string.
+ * The next clock hour in `tz`, as a UTC ISO string.
  *
  * Exported so callers can seed their state to the same value the picker
  * displays — otherwise the UI shows a time the request never sends (the
@@ -39,8 +39,7 @@ const MINUTE_STEPS = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55];
 export function defaultPickedAt(tz: string): string {
     return dayjs()
         .tz(tz)
-        .add(1, 'day')
-        .hour(9)
+        .add(1, 'hour')
         .minute(0)
         .second(0)
         .millisecond(0)


### PR DESCRIPTION
## Summary

- Default the compose scheduler to the next clock hour in the workspace scheduling timezone.
- Update the picker helper comment to match the new behavior.
- Add test coverage for the next-hour default time calculation.