### PR TITLE
feat(accounts): add default accounts and X premium limits

### DIFF
--- a/app/Dto/ConnectedAccount/ConnectedAccountData.php
+++ b/app/Dto/ConnectedAccount/ConnectedAccountData.php
@@ -13,6 +13,7 @@ final readonly class ConnectedAccountData
 {
     /**
      * @param  array<string, mixed>|null  $session
+     * @param  array<string, mixed>|null  $capabilities
      */
     public function __construct(
         public Platform $platform,
@@ -25,6 +26,7 @@ final readonly class ConnectedAccountData
         public ?string $refreshToken = null,
         public ?string $appPassword = null,
         public ?array $session = null,
+        public ?array $capabilities = null,
         public ?CarbonImmutable $tokenExpiresAt = null,
     ) {}
 
@@ -43,6 +45,27 @@ final readonly class ConnectedAccountData
             accessToken: $attributes['token'] ?? null,
             refreshToken: $attributes['refreshToken'] ?? null,
             tokenExpiresAt: $expiresIn ? Date::now()->addSeconds((int) $expiresIn)->toImmutable() : null,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $capabilities
+     */
+    public function withCapabilities(?array $capabilities): self
+    {
+        return new self(
+            platform: $this->platform,
+            remoteAccountId: $this->remoteAccountId,
+            handle: $this->handle,
+            displayName: $this->displayName,
+            avatarUrl: $this->avatarUrl,
+            authMethod: $this->authMethod,
+            accessToken: $this->accessToken,
+            refreshToken: $this->refreshToken,
+            appPassword: $this->appPassword,
+            session: $this->session,
+            capabilities: $capabilities,
+            tokenExpiresAt: $this->tokenExpiresAt,
         );
     }
 

--- a/app/Http/Controllers/ConnectedAccounts/ConnectedAccountController.php
+++ b/app/Http/Controllers/ConnectedAccounts/ConnectedAccountController.php
@@ -25,11 +25,13 @@ class ConnectedAccountController extends Controller
     public function index(Request $request): Response
     {
         $request->user()->can('viewAny', ConnectedAccount::class) ?: abort(403);
+        $defaultAccountId = $request->user()->currentWorkspace()->value('default_connected_account_id');
 
         $accounts = ConnectedAccount::query()
             ->with('connectedBy:id,name')
             ->latest()
             ->get()
+            ->sortByDesc(fn (ConnectedAccount $account): bool => $account->id === $defaultAccountId)
             ->map(fn (ConnectedAccount $account): array => [
                 'id' => $account->id,
                 'platform' => $account->platform->value,
@@ -42,7 +44,11 @@ class ConnectedAccountController extends Controller
                 'auth_method' => $account->auth_method,
                 'connected_by' => $account->connectedBy?->name,
                 'token_expires_at' => $account->token_expires_at?->toIso8601String(),
+                'max_text_length' => $account->maxTextLength(),
+                'x_premium' => $account->hasXPremium(),
+                'is_default' => $account->id === $defaultAccountId,
             ])
+            ->values()
             ->all();
 
         return Inertia::render('accounts/index', [
@@ -95,9 +101,27 @@ class ConnectedAccountController extends Controller
         return redirect()->route('accounts.index')->with('success', 'Account reconnected.');
     }
 
+    public function makeDefault(Request $request, ConnectedAccount $account): RedirectResponse
+    {
+        $request->user()->can('update', $account) ?: abort(403);
+
+        $workspace = $request->user()->currentWorkspace()->firstOrFail();
+
+        $workspace->forceFill([
+            'default_connected_account_id' => $account->id,
+        ])->save();
+
+        return redirect()->route('accounts.index')->with('success', "{$account->handle} is now the default account.");
+    }
+
     public function destroy(Request $request, ConnectedAccount $account): RedirectResponse
     {
         $request->user()->can('delete', $account) ?: abort(403);
+
+        $workspace = $request->user()->currentWorkspace()->first();
+        if ($workspace?->default_connected_account_id === $account->id) {
+            $workspace->forceFill(['default_connected_account_id' => null])->save();
+        }
 
         $account->secret()->delete();
         $account->delete();

--- a/app/Http/Controllers/ConnectedAccounts/OAuthConnectionController.php
+++ b/app/Http/Controllers/ConnectedAccounts/OAuthConnectionController.php
@@ -9,6 +9,7 @@ use App\Enums\Platform;
 use App\Http\Controllers\Controller;
 use App\Models\ConnectedAccount;
 use App\Services\ConnectedAccounts\AccountConnectionService;
+use App\Services\ConnectedAccounts\XAccountCapabilities;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -20,7 +21,10 @@ use Throwable;
 
 class OAuthConnectionController extends Controller
 {
-    public function __construct(private readonly AccountConnectionService $connections) {}
+    public function __construct(
+        private readonly AccountConnectionService $connections,
+        private readonly XAccountCapabilities $xCapabilities,
+    ) {}
 
     public function redirect(Request $request, string $platform): Response
     {
@@ -65,10 +69,13 @@ class OAuthConnectionController extends Controller
             return $this->failed("We couldn't read your {$resolved->label()} profile. Please try again.");
         }
 
-        $this->connections->store(
-            ConnectedAccountData::fromSocialite($resolved, $oauthUser),
-            $request->user(),
-        );
+        $data = ConnectedAccountData::fromSocialite($resolved, $oauthUser);
+
+        if ($resolved === Platform::X) {
+            $data = $data->withCapabilities($this->xCapabilities->forAccessToken($data->accessToken));
+        }
+
+        $this->connections->store($data, $request->user());
 
         return redirect()->route('accounts.index')
             ->with('success', "{$resolved->label()} account connected.");

--- a/app/Http/Controllers/Posts/ComposerController.php
+++ b/app/Http/Controllers/Posts/ComposerController.php
@@ -21,16 +21,20 @@ class ComposerController extends Controller
     public function show(Request $request, Post $post): Response
     {
         $request->user()->can('viewAny', Post::class) ?: abort(403);
+        $defaultAccountId = $request->user()->currentWorkspace()->value('default_connected_account_id');
 
         $accounts = ConnectedAccount::query()
             ->get()
+            ->sortByDesc(fn (ConnectedAccount $account): bool => $account->id === $defaultAccountId)
             ->map(fn (ConnectedAccount $account): array => [
                 'id' => $account->id,
                 'platform' => $account->platform->value,
                 'handle' => $account->handle,
                 'display_name' => $account->display_name,
                 'avatar_url' => $account->avatar_url,
-            ])->all();
+                'max_text_length' => $account->maxTextLength(),
+                'x_premium' => $account->hasXPremium(),
+            ])->values()->all();
 
         $sets = AccountSet::query()
             ->with('accounts:id')

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -86,16 +86,20 @@ class HandleInertiaRequests extends Middleware
         // the context — being explicit keeps shell data correct regardless of
         // middleware ordering and prevents cross-workspace leakage.
         $workspaceId = $user->current_workspace_id;
+        $defaultAccountId = $user->currentWorkspace()->value('default_connected_account_id');
 
         $accounts = ConnectedAccount::query()
             ->where('workspace_id', $workspaceId)
             ->get()
+            ->sortByDesc(fn (ConnectedAccount $account): bool => $account->id === $defaultAccountId)
             ->map(fn (ConnectedAccount $account): array => [
                 'id' => $account->id,
                 'platform' => $account->platform->value,
                 'handle' => $account->handle,
                 'display_name' => $account->display_name,
                 'avatar_url' => $account->avatar_url,
+                'max_text_length' => $account->maxTextLength(),
+                'x_premium' => $account->hasXPremium(),
             ])->values()->all();
 
         $sets = AccountSet::query()

--- a/app/Models/ConnectedAccount.php
+++ b/app/Models/ConnectedAccount.php
@@ -30,6 +30,7 @@ use Override;
  * @property string $auth_method
  * @property string|null $connected_by_user_id
  * @property ConnectedAccountStatus $status
+ * @property array<string, mixed>|null $capabilities
  * @property CarbonImmutable|null $token_expires_at
  * @property CarbonImmutable|null $last_refreshed_at
  * @property CarbonImmutable|null $metrics_captured_at
@@ -45,6 +46,7 @@ use Override;
     'auth_method',
     'connected_by_user_id',
     'status',
+    'capabilities',
     'token_expires_at',
     'last_refreshed_at',
     'metrics_captured_at',
@@ -64,11 +66,23 @@ class ConnectedAccount extends Model
         return [
             'platform' => Platform::class,
             'status' => ConnectedAccountStatus::class,
+            'capabilities' => 'array',
             'token_expires_at' => 'immutable_datetime',
             'last_refreshed_at' => 'immutable_datetime',
             'metrics_captured_at' => 'immutable_datetime',
             'metrics_status' => MetricsStatus::class,
         ];
+    }
+
+    public function maxTextLength(): int
+    {
+        return (int) ($this->capabilities['max_text_length'] ?? $this->platform->maxLength());
+    }
+
+    public function hasXPremium(): bool
+    {
+        return $this->platform === Platform::X
+            && (bool) ($this->capabilities['x_premium'] ?? false);
     }
 
     /**

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
     'logo',
     'timezone',
     'owner_id',
+    'default_connected_account_id',
 ])]
 class Workspace extends Model
 {
@@ -36,6 +37,14 @@ class Workspace extends Model
     public function owner(): BelongsTo
     {
         return $this->belongsTo(User::class, 'owner_id');
+    }
+
+    /**
+     * @return BelongsTo<ConnectedAccount, $this>
+     */
+    public function defaultConnectedAccount(): BelongsTo
+    {
+        return $this->belongsTo(ConnectedAccount::class, 'default_connected_account_id');
     }
 
     /**

--- a/app/Services/ConnectedAccounts/AccountConnectionService.php
+++ b/app/Services/ConnectedAccounts/AccountConnectionService.php
@@ -39,6 +39,7 @@ class AccountConnectionService
                     'auth_method' => $data->authMethod,
                     'connected_by_user_id' => $connectedBy->id,
                     'status' => ConnectedAccountStatus::Active->value,
+                    'capabilities' => $data->capabilities,
                     'token_expires_at' => $data->tokenExpiresAt,
                     'last_refreshed_at' => Date::now(),
                 ],

--- a/app/Services/ConnectedAccounts/XAccountCapabilities.php
+++ b/app/Services/ConnectedAccounts/XAccountCapabilities.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ConnectedAccounts;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Factory as HttpFactory;
+use Illuminate\Support\Facades\Log;
+
+class XAccountCapabilities
+{
+    private const string USER_URL = 'https://api.twitter.com/2/users/me';
+
+    private const int STANDARD_TEXT_LENGTH = 280;
+
+    private const int PREMIUM_TEXT_LENGTH = 25_000;
+
+    public function __construct(private readonly HttpFactory $http) {}
+
+    /**
+     * @return array{x_premium: bool, max_text_length: int, verified_type: string|null}
+     */
+    public function forAccessToken(?string $token): array
+    {
+        if ($token === null || $token === '') {
+            return self::fromUserData([]);
+        }
+
+        try {
+            $response = $this->http
+                ->withToken($token)
+                ->acceptJson()
+                ->timeout(5)
+                ->connectTimeout(3)
+                ->get(self::USER_URL, [
+                    'user.fields' => 'verified,verified_type',
+                ]);
+        } catch (ConnectionException $exception) {
+            Log::warning('Could not detect X account capabilities.', [
+                'exception' => $exception::class,
+                'message' => $exception->getMessage(),
+            ]);
+
+            return self::fromUserData([]);
+        }
+
+        if ($response->failed()) {
+            Log::warning('X account capabilities lookup failed.', [
+                'status' => $response->status(),
+            ]);
+
+            return self::fromUserData([]);
+        }
+
+        return self::fromUserData((array) $response->json('data', []));
+    }
+
+    /**
+     * @param  array<string, mixed>  $user
+     * @return array{x_premium: bool, max_text_length: int, verified_type: string|null}
+     */
+    public static function fromUserData(array $user): array
+    {
+        $verifiedType = isset($user['verified_type']) ? (string) $user['verified_type'] : null;
+        $isPremium = in_array($verifiedType, ['blue', 'business', 'government'], true);
+
+        return [
+            'x_premium' => $isPremium,
+            'max_text_length' => $isPremium ? self::PREMIUM_TEXT_LENGTH : self::STANDARD_TEXT_LENGTH,
+            'verified_type' => $verifiedType,
+        ];
+    }
+}

--- a/app/Services/Posts/DraftService.php
+++ b/app/Services/Posts/DraftService.php
@@ -12,6 +12,7 @@ use App\Models\Post;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
 use App\Models\User;
+use App\Models\Workspace;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 
@@ -68,7 +69,29 @@ class DraftService
                 ->pluck('id'),
         };
 
-        return array_values($ids->map(static fn (mixed $id): string => (string) $id)->all());
+        return $this->defaultFirst($workspaceId, $ids->map(static fn (mixed $id): string => (string) $id)->all());
+    }
+
+    /**
+     * @param  array<int, string>  $accountIds
+     * @return list<string>
+     */
+    private function defaultFirst(string $workspaceId, array $accountIds): array
+    {
+        $defaultAccountId = (string) (DB::table((new Workspace)->getTable())
+            ->where('id', $workspaceId)
+            ->value('default_connected_account_id') ?? '');
+
+        if ($defaultAccountId === '') {
+            return array_values($accountIds);
+        }
+
+        usort(
+            $accountIds,
+            static fn (string $left, string $right): int => (int) ($right === $defaultAccountId) <=> (int) ($left === $defaultAccountId),
+        );
+
+        return $accountIds;
     }
 
     /**
@@ -110,7 +133,12 @@ class DraftService
                 : $currentOverride;
 
             $effectiveText = $override['text'] ?? $baseText;
-            $sections = $this->splitter->split($effectiveText, $account->platform, $autoSplit)->sections;
+            $sections = $this->splitter->split(
+                $effectiveText,
+                $account->platform,
+                $autoSplit,
+                $account->maxTextLength(),
+            )->sections;
 
             PostTarget::updateOrCreate(
                 ['post_id' => $post->id, 'connected_account_id' => $accountId],

--- a/app/Services/Posts/PostSplitter.php
+++ b/app/Services/Posts/PostSplitter.php
@@ -16,14 +16,14 @@ class PostSplitter
     /**
      * Split text into platform sections and collect advisory validation issues.
      */
