### PR TITLE
fix(dashboard): soften navbar over aura backdrop

### DIFF
--- a/resources/js/components/dashboard/__tests__/dashboard-aura.test.ts
+++ b/resources/js/components/dashboard/__tests__/dashboard-aura.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { dashboardAuraBackdropClassName } from '../dashboard-aura';
+
+describe('dashboardAuraBackdropClassName', () => {
+    it('extends the aura behind the dashboard navbar', () => {
+        expect(dashboardAuraBackdropClassName).toContain('-top-16');
+        expect(dashboardAuraBackdropClassName).toContain('h-[624px]');
+    });
+
+    it('keeps the aura behind dashboard content', () => {
+        expect(dashboardAuraBackdropClassName).toContain('-z-10');
+    });
+});

--- a/resources/js/components/dashboard/dashboard-aura.tsx
+++ b/resources/js/components/dashboard/dashboard-aura.tsx
@@ -12,12 +12,12 @@
  * and an SVG grain overlay for texture. All motion honors
  * `prefers-reduced-motion` (see app.css), leaving a static textured wash.
  */
+export const dashboardAuraBackdropClassName =
+    'pointer-events-none absolute -top-16 left-1/2 -z-10 h-[624px] w-screen -translate-x-1/2 overflow-hidden [mask-image:radial-gradient(125%_82%_at_50%_0%,black_42%,transparent)]';
+
 export function DashboardAura() {
     return (
-        <div
-            aria-hidden="true"
-            className="pointer-events-none absolute top-0 left-1/2 -z-10 h-[560px] w-screen -translate-x-1/2 overflow-hidden [mask-image:radial-gradient(125%_82%_at_50%_0%,black_42%,transparent)]"
-        >
+        <div aria-hidden="true" className={dashboardAuraBackdropClassName}>
             {/* Rotating conic sheen. Centered with a negative margin (not
                 translate) so the spin transform doesn't fight the positioning. */}
             <div className="absolute -top-[42%] left-1/2 -ml-[380px] size-[760px] animate-aura-spin rounded-full opacity-70 blur-2xl [background:conic-gradient(from_0deg,transparent,color-mix(in_oklch,var(--primary)_28%,transparent),transparent_45%,color-mix(in_oklch,var(--primary)_16%,transparent),transparent_75%)]" />

--- a/resources/js/components/layout/__tests__/app-sidebar-header.test.ts
+++ b/resources/js/components/layout/__tests__/app-sidebar-header.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { appSidebarHeaderBackground } from '../app-sidebar-header-background';
+
+describe('appSidebarHeaderBackground', () => {
+    it('makes only the dashboard navbar 80% opaque', () => {
+        expect(appSidebarHeaderBackground('dashboard')).toBe(
+            'bg-background/80',
+        );
+    });
+
+    it('keeps the regular navbar background on other pages', () => {
+        expect(appSidebarHeaderBackground('posts/index')).toBe(
+            'bg-background/85',
+        );
+    });
+});

--- a/resources/js/components/layout/app-sidebar-header-background.ts
+++ b/resources/js/components/layout/app-sidebar-header-background.ts
@@ -1,0 +1,3 @@
+export function appSidebarHeaderBackground(component: string): string {
+    return component === 'dashboard' ? 'bg-background/5' : 'bg-background/85';
+}

--- a/resources/js/components/layout/app-sidebar-header.tsx
+++ b/resources/js/components/layout/app-sidebar-header.tsx
@@ -1,3 +1,4 @@
+import { usePage } from '@inertiajs/react';
 import { Search } from 'lucide-react';
 
 import { ThemeToggle } from '@/components/common/theme-toggle';
@@ -7,7 +8,10 @@ import { NotificationBell } from '@/components/notifications/notification-bell';
 import { Kbd } from '@/components/ui/kbd';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { useNotificationsPoll } from '@/hooks/notifications/use-notifications-poll';
+import { cn } from '@/lib/utils';
 import type { BreadcrumbItem as BreadcrumbItemType } from '@/types';
+
+import { appSidebarHeaderBackground } from './app-sidebar-header-background';
 
 export function AppSidebarHeader({
     breadcrumbs = [],
@@ -15,9 +19,15 @@ export function AppSidebarHeader({
     breadcrumbs?: BreadcrumbItemType[];
 }) {
     useNotificationsPoll();
+    const { component } = usePage();
 
     return (
-        <header className="sticky top-0 z-20 flex h-16 shrink-0 items-center gap-2 border-b border-sidebar-border/50 bg-background/85 px-6 backdrop-blur-md transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-4">
+        <header
+            className={cn(
+                'sticky top-0 z-20 flex h-16 shrink-0 items-center gap-2 border-b border-sidebar-border/50 px-6 backdrop-blur-md transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-4',
+                appSidebarHeaderBackground(component),
+            )}
+        >
             <div className="flex items-center gap-2">
                 <SidebarTrigger className="-ml-1" />
                 <Breadcrumbs breadcrumbs={breadcrumbs} />


### PR DESCRIPTION
## Summary
- Makes the dashboard header more transparent so the aura backdrop can show through behind the sticky navbar.
- Extends the dashboard aura upward and increases its height so it continues behind the navbar.
- Adds focused tests for dashboard aura positioning and page-specific navbar background behavior.