### PR TITLE
feat(compose): improve composer keyboard access

### DIFF
--- a/resources/js/components/compose/__tests__/editor-body.test.ts
+++ b/resources/js/components/compose/__tests__/editor-body.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldFocusEditorOnMount } from '../editor-body';
+
+describe('shouldFocusEditorOnMount', () => {
+    it('focuses only when autofocus is requested and the editor is editable', () => {
+        expect(shouldFocusEditorOnMount(true, true)).toBe(true);
+        expect(shouldFocusEditorOnMount(false, true)).toBe(false);
+        expect(shouldFocusEditorOnMount(true, false)).toBe(false);
+    });
+});

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -45,6 +45,8 @@ type ComposerProps = {
     initialScheduleAt?: string | null;
     /** Seed the destination for a brand-new post (e.g. compose-for-channel). */
     initialDestination?: Destination | null;
+    /** Focus the editor as soon as it mounts. */
+    autoFocusEditor?: boolean;
 };
 
 function accountIdsFor(
@@ -77,6 +79,7 @@ export default function Composer({
     limits,
     initialScheduleAt = null,
     initialDestination = null,
+    autoFocusEditor = false,
 }: ComposerProps) {
     const schedulingTz = useSchedulingTimezone();
     // True while any attachment is still uploading — blocks publish/schedule.
@@ -266,6 +269,7 @@ export default function Composer({
                 onChange={handleText}
                 onBlur={flush}
                 editable={!readOnly}
+                autoFocus={autoFocusEditor}
                 overrideBanner={overrideActive}
                 activePlatformLabel={activeAccount?.platform ?? null}
                 onResetOverride={() =>

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -24,6 +24,8 @@ type EditorBodyProps = {
     activePlatformLabel?: string | null;
     /** Reset-to-base handler for the override banner. */
     onResetOverride?: () => void;
+    /** Focus the editor when it mounts. */
+    autoFocus?: boolean;
     /**
      * Active platform + splitting config pushed into the section-markers plugin
      * whenever the active tab changes. Omit to leave markers at their defaults.
@@ -36,11 +38,19 @@ type EditorBodyProps = {
     };
 };
 
+export function shouldFocusEditorOnMount(
+    autoFocus: boolean,
+    editable: boolean,
+): boolean {
+    return autoFocus && editable;
+}
+
 export default function EditorBody({
     value,
     onChange,
     onBlur,
     placeholder,
+    autoFocus = false,
     overrideBanner = false,
     activePlatformLabel,
     onResetOverride,
@@ -55,6 +65,18 @@ export default function EditorBody({
             onChange(docToBaseText(editor.getJSON() as DocNode)),
         onBlur,
     });
+
+    useEffect(() => {
+        if (!editor || !shouldFocusEditorOnMount(autoFocus, editable)) {
+            return;
+        }
+
+        const frame = window.requestAnimationFrame(() => {
+            editor.commands.focus('end');
+        });
+
+        return () => window.cancelAnimationFrame(frame);
+    }, [editor, autoFocus, editable]);
 
     // Reflect editability changes (tiptap caches it from the initial options).
     useEffect(() => {

--- a/resources/js/components/layout/app-sidebar.tsx
+++ b/resources/js/components/layout/app-sidebar.tsx
@@ -31,7 +31,10 @@ import {
 } from '@/components/ui/sidebar';
 import { WorkspaceSelector } from '@/components/workspace/workspace-selector';
 import { useCurrentUrl } from '@/hooks/use-current-url';
-import { cn } from '@/lib/utils';
+import {
+    composeButtonClassName,
+    composeIconClassName,
+} from '@/lib/navigation/compose-nav';
 import { dashboard } from '@/routes';
 import { index as accountsRoute } from '@/routes/accounts';
 import { index as analyticsRoute } from '@/routes/analytics';
@@ -109,10 +112,8 @@ export function AppSidebar() {
                                     asChild
                                     tooltip="Compose new post"
                                     isActive={isCurrentUrl(composeHref)}
-                                    className={cn(
-                                        'h-9 justify-between gap-2 bg-primary font-medium text-primary-foreground shadow-sm ring-1 ring-primary/20 transition-all',
-                                        'hover:bg-primary/90 hover:text-primary-foreground hover:shadow active:scale-[0.98]',
-                                        'data-[active=true]:bg-primary data-[active=true]:text-primary-foreground',
+                                    className={composeButtonClassName(
+                                        collapsed,
                                     )}
                                 >
                                     <Link
@@ -120,8 +121,10 @@ export function AppSidebar() {
                                         prefetch={['mount', 'hover']}
                                         cacheFor={['30s', '1m']}
                                     >
-                                        <span className="flex items-center gap-2">
-                                            <span className="flex size-5 items-center justify-center rounded-md bg-primary-foreground/15 [&>svg]:size-3.5">
+                                        <span className="pointer-events-none flex items-center gap-2">
+                                            <span
+                                                className={composeIconClassName()}
+                                            >
                                                 <Pencil aria-hidden="true" />
                                             </span>
                                             {!collapsed && (
@@ -130,7 +133,7 @@ export function AppSidebar() {
                                         </span>
                                         {!collapsed && (
                                             <Kbd className="bg-primary-foreground/15 text-primary-foreground">
-                                                ⌘N
+                                                ⌘.
                                             </Kbd>
                                         )}
                                     </Link>

--- a/resources/js/components/layout/command-palette.tsx
+++ b/resources/js/components/layout/command-palette.tsx
@@ -33,6 +33,10 @@ import {
     type RecentItem,
 } from '@/lib/command/recents';
 import { usePostSearch } from '@/lib/command/use-post-search';
+import {
+    commandShortcutListenerOptions,
+    isComposeShortcut,
+} from '@/lib/navigation/compose-nav';
 import { switchWorkspace } from '@/lib/workspaces/switch-workspace';
 import { dashboard, logout } from '@/routes';
 import { index as accountsRoute } from '@/routes/accounts';
@@ -84,7 +88,7 @@ export function CommandPalette() {
             if (key === 'k') {
                 e.preventDefault();
                 setOpen((v) => !v);
-            } else if (key === 'n') {
+            } else if (isComposeShortcut(e)) {
                 e.preventDefault();
                 router.visit(composeUrl);
             }
@@ -92,11 +96,19 @@ export function CommandPalette() {
         function onOpen() {
             setOpen(true);
         }
-        window.addEventListener('keydown', onKey);
+        window.addEventListener(
+            'keydown',
+            onKey,
+            commandShortcutListenerOptions,
+        );
         window.addEventListener(OPEN_COMMAND_EVENT, onOpen);
 
         return () => {
-            window.removeEventListener('keydown', onKey);
+            window.removeEventListener(
+                'keydown',
+                onKey,
+                commandShortcutListenerOptions,
+            );
             window.removeEventListener(OPEN_COMMAND_EVENT, onOpen);
         };
     }, [composeUrl]);

--- a/resources/js/lib/navigation/__tests__/compose-nav.test.ts
+++ b/resources/js/lib/navigation/__tests__/compose-nav.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    commandShortcutListenerOptions,
+    composeButtonClassName,
+    composeIconClassName,
+    isComposeShortcut,
+} from '../compose-nav';
+
+describe('isComposeShortcut', () => {
+    it('matches plain command or control period only', () => {
+        expect(
+            isComposeShortcut({
+                altKey: false,
+                ctrlKey: false,
+                key: '.',
+                metaKey: true,
+                shiftKey: false,
+            }),
+        ).toBe(true);
+        expect(
+            isComposeShortcut({
+                altKey: false,
+                ctrlKey: true,
+                key: '.',
+                metaKey: false,
+                shiftKey: false,
+            }),
+        ).toBe(true);
+        expect(
+            isComposeShortcut({
+                altKey: false,
+                ctrlKey: false,
+                key: 'k',
+                metaKey: true,
+                shiftKey: false,
+            }),
+        ).toBe(false);
+        expect(
+            isComposeShortcut({
+                altKey: false,
+                ctrlKey: false,
+                key: '.',
+                metaKey: true,
+                shiftKey: true,
+            }),
+        ).toBe(false);
+    });
+});
+
+describe('compose navigation classes', () => {
+    it('keeps collapsed compose centered and removes nested icon backgrounds', () => {
+        expect(composeButtonClassName(true)).toContain('justify-center');
+        expect(composeButtonClassName(false)).not.toContain('justify-center');
+        expect(composeIconClassName()).toContain('pointer-events-none');
+        expect(composeIconClassName()).not.toContain('bg-');
+        expect(composeIconClassName()).not.toContain('rounded');
+    });
+});
+
+describe('command shortcut listener options', () => {
+    it('listens in capture phase so browser chrome shortcuts are intercepted early', () => {
+        expect(commandShortcutListenerOptions).toEqual({ capture: true });
+    });
+});

--- a/resources/js/lib/navigation/compose-nav.ts
+++ b/resources/js/lib/navigation/compose-nav.ts
@@ -1,0 +1,30 @@
+import { cn } from '@/lib/utils';
+
+type ShortcutEvent = Pick<
+    KeyboardEvent,
+    'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'
+>;
+
+export const commandShortcutListenerOptions = { capture: true } as const;
+
+export function isComposeShortcut(event: ShortcutEvent): boolean {
+    return (
+        (event.metaKey || event.ctrlKey) &&
+        !event.altKey &&
+        !event.shiftKey &&
+        event.key === '.'
+    );
+}
+
+export function composeButtonClassName(collapsed: boolean): string {
+    return cn(
+        'h-9 justify-between gap-2 bg-primary font-medium text-primary-foreground shadow-sm ring-1 ring-primary/20 transition-all select-none',
+        'hover:bg-primary/90 hover:text-primary-foreground hover:shadow active:scale-[0.98]',
+        'data-[active=true]:bg-primary data-[active=true]:text-primary-foreground',
+        collapsed && 'justify-center',
+    );
+}
+
+export function composeIconClassName(): string {
+    return 'pointer-events-none flex size-5 items-center justify-center [&>svg]:size-3.5';
+}

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -83,6 +83,7 @@ export default function Dashboard({ onboarding }: Props) {
                         limits={shell.limits}
                         initialScheduleAt={initialScheduleAt}
                         initialDestination={initialDestination}
+                        autoFocusEditor
                     />
                 )}
             </div>


### PR DESCRIPTION
## Summary
- Adds a dedicated compose shortcut using `⌘.` / `Ctrl+.` and updates the sidebar shortcut label.
- Focuses the composer editor automatically when opening compose from the dashboard.
- Extracts compose navigation helpers and adds Vitest coverage for shortcut handling, focus behavior, and sidebar classes.