-    public function split(string $text, Platform $platform, bool $autoSplit): SplitResult
+    public function split(string $text, Platform $platform, bool $autoSplit, ?int $maxLength = null): SplitResult
     {
         $segments = $this->manualSegments($text);
 
         $sections = [];
         foreach ($segments as $segment) {
             if ($autoSplit) {
-                foreach ($this->chunk($segment, $platform) as $chunk) {
+                foreach ($this->chunk($segment, $platform, $maxLength) as $chunk) {
                     $sections[] = $chunk;
                 }
             } else {
@@ -35,7 +35,7 @@ class PostSplitter
             $sections = [''];
         }
 
-        return new SplitResult($sections, $this->validateSections($sections, $platform, 0));
+        return new SplitResult($sections, $this->validateSections($sections, $platform, 0, $maxLength));
     }
 
     /**
@@ -44,12 +44,13 @@ class PostSplitter
      * @param  list<string>  $sections
      * @return list<string>
      */
-    public function validateSections(array $sections, Platform $platform, int $mediaCount): array
+    public function validateSections(array $sections, Platform $platform, int $mediaCount, ?int $maxLength = null): array
     {
         $issues = [];
+        $limit = $maxLength ?? $platform->maxLength();
 
         foreach ($sections as $section) {
-            if ($platform->measure($section) > $platform->maxLength()) {
+            if ($platform->measure($section) > $limit) {
                 $issues[] = 'section_too_long';
                 break;
             }
@@ -104,13 +105,13 @@ class PostSplitter
      *
      * @return list<string>
      */
-    private function chunk(string $segment, Platform $platform): array
+    private function chunk(string $segment, Platform $platform, ?int $maxLength): array
     {
-        if ($platform->measure($segment) <= $platform->maxLength()) {
+        $limit = $maxLength ?? $platform->maxLength();
+
+        if ($platform->measure($segment) <= $limit) {
             return [$segment];
         }
-
-        $limit = $platform->maxLength();
 
         $sections = [];
         $current = '';
@@ -126,7 +127,7 @@ class PostSplitter
                     $hasCurrent = false;
                 }
 
-                foreach ($this->splitParagraph($paragraph, $platform) as $piece) {
+                foreach ($this->splitParagraph($paragraph, $platform, $limit) as $piece) {
                     $sections[] = $piece;
                 }
 
@@ -162,9 +163,8 @@ class PostSplitter
      *
      * @return list<string>
      */
-    private function splitParagraph(string $paragraph, Platform $platform): array
+    private function splitParagraph(string $paragraph, Platform $platform, int $limit): array
     {
-        $limit = $platform->maxLength();
         $words = preg_split('/\s+/', trim($paragraph)) ?: [$paragraph];
 
         $chunks = [];
@@ -186,7 +186,7 @@ class PostSplitter
 
             // A single word longer than the limit is hard-split by characters.
             if ($platform->measure($word) > $limit) {
-                foreach ($this->hardSplit($word, $platform) as $piece) {
+                foreach ($this->hardSplit($word, $platform, $limit) as $piece) {
                     $chunks[] = $piece;
                 }
             } else {
@@ -204,9 +204,8 @@ class PostSplitter
     /**
      * @return list<string>
      */
-    private function hardSplit(string $word, Platform $platform): array
+    private function hardSplit(string $word, Platform $platform, int $limit): array
     {
-        $limit = $platform->maxLength();
         $pieces = [];
         $buffer = '';
 

--- a/app/Support/PostView.php
+++ b/app/Support/PostView.php
@@ -18,6 +18,7 @@ final class PostView
     {
         $splitter = app(PostSplitter::class);
         $mediaCount = $post->media->count();
+        $defaultAccountId = $post->workspace()->value('default_connected_account_id');
 
         return [
             'id' => $post->id,
@@ -27,22 +28,29 @@ final class PostView
             'published_at' => $post->published_at?->toIso8601String(),
             'updated_at' => $post->updated_at->toIso8601String(),
             'destination' => self::destination($post),
-            'targets' => $post->targets->map(fn (PostTarget $target): array => [
-                'id' => $target->id,
-                'connected_account_id' => $target->connected_account_id,
-                'platform' => $target->platform->value,
-                'handle' => $target->account?->handle,
-                'display_name' => $target->account?->display_name,
-                'avatar_url' => $target->account?->avatar_url,
-                'sections' => $target->sections,
-                'content_override' => $target->content_override,
-                'auto_split' => $target->auto_split,
-                'status' => $target->status->value,
-                'error_kind' => $target->error_kind?->value,
-                'error_message' => $target->error_message,
-                'remote_id' => $target->remote_id,
-                'issues' => $splitter->validateSections($target->sections, $target->platform, $mediaCount),
-            ])->all(),
+            'targets' => $post->targets
+                ->sortByDesc(fn (PostTarget $target): bool => $target->connected_account_id === $defaultAccountId)
+                ->map(fn (PostTarget $target): array => [
+                    'id' => $target->id,
+                    'connected_account_id' => $target->connected_account_id,
+                    'platform' => $target->platform->value,
+                    'handle' => $target->account?->handle,
+                    'display_name' => $target->account?->display_name,
+                    'avatar_url' => $target->account?->avatar_url,
+                    'sections' => $target->sections,
+                    'content_override' => $target->content_override,
+                    'auto_split' => $target->auto_split,
+                    'status' => $target->status->value,
+                    'error_kind' => $target->error_kind?->value,
+                    'error_message' => $target->error_message,
+                    'remote_id' => $target->remote_id,
+                    'issues' => $splitter->validateSections(
+                        $target->sections,
+                        $target->platform,
+                        $mediaCount,
+                        $target->account?->maxTextLength(),
+                    ),
+                ])->values()->all(),
             'media' => $post->media->map(fn (PostMedia $media): array => [
                 'id' => $media->id,
                 'url' => $media->url(),

--- a/database/migrations/2026_06_23_000001_add_capabilities_to_connected_accounts_table.php
+++ b/database/migrations/2026_06_23_000001_add_capabilities_to_connected_accounts_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('connected_accounts', function (Blueprint $table): void {
+            $table->json('capabilities')->nullable()->after('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('connected_accounts', function (Blueprint $table): void {
+            $table->dropColumn('capabilities');
+        });
+    }
+};

--- a/database/migrations/2026_06_23_072417_add_default_connected_account_to_workspaces_table.php
+++ b/database/migrations/2026_06_23_072417_add_default_connected_account_to_workspaces_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('workspaces', function (Blueprint $table): void {
+            $table->foreignUuid('default_connected_account_id')
+                ->nullable()
+                ->after('owner_id')
+                ->constrained('connected_accounts')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('workspaces', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('default_connected_account_id');
+        });
+    }
+};

--- a/resources/js/components/accounts/account-card.tsx
+++ b/resources/js/components/accounts/account-card.tsx
@@ -6,6 +6,7 @@ import ConnectedAccountController from '@/actions/App/Http/Controllers/Connected
 import InputError from '@/components/common/input-error';
 import { PlatformGlyph } from '@/components/common/platform-glyph';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -185,6 +186,28 @@ export function AccountCard({
 
             <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11.5px] text-muted-foreground">
                 <span>{account.platform_label}</span>
+                {account.is_default && (
+                    <>
+                        <span aria-hidden>·</span>
+                        <Badge
+                            variant="success"
+                            className="h-4 rounded-full px-1.5 text-[10.5px]"
+                        >
+                            Default
+                        </Badge>
+                    </>
+                )}
+                {account.x_premium && (
+                    <>
+                        <span aria-hidden>·</span>
+                        <Badge
+                            variant="info"
+                            className="h-4 rounded-full px-1.5 text-[10.5px]"
+                        >
+                            Premium
+                        </Badge>
+                    </>
+                )}
                 {account.connected_by && (
                     <>
                         <span aria-hidden>·</span>
@@ -209,6 +232,26 @@ export function AccountCard({
                             <RefreshCw className="size-4" />
                             Reconnect
                         </Button>
+                    )}
+                    {!account.is_default && (
+                        <Form
+                            {...ConnectedAccountController.makeDefault.form(
+                                account.id,
+                            )}
+                            options={{ preserveScroll: true }}
+                        >
+                            {({ processing }) => (
+                                <Button
+                                    type="submit"
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-8 text-muted-foreground"
+                                    disabled={processing}
+                                >
+                                    Make default
+                                </Button>
+                            )}
+                        </Form>
                     )}
                     <Button
                         variant="ghost"

--- a/resources/js/components/accounts/types.ts
+++ b/resources/js/components/accounts/types.ts
@@ -10,6 +10,9 @@ export type Account = {
     auth_method: string;
     connected_by: string | null;
     token_expires_at: string | null;
+    max_text_length: number;
+    x_premium: boolean;
+    is_default: boolean;
 };
 
 export type Capability = {

--- a/resources/js/components/compose/__tests__/composer-tabs.test.ts
+++ b/resources/js/components/compose/__tests__/composer-tabs.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+describe('composer platform tabs', () => {
+    it('uses the section count chip for every platform', () => {
+        const source = readFileSync(
+            resolve(
+                process.cwd(),
+                'resources/js/components/compose/composer.tsx',
+            ),
+            'utf8',
+        );
+
+        expect(source).toContain(
+            'return String(target?.sections.length ?? 1);',
+        );
+        expect(source).not.toContain("account.platform === 'linkedin'");
+    });
+});

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -165,8 +165,12 @@ export default function Composer({
             ? (state.overrideByAccount[activeAccount.id] as string)
             : state.baseText;
 
-    function limitFor(platform: PlatformName): number {
+    function limitForPlatform(platform: PlatformName): number {
         return limits.find((l) => l.platform === platform)?.maxLength ?? 0;
+    }
+
+    function limitForAccount(account: Account): number {
+        return account.max_text_length || limitForPlatform(account.platform);
     }
 
     function severityFor(accountId: string): 'ok' | 'warn' | 'over' {
@@ -178,7 +182,7 @@ export default function Composer({
             state.overrideByAccount[accountId] !== undefined
                 ? (state.overrideByAccount[accountId] as string)
                 : state.baseText;
-        const limit = limitFor(account.platform);
+        const limit = limitForAccount(account);
         const count = measure(text, account.platform);
         if (limit > 0 && count > limit) {
             return 'over';
@@ -195,10 +199,6 @@ export default function Composer({
         const target = post?.targets.find(
             (t) => t.connected_account_id === accountId,
         );
-        if (account.platform === 'linkedin') {
-            return (target?.issues.length ?? 0) === 0 ? '✓' : '!';
-        }
-
         return String(target?.sections.length ?? 1);
     }
 
@@ -286,7 +286,7 @@ export default function Composer({
                               autoSplit:
                                   state.autoSplitByAccount[activeAccount.id] ??
                                   true,
-                              limit: limitFor(activeAccount.platform),
+                              limit: limitForAccount(activeAccount),
                               threadMax:
                                   limits.find(
                                       (l) =>
@@ -301,7 +301,7 @@ export default function Composer({
             {activeAccount ? (
                 <CharCounter
                     count={measure(activeText, activeAccount.platform)}
-                    limit={limitFor(activeAccount.platform)}
+                    limit={limitForAccount(activeAccount)}
                     sectionTotal={activeSectionTotal}
                     state={severityFor(activeAccount.id)}
                 />

--- a/resources/js/lib/compose/__tests__/composer-state.test.ts
+++ b/resources/js/lib/compose/__tests__/composer-state.test.ts
@@ -20,6 +20,8 @@ function account(id: string): Account {
         handle: `@${id}`,
         display_name: null,
         avatar_url: null,
+        max_text_length: 280,
+        x_premium: false,
     };
 }
 

--- a/resources/js/types/compose.ts
+++ b/resources/js/types/compose.ts
@@ -13,6 +13,8 @@ export type Account = {
     handle: string;
     display_name: string | null;
     avatar_url: string | null;
+    max_text_length: number;
+    x_premium: boolean;
 };
 
 export type AccountSet = {

--- a/routes/accounts.php
+++ b/routes/accounts.php
@@ -36,6 +36,9 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
         ->middleware('throttle:10,1')
         ->name('accounts.reconnect');
 
+    Route::post('accounts/{account}/default', [ConnectedAccountController::class, 'makeDefault'])
+        ->name('accounts.default');
+
     Route::delete('accounts/{account}', [ConnectedAccountController::class, 'destroy'])
         ->name('accounts.destroy');
 });

--- a/tests/Feature/ConnectedAccounts/AccountsPageTest.php
+++ b/tests/Feature/ConnectedAccounts/AccountsPageTest.php
@@ -20,6 +20,11 @@ function viewerInWorkspace(WorkspaceRole $role): User
     ConnectedAccount::factory()->create([
         'workspace_id' => $workspace->id,
         'handle' => '@listed',
+        'capabilities' => [
+            'x_premium' => true,
+            'max_text_length' => 25_000,
+            'verified_type' => 'blue',
+        ],
     ]);
 
     return $user;
@@ -35,8 +40,83 @@ test('the accounts page lists accounts and exposes capabilities and canManage to
             ->has('capabilities', 3)
             ->has('accounts', 1)
             ->where('accounts.0.handle', '@listed')
+            ->where('accounts.0.x_premium', true)
+            ->where('accounts.0.max_text_length', 25_000)
+            ->where('accounts.0.is_default', false)
             ->missing('accounts.0.secret'),
         );
+});
+
+test('owners can set a workspace default account from the accounts page', function () {
+    $owner = User::factory()->create(['email_verified_at' => now()]);
+    $workspace = Workspace::factory()->create(['owner_id' => $owner->id]);
+    WorkspaceMembership::factory()->owner()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $owner->id,
+    ]);
+    $owner->forceFill(['current_workspace_id' => $workspace->id])->save();
+    $account = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+
+    test()->actingAs($owner)
+        ->post(route('accounts.default', $account))
+        ->assertRedirect(route('accounts.index'));
+
+    expect($workspace->fresh()->default_connected_account_id)->toBe($account->id);
+});
+
+test('members cannot set a workspace default account', function () {
+    $member = User::factory()->create(['email_verified_at' => now()]);
+    $workspace = Workspace::factory()->create();
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $member->id,
+    ]);
+    $member->forceFill(['current_workspace_id' => $workspace->id])->save();
+    $account = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+
+    test()->actingAs($member)
+        ->post(route('accounts.default', $account))
+        ->assertForbidden();
+
+    expect($workspace->fresh()->default_connected_account_id)->toBeNull();
+});
+
+test('the accounts page marks and lists the workspace default account first', function () {
+    $owner = User::factory()->create(['email_verified_at' => now()]);
+    $workspace = Workspace::factory()->create(['owner_id' => $owner->id]);
+    WorkspaceMembership::factory()->owner()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $owner->id,
+    ]);
+    $owner->forceFill(['current_workspace_id' => $workspace->id])->save();
+    ConnectedAccount::factory()->create(['workspace_id' => $workspace->id, 'handle' => '@regular']);
+    $default = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id, 'handle' => '@default']);
+    $workspace->forceFill(['default_connected_account_id' => $default->id])->save();
+
+    test()->actingAs($owner)->get('/accounts')
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('accounts.0.id', $default->id)
+            ->where('accounts.0.is_default', true)
+            ->where('accounts.0.handle', '@default'),
+        );
+});
+
+test('disconnecting the workspace default account clears the default', function () {
+    $owner = User::factory()->create(['email_verified_at' => now()]);
+    $workspace = Workspace::factory()->create(['owner_id' => $owner->id]);
+    WorkspaceMembership::factory()->owner()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $owner->id,
+    ]);
+    $owner->forceFill(['current_workspace_id' => $workspace->id])->save();
+    $account = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+    $workspace->forceFill(['default_connected_account_id' => $account->id])->save();
+
+    test()->actingAs($owner)
+        ->delete(route('accounts.destroy', $account))
+        ->assertRedirect(route('accounts.index'));
+
+    expect($workspace->fresh()->default_connected_account_id)->toBeNull();
 });
 
 test('members see the list but cannot manage', function () {

--- a/tests/Feature/ConnectedAccounts/ConnectOAuthTest.php
+++ b/tests/Feature/ConnectedAccounts/ConnectOAuthTest.php
@@ -7,6 +7,7 @@ use App\Models\ConnectedAccount;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Models\WorkspaceMembership;
+use Illuminate\Support\Facades\Http;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\AbstractProvider;
 use Laravel\Socialite\Two\User as SocialiteUser;
@@ -94,6 +95,11 @@ test('callback persists an active X account with an encrypted token', function (
         'refreshToken' => 'refresh',
         'expiresIn' => 7200,
     ]);
+    Http::fake([
+        'https://api.twitter.com/2/users/me*' => Http::response([
+            'data' => ['id' => 'x-99', 'verified_type' => 'none'],
+        ]),
+    ]);
 
     test()->get('/accounts/callback/x')->assertRedirect(route('accounts.index'));
 
@@ -103,7 +109,35 @@ test('callback persists an active X account with an encrypted token', function (
         ->and($account->status)->toBe(ConnectedAccountStatus::Active)
         ->and($account->handle)->toBe('@ada')
         ->and($account->workspace_id)->toBe($workspace->id)
-        ->and($account->secret->access_token)->toBe('access');
+        ->and($account->secret->access_token)->toBe('access')
+        ->and($account->capabilities)->toBe([
+            'x_premium' => false,
+            'max_text_length' => 280,
+            'verified_type' => 'none',
+        ]);
+});
+
+test('callback detects X premium accounts for long tweets', function () {
+    config()->set('services.x.client_id', 'cid');
+    config()->set('services.x.client_secret', 'secret');
+    config()->set('services.x.redirect', 'https://app.test/accounts/callback/x');
+    ownerActingIn();
+    fakeOAuthUser('x', [
+        'id' => 'x-premium',
+        'nickname' => 'premium',
+        'token' => 'access',
+    ]);
+    Http::fake([
+        'https://api.twitter.com/2/users/me*' => Http::response([
+            'data' => ['id' => 'x-premium', 'verified_type' => 'blue'],
+        ]),
+    ]);
+
+    test()->get('/accounts/callback/x')->assertRedirect(route('accounts.index'));
+
+    $account = ConnectedAccount::withoutGlobalScopes()->firstWhere('remote_account_id', 'x-premium');
+    expect($account->hasXPremium())->toBeTrue()
+        ->and($account->maxTextLength())->toBe(25_000);
 });
 
 test('callback maps a linkedin-openid user', function () {

--- a/tests/Feature/Posts/DraftServiceCreateTest.php
+++ b/tests/Feature/Posts/DraftServiceCreateTest.php
@@ -7,6 +7,7 @@ use App\Models\ConnectedAccount;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Services\Posts\DraftService;
+use App\Support\PostView;
 use Illuminate\Support\Facades\Context;
 
 function workspaceWithAccounts(int $count = 2): array
@@ -45,6 +46,49 @@ test('createDraft with a single-account destination seeds exactly one target', f
 
     expect($post->targets()->count())->toBe(1)
         ->and($post->targets->first()->connected_account_id)->toBe($only->id);
+});
+
+test('createDraft orders the workspace default account first for all destinations', function () {
+    [$user, $workspace, $accounts] = workspaceWithAccounts(3);
+    $default = $accounts[2];
+    $workspace->forceFill(['default_connected_account_id' => $default->id])->save();
+
+    $post = app(DraftService::class)->createDraft($workspace->id, $user, ['kind' => 'all'], 'hello');
+
+    $view = PostView::make($post->fresh(['targets.account', 'media']));
+
+    expect($view['targets'][0]['connected_account_id'])->toBe($default->id);
+});
+
+test('createDraft orders the workspace default account first inside sets', function () {
+    [$user, $workspace, $accounts] = workspaceWithAccounts(3);
+    $default = $accounts[1];
+    $workspace->forceFill(['default_connected_account_id' => $default->id])->save();
+    $set = AccountSet::factory()->create(['workspace_id' => $workspace->id]);
+    $set->accounts()->attach([$accounts[0]->id, $default->id]);
+
+    $post = app(DraftService::class)->createDraft($workspace->id, $user, ['kind' => 'set', 'id' => $set->id], 'hello');
+
+    $view = PostView::make($post->fresh(['targets.account', 'media']));
+
+    expect($view['targets'][0]['connected_account_id'])->toBe($default->id);
+});
+
+test('createDraft keeps long X text together for premium accounts', function () {
+    [$user, $workspace, $accounts] = workspaceWithAccounts(1);
+    $account = $accounts->first();
+    $account->forceFill([
+        'capabilities' => [
+            'x_premium' => true,
+            'max_text_length' => 25_000,
+            'verified_type' => 'blue',
+        ],
+    ])->save();
+
+    $text = str_repeat('a', 400);
+    $post = app(DraftService::class)->createDraft($workspace->id, $user, ['kind' => 'account', 'id' => $account->id], $text);
+
+    expect($post->targets()->first()->sections)->toBe([$text]);
 });
 
 test('createDraft with a set destination snapshots that set membership', function () {

--- a/tests/Feature/Workspace/ShellWorkspaceIsolationTest.php
+++ b/tests/Feature/Workspace/ShellWorkspaceIsolationTest.php
@@ -55,3 +55,25 @@ test('shell only exposes account sets from the current workspace', function () {
             ->where('shell.sets.0.id', $mine->id)
         );
 });
+
+test('shell lists the workspace default connected account first', function () {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->create([
+        'current_workspace_id' => $workspace->id,
+        'email_verified_at' => now(),
+    ]);
+    WorkspaceMembership::factory()->owner()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+    ]);
+
+    ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+    $default = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+    $workspace->forceFill(['default_connected_account_id' => $default->id])->save();
+
+    $this->actingAs($user)->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->where('shell.accounts.0.id', $default->id)
+        );
+});

--- a/tests/Unit/ConnectedAccounts/XAccountCapabilitiesTest.php
+++ b/tests/Unit/ConnectedAccounts/XAccountCapabilitiesTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Services\ConnectedAccounts\XAccountCapabilities;
+use Illuminate\Support\Facades\Http;
+
+test('it maps blue verified X accounts to the premium tweet length', function () {
+    expect(XAccountCapabilities::fromUserData(['verified_type' => 'blue']))
+        ->toBe([
+            'x_premium' => true,
+            'max_text_length' => 25_000,
+            'verified_type' => 'blue',
+        ]);
+});
+
+test('it maps unverified X accounts to the standard tweet length', function () {
+    expect(XAccountCapabilities::fromUserData(['verified_type' => 'none']))
+        ->toBe([
+            'x_premium' => false,
+            'max_text_length' => 280,
+            'verified_type' => 'none',
+        ]);
+});
+
+test('it detects premium status from the X users me endpoint', function () {
+    Http::fake([
+        'https://api.twitter.com/2/users/me*' => Http::response([
+            'data' => ['id' => '1', 'verified_type' => 'blue'],
+        ]),
+    ]);
+
+    $capabilities = app(XAccountCapabilities::class)->forAccessToken('tok');
+
+    expect($capabilities['x_premium'])->toBeTrue()
+        ->and($capabilities['max_text_length'])->toBe(25_000);
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://api.twitter.com/2/users/me?user.fields=verified%2Cverified_type'
+        && $request->hasHeader('Authorization', 'Bearer tok'));
+});

--- a/tests/Unit/Posts/PostSplitterTest.php
+++ b/tests/Unit/Posts/PostSplitterTest.php
@@ -72,6 +72,14 @@ test('without auto split an over-limit segment stays whole and is flagged', func
         ->and($result->issues)->toContain('section_too_long');
 });
 
+test('x can use a premium account length budget', function () {
+    $text = str_repeat('a', 400);
+    $result = splitter()->split($text, Platform::X, true, maxLength: 25_000);
+
+    expect($result->sections)->toBe([$text])
+        ->and($result->issues)->toBe([]);
+});
+
 test('linkedin thread max flags multi-section drafts', function () {
     $result = splitter()->split("one\n---\ntwo", Platform::LinkedIn, true);
 


### PR DESCRIPTION
## Summary
- Add workspace-level default connected accounts and show them first across account lists, composer targets, and shell account data.
- Detect X premium capability during OAuth connection and store per-account posting limits.
- Use account-specific text limits in composer counters, post splitting, and validation so premium X accounts can draft longer posts.
- Add account badges and controls for default and premium status, with tests covering permissions, ordering, capability detection, and splitting behavior.