### PR TITLE
fix(notifications): default email to critical events only

### DIFF
--- a/app/Enums/NotificationType.php
+++ b/app/Enums/NotificationType.php
@@ -22,4 +22,12 @@ enum NotificationType: string
             default => false,
         };
     }
+
+    public function emailOnByDefault(): bool
+    {
+        return match ($this) {
+            self::PublishFailed, self::AccountNeedsAttention => true,
+            default => false,
+        };
+    }
 }

--- a/app/Support/Notifications/NotificationPreferences.php
+++ b/app/Support/Notifications/NotificationPreferences.php
@@ -18,7 +18,7 @@ final class NotificationPreferences
         $matrix = [];
 
         foreach (NotificationType::cases() as $type) {
-            $matrix[$type->value] = ['in_app' => true, 'mail' => true];
+            $matrix[$type->value] = ['in_app' => true, 'mail' => $type->emailOnByDefault()];
         }
 
         return new self($matrix);
@@ -44,7 +44,7 @@ final class NotificationPreferences
 
             $prefs->matrix[$type->value] = [
                 'in_app' => (bool) ($row['in_app'] ?? true),
-                'mail' => (bool) ($row['mail'] ?? true),
+                'mail' => (bool) ($row['mail'] ?? $type->emailOnByDefault()),
             ];
         }
 

--- a/resources/js/pages/settings/notifications.tsx
+++ b/resources/js/pages/settings/notifications.tsx
@@ -100,7 +100,9 @@ export default function Notifications() {
                                 const isAlwaysOn = alwaysOn.includes(event.key);
                                 const row = prefs[event.key] ?? {
                                     in_app: true,
-                                    mail: true,
+                                    mail:
+                                        event.key === 'publish_failed' ||
+                                        event.key === 'account_needs_attention',
                                 };
 
                                 return (

--- a/tests/Feature/NotificationChannelsTest.php
+++ b/tests/Feature/NotificationChannelsTest.php
@@ -7,12 +7,13 @@ use App\Models\User;
 use App\Models\WorkspaceInvitation;
 use App\Notifications\AccountNeedsAttentionNotification;
 use App\Notifications\PostPublishedNotification;
+use App\Notifications\PublishFailedNotification;
 use App\Notifications\WorkspaceInviteNotification;
 use App\Support\Notifications\NotificationPreferences;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Support\Facades\Notification;
 
-test('post published notifies on both channels by default', function () {
+test('post published notifies in-app only by default', function () {
     Notification::fake();
     $user = User::factory()->create();
     $post = Post::factory()->for($user, 'author')->create();
@@ -21,6 +22,19 @@ test('post published notifies on both channels by default', function () {
     $user->notify(new PostPublishedNotification($target));
 
     Notification::assertSentTo($user, PostPublishedNotification::class, function ($notification) use ($user) {
+        return $notification->via($user) === ['database'];
+    });
+});
+
+test('publish failed notifies on both channels by default', function () {
+    Notification::fake();
+    $user = User::factory()->create();
+    $post = Post::factory()->for($user, 'author')->create();
+    $target = PostTarget::factory()->for($post)->create();
+
+    $user->notify(new PublishFailedNotification($target));
+
+    Notification::assertSentTo($user, PublishFailedNotification::class, function ($notification) use ($user) {
         return $notification->via($user) === ['database', 'mail'];
     });
 });

--- a/tests/Feature/NotificationPreferencesCastTest.php
+++ b/tests/Feature/NotificationPreferencesCastTest.php
@@ -22,5 +22,8 @@ test('notification preferences persist and round-trip through the cast', functio
 test('user with no stored preferences returns defaults', function () {
     $user = User::factory()->create();
 
-    expect($user->notificationPreferences()->allows(NotificationType::PostPublished, 'mail'))->toBeTrue();
+    expect($user->notificationPreferences()->allows(NotificationType::PostPublished, 'in_app'))->toBeTrue();
+    expect($user->notificationPreferences()->allows(NotificationType::PostPublished, 'mail'))->toBeFalse();
+    expect($user->notificationPreferences()->allows(NotificationType::PublishFailed, 'mail'))->toBeTrue();
+    expect($user->notificationPreferences()->allows(NotificationType::AccountNeedsAttention, 'mail'))->toBeTrue();
 });

--- a/tests/Unit/NotificationPreferencesTest.php
+++ b/tests/Unit/NotificationPreferencesTest.php
@@ -3,13 +3,17 @@
 use App\Enums\NotificationType;
 use App\Support\Notifications\NotificationPreferences;
 
-test('defaults enable every channel for every event', function () {
+test('defaults enable in-app notifications and only critical email notifications', function () {
     $prefs = NotificationPreferences::defaults();
 
     foreach (NotificationType::cases() as $type) {
         expect($prefs->allows($type, 'in_app'))->toBeTrue();
-        expect($prefs->allows($type, 'mail'))->toBeTrue();
     }
+
+    expect($prefs->allows(NotificationType::PostPublished, 'mail'))->toBeFalse();
+    expect($prefs->allows(NotificationType::WorkspaceInvite, 'mail'))->toBeFalse();
+    expect($prefs->allows(NotificationType::PublishFailed, 'mail'))->toBeTrue();
+    expect($prefs->allows(NotificationType::AccountNeedsAttention, 'mail'))->toBeTrue();
 });
 
 test('always-on in-app events cannot be disabled', function () {


### PR DESCRIPTION
## Summary
- Keep in-app notifications enabled by default for all notification types.
- Default email notifications to off for non-critical events like published posts and workspace invites.
- Keep email enabled by default for critical events: publish failures and accounts needing attention.
- Update notification preference fallbacks and settings UI defaults to match the new behavior.
- Add coverage for default channel behavior and critical email notifications.