### PR TITLE
feat(posts): support custom account destinations

### DIFF
--- a/app/Dto/Post/DraftData.php
+++ b/app/Dto/Post/DraftData.php
@@ -12,6 +12,7 @@ final class DraftData
      * "set this override to null" from "leave the existing override untouched"
      * (the smart-merge that preserves edits across a destination switch).
      *
+     * @param  list<string>  $destinationIds
      * @param  list<string>  $mediaIds
      * @param  array<string, array{auto_split?: bool, content_override?: array{text?: string|null, media_ids?: list<string>}|null}>  $targetsByAccount
      */
@@ -19,6 +20,7 @@ final class DraftData
         public readonly string $baseText,
         public readonly string $destinationKind,
         public readonly ?string $destinationId,
+        public readonly array $destinationIds,
         public readonly array $mediaIds,
         public readonly array $targetsByAccount,
         public readonly ?string $expectedUpdatedAt,
@@ -47,6 +49,7 @@ final class DraftData
             baseText: (string) ($payload['base_text'] ?? ''),
             destinationKind: (string) $destination['kind'],
             destinationId: $destination['id'] ?? null,
+            destinationIds: array_values($destination['ids'] ?? []),
             mediaIds: array_values($payload['media_ids'] ?? []),
             targetsByAccount: $targetsByAccount,
             expectedUpdatedAt: $payload['expected_updated_at'] ?? null,

--- a/app/Http/Requests/Post/StorePostRequest.php
+++ b/app/Http/Requests/Post/StorePostRequest.php
@@ -23,8 +23,10 @@ class StorePostRequest extends FormRequest
         return [
             'base_text' => ['present', 'nullable', 'string'],
             'destination' => ['required', 'array'],
-            'destination.kind' => ['required', Rule::in(['all', 'set', 'account'])],
+            'destination.kind' => ['required', Rule::in(['all', 'set', 'account', 'accounts'])],
             'destination.id' => ['nullable', 'string', 'required_if:destination.kind,set,account'],
+            'destination.ids' => ['array', 'required_if:destination.kind,accounts'],
+            'destination.ids.*' => ['string'],
         ];
     }
 }

--- a/app/Http/Requests/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/Post/UpdatePostRequest.php
@@ -22,8 +22,10 @@ class UpdatePostRequest extends FormRequest
         return [
             'base_text' => ['present', 'nullable', 'string'],
             'destination' => ['required', 'array'],
-            'destination.kind' => ['required', Rule::in(['all', 'set', 'account'])],
+            'destination.kind' => ['required', Rule::in(['all', 'set', 'account', 'accounts'])],
             'destination.id' => ['nullable', 'string', 'required_if:destination.kind,set,account'],
+            'destination.ids' => ['array', 'required_if:destination.kind,accounts'],
+            'destination.ids.*' => ['string'],
             'targets' => ['array'],
             'targets.*.connected_account_id' => ['required', 'string'],
             'targets.*.auto_split' => ['boolean'],

--- a/app/Services/Posts/DraftService.php
+++ b/app/Services/Posts/DraftService.php
@@ -22,7 +22,7 @@ class DraftService
     /**
      * Create a draft and snapshot the destination's accounts into targets.
      *
-     * @param  array{kind: string, id?: string|null}  $destination
+     * @param  array{kind: string, id?: string|null, ids?: list<string>}  $destination
      */
     public function createDraft(string $workspaceId, User $author, array $destination, string $baseText): Post
     {
@@ -45,7 +45,7 @@ class DraftService
     /**
      * Resolve a destination descriptor to the concrete account ids it targets.
      *
-     * @param  array{kind: string, id?: string|null}  $destination
+     * @param  array{kind: string, id?: string|null, ids?: list<string>}  $destination
      * @return list<string>
      */
     public function resolveDestinationAccountIds(string $workspaceId, array $destination): array
@@ -63,6 +63,10 @@ class DraftService
                     ->whereKey($destination['id'])
                     ->first()?->accounts()->pluck('connected_accounts.id') ?? collect()
                 : collect(),
+            'accounts' => ConnectedAccount::withoutGlobalScopes()
+                ->where('workspace_id', $workspaceId)
+                ->whereIn('id', $destination['ids'] ?? [])
+                ->pluck('id'),
             default => ConnectedAccount::withoutGlobalScopes()
                 ->where('workspace_id', $workspaceId)
                 ->pluck('id'),
@@ -140,7 +144,11 @@ class DraftService
                 throw new PostStaleWriteException;
             }
 
-            $destination = ['kind' => $data->destinationKind, 'id' => $data->destinationId];
+            $destination = [
+                'kind' => $data->destinationKind,
+                'id' => $data->destinationId,
+                'ids' => $data->destinationIds,
+            ];
             $accountIds = $this->resolveDestinationAccountIds($post->workspace_id, $destination);
 
             // Only carry an explicitly-sent override/auto-split into the merge;
@@ -175,7 +183,7 @@ class DraftService
      * that actually belongs to the workspace. A foreign or unknown set id resolves to
      * null (it would yield zero targets anyway), preventing a dangling reference.
      *
-     * @param  array{kind: string, id?: string|null}  $destination
+     * @param  array{kind: string, id?: string|null, ids?: list<string>}  $destination
      */
     private function scopedAccountSetId(string $workspaceId, array $destination): ?string
     {

--- a/app/Support/PostView.php
+++ b/app/Support/PostView.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Support;
 
+use App\Models\ConnectedAccount;
 use App\Models\Post;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
@@ -56,7 +57,7 @@ final class PostView
     }
 
     /**
-     * @return array{kind: string, id: string|null}
+     * @return array{kind: string, id: string|null, ids?: list<string>}
      */
     private static function destination(Post $post): array
     {
@@ -64,8 +65,26 @@ final class PostView
             return ['kind' => 'set', 'id' => $post->account_set_id];
         }
 
-        return $post->targets->count() === 1
-            ? ['kind' => 'account', 'id' => $post->targets->first()->connected_account_id]
-            : ['kind' => 'all', 'id' => null];
+        if ($post->targets->count() === 1) {
+            return ['kind' => 'account', 'id' => $post->targets->first()->connected_account_id];
+        }
+
+        $targetIds = $post->targets
+            ->pluck('connected_account_id')
+            ->map(static fn (mixed $id): string => (string) $id)
+            ->sort()
+            ->values()
+            ->all();
+        $allAccountIds = ConnectedAccount::withoutGlobalScopes()
+            ->where('workspace_id', $post->workspace_id)
+            ->pluck('id')
+            ->map(static fn (mixed $id): string => (string) $id)
+            ->sort()
+            ->values()
+            ->all();
+
+        return $targetIds === $allAccountIds
+            ? ['kind' => 'all', 'id' => null]
+            : ['kind' => 'accounts', 'id' => null, 'ids' => $targetIds];
     }
 }

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -63,6 +63,11 @@ function accountIdsFor(
 
         return set ? set.connected_account_ids : [];
     }
+    if (destination.kind === 'accounts') {
+        const selected = new Set(destination.ids);
+
+        return accounts.filter((a) => selected.has(a.id)).map((a) => a.id);
+    }
 
     return accounts.map((a) => a.id);
 }

--- a/resources/js/components/compose/destination-selector.tsx
+++ b/resources/js/components/compose/destination-selector.tsx
@@ -1,16 +1,13 @@
-import { Layers } from 'lucide-react';
+import { Check, ChevronDown, Layers } from 'lucide-react';
+import type React from 'react';
 
 import { PlatformGlyph } from '@/components/common/platform-glyph';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
-    Select,
-    SelectContent,
-    SelectGroup,
-    SelectItem,
-    SelectLabel,
-    SelectTrigger,
-    SelectValue,
-} from '@/components/ui/select';
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import type { Account, AccountSet, Destination } from '@/types/compose';
 
@@ -49,7 +46,7 @@ function AccountVisual({ account }: { account: Account }) {
                     brand.glyph,
                 )}
             >
-                {/* size-* class is required: the Select CSS force-sizes any
+                {/* size-* class is required: shared item CSS force-sizes any
                     class-less svg to size-4 (16px). */}
                 <PlatformGlyph
                     platform={account.platform}
@@ -78,12 +75,77 @@ type DestinationSelectorProps = {
     disabled?: boolean;
 };
 
-function toValue(destination: Destination): string {
-    if (destination.kind === 'all') {
-        return 'all';
+function selectedAccountIds(
+    destination: Destination,
+    accounts: Account[],
+    sets: AccountSet[],
+): string[] {
+    if (destination.kind === 'account') {
+        return accounts.some((a) => a.id === destination.id)
+            ? [destination.id]
+            : [];
+    }
+    if (destination.kind === 'accounts') {
+        const available = new Set(accounts.map((a) => a.id));
+
+        return destination.ids.filter((id) => available.has(id));
+    }
+    if (destination.kind === 'set') {
+        return (
+            sets.find((s) => s.id === destination.id)?.connected_account_ids ??
+            []
+        );
     }
 
-    return `${destination.kind}:${destination.id}`;
+    return accounts.map((a) => a.id);
+}
+
+function sameIds(left: string[], right: string[]): boolean {
+    if (left.length !== right.length) {
+        return false;
+    }
+    const selected = new Set(left);
+
+    return right.every((id) => selected.has(id));
+}
+
+function destinationFromIds(
+    ids: string[],
+    accounts: Account[],
+    preferredSet: AccountSet | null = null,
+): Destination {
+    if (ids.length === accounts.length) {
+        return { kind: 'all' };
+    }
+    if (preferredSet && sameIds(ids, preferredSet.connected_account_ids)) {
+        return { kind: 'set', id: preferredSet.id };
+    }
+    if (ids.length === 1) {
+        return { kind: 'account', id: ids[0] };
+    }
+
+    return { kind: 'accounts', ids };
+}
+
+function triggerLabel(
+    destination: Destination,
+    selectedIds: string[],
+    accounts: Account[],
+    sets: AccountSet[],
+): string {
+    if (selectedIds.length === accounts.length) {
+        return 'All accounts';
+    }
+    if (destination.kind === 'set') {
+        return sets.find((s) => s.id === destination.id)?.name ?? 'Set';
+    }
+    if (selectedIds.length === 1) {
+        return (
+            accounts.find((a) => a.id === selectedIds[0])?.handle ?? '1 account'
+        );
+    }
+
+    return `${selectedIds.length} accounts`;
 }
 
 export default function DestinationSelector({
@@ -93,60 +155,128 @@ export default function DestinationSelector({
     onChange,
     disabled = false,
 }: DestinationSelectorProps) {
-    function handleChange(value: string) {
-        if (value === 'all') {
-            onChange({ kind: 'all' });
+    const selectedIds = selectedAccountIds(destination, accounts, sets);
+    const selected = new Set(selectedIds);
+    const label = triggerLabel(destination, selectedIds, accounts, sets);
 
+    function chooseAll() {
+        onChange({ kind: 'all' });
+    }
+
+    function toggleAccount(accountId: string) {
+        const next = selected.has(accountId)
+            ? selectedIds.filter((id) => id !== accountId)
+            : [...selectedIds, accountId];
+
+        if (next.length === 0) {
             return;
         }
-        const [kind, id] = value.split(':');
-        onChange(
-            kind === 'set' ? { kind: 'set', id } : { kind: 'account', id },
+
+        onChange(destinationFromIds(next, accounts));
+    }
+
+    function toggleSet(set: AccountSet) {
+        const allSetAccountsSelected = set.connected_account_ids.every((id) =>
+            selected.has(id),
         );
+        const setIds = new Set(set.connected_account_ids);
+        const next = allSetAccountsSelected
+            ? selectedIds.filter((id) => !setIds.has(id))
+            : [...new Set([...selectedIds, ...set.connected_account_ids])];
+
+        if (next.length === 0) {
+            return;
+        }
+
+        onChange(destinationFromIds(next, accounts, set));
     }
 
     return (
-        <Select
-            value={toValue(destination)}
-            onValueChange={handleChange}
-            disabled={disabled}
-        >
-            <SelectTrigger
-                size="sm"
-                aria-label="Post destination"
-                className="max-w-[150px] gap-1 rounded-md border-transparent bg-transparent px-2 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground data-[size=sm]:h-7"
+        <Popover>
+            <PopoverTrigger asChild disabled={disabled}>
+                <button
+                    type="button"
+                    aria-label="Post destination"
+                    className="inline-flex h-7 max-w-[150px] items-center gap-1 rounded-md border border-transparent bg-transparent px-2 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+                >
+                    <span className="truncate">{label}</span>
+                    <ChevronDown className="size-3 shrink-0 opacity-70" />
+                </button>
+            </PopoverTrigger>
+            <PopoverContent
+                align="end"
+                className="w-[216px] gap-1 rounded-3xl p-2 text-sm"
             >
-                <SelectValue placeholder="Choose where to post" />
-            </SelectTrigger>
-            <SelectContent>
-                <SelectGroup>
-                    <SelectLabel>Sets</SelectLabel>
-                    <SelectItem value="all">
+                <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+                    Sets
+                </div>
+                <OptionButton
+                    selected={selectedIds.length === accounts.length}
+                    onClick={chooseAll}
+                >
+                    <SetVisual />
+                    All accounts
+                </OptionButton>
+                {sets.map((set) => (
+                    <OptionButton
+                        key={set.id}
+                        selected={sameIds(
+                            selectedIds,
+                            set.connected_account_ids,
+                        )}
+                        onClick={() => toggleSet(set)}
+                    >
                         <SetVisual />
-                        All accounts
-                    </SelectItem>
-                    {sets.map((set) => (
-                        <SelectItem key={set.id} value={`set:${set.id}`}>
-                            <SetVisual />
-                            {set.name}
-                        </SelectItem>
-                    ))}
-                </SelectGroup>
+                        {set.name}
+                    </OptionButton>
+                ))}
                 {accounts.length > 0 && (
-                    <SelectGroup>
-                        <SelectLabel>Accounts</SelectLabel>
+                    <>
+                        <div className="px-2 pt-3 pb-1.5 text-xs font-medium text-muted-foreground">
+                            Accounts
+                        </div>
                         {accounts.map((account) => (
-                            <SelectItem
+                            <OptionButton
                                 key={account.id}
-                                value={`account:${account.id}`}
+                                selected={selected.has(account.id)}
+                                onClick={() => toggleAccount(account.id)}
                             >
                                 <AccountVisual account={account} />
                                 {account.handle}
-                            </SelectItem>
+                            </OptionButton>
                         ))}
-                    </SelectGroup>
+                    </>
                 )}
-            </SelectContent>
-        </Select>
+            </PopoverContent>
+        </Popover>
+    );
+}
+
+function OptionButton({
+    selected,
+    children,
+    onClick,
+}: {
+    selected: boolean;
+    children: React.ReactNode;
+    onClick: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            aria-pressed={selected}
+            onClick={onClick}
+            className="flex min-h-8 w-full items-center gap-2 rounded-xl px-2 py-1.5 text-left text-sm outline-hidden select-none hover:bg-muted focus-visible:bg-muted"
+        >
+            <span className="flex min-w-0 flex-1 items-center gap-2 truncate">
+                {children}
+            </span>
+            <Check
+                className={cn(
+                    'ml-auto size-4 shrink-0 text-foreground',
+                    selected ? 'opacity-100' : 'opacity-0',
+                )}
+            />
+        </button>
     );
 }

--- a/resources/js/lib/compose/__tests__/composer-state.test.ts
+++ b/resources/js/lib/compose/__tests__/composer-state.test.ts
@@ -598,6 +598,19 @@ describe('buildPutBody', () => {
         expect(body.expected_updated_at).toBe('2026-06-12T10:00:00+00:00');
     });
 
+    it('carries a custom multi-account destination', () => {
+        const state = composerReducer(hydrated(), {
+            type: 'setDestination',
+            destination: { kind: 'accounts', ids: ['a1', 'a2'] },
+        });
+        const body = buildPutBody(state, ['a1', 'a2']);
+
+        expect(body.destination).toEqual({
+            kind: 'accounts',
+            ids: ['a1', 'a2'],
+        });
+    });
+
     it('emits media_ids from state.media', () => {
         let state = composerReducer(hydrated(), {
             type: 'addMedia',
@@ -699,12 +712,17 @@ describe('parseDestinationParam', () => {
             kind: 'set',
             id: 'xyz',
         });
+        expect(parseDestinationParam('accounts:a,b')).toEqual({
+            kind: 'accounts',
+            ids: ['a', 'b'],
+        });
     });
 
     it('returns null for junk or missing input', () => {
         expect(parseDestinationParam(null)).toBeNull();
         expect(parseDestinationParam('nope')).toBeNull();
         expect(parseDestinationParam('account:')).toBeNull();
+        expect(parseDestinationParam('accounts:')).toBeNull();
     });
 });
 

--- a/resources/js/lib/compose/composer-state.ts
+++ b/resources/js/lib/compose/composer-state.ts
@@ -130,6 +130,11 @@ export function parseDestinationParam(raw: string | null): Destination | null {
     if ((kind === 'account' || kind === 'set') && id) {
         return { kind, id };
     }
+    if (kind === 'accounts' && id) {
+        const ids = id.split(',').filter(Boolean);
+
+        return ids.length > 0 ? { kind: 'accounts', ids } : null;
+    }
 
     return null;
 }
@@ -158,7 +163,11 @@ function hydrate(post: PostView): ComposerState {
                 ? { kind: 'set', id: post.destination.id }
                 : post.destination.kind === 'account' && post.destination.id
                   ? { kind: 'account', id: post.destination.id }
-                  : { kind: 'all' },
+                  : post.destination.kind === 'accounts' &&
+                      post.destination.ids &&
+                      post.destination.ids.length > 0
+                    ? { kind: 'accounts', ids: post.destination.ids }
+                    : { kind: 'all' },
         autoSplitByAccount,
         overrideByAccount,
         mediaSubsetExcludes,

--- a/resources/js/types/compose.ts
+++ b/resources/js/types/compose.ts
@@ -5,7 +5,8 @@ export type PlatformName = 'x' | 'bluesky' | 'linkedin';
 export type Destination =
     | { kind: 'all' }
     | { kind: 'set'; id: string }
-    | { kind: 'account'; id: string };
+    | { kind: 'account'; id: string }
+    | { kind: 'accounts'; ids: string[] };
 
 export type Account = {
     id: string;
@@ -97,7 +98,7 @@ export type PostView = {
     published_at: string | null;
     updated_at: string;
     scheduled_at: string | null;
-    destination: { kind: string; id: string | null };
+    destination: { kind: string; id: string | null; ids?: string[] };
     targets: TargetView[];
     media: MediaView[];
 };

--- a/tests/Feature/Posts/ComposeApiTest.php
+++ b/tests/Feature/Posts/ComposeApiTest.php
@@ -45,6 +45,18 @@ test('POST /posts lazily creates a draft and returns its view as JSON', function
     expect(Post::withoutGlobalScopes()->count())->toBe(1);
 });
 
+test('POST /posts accepts a custom accounts destination', function () {
+    [$user, $workspace, $accounts] = actingMember(3);
+
+    test()->postJson('/posts', [
+        'base_text' => 'custom draft',
+        'destination' => ['kind' => 'accounts', 'ids' => [$accounts[0]->id, $accounts[2]->id]],
+    ])->assertCreated()
+        ->assertJsonPath('post.destination.kind', 'accounts')
+        ->assertJsonPath('post.destination.ids', collect([$accounts[0]->id, $accounts[2]->id])->sort()->values()->all())
+        ->assertJsonCount(2, 'post.targets');
+});
+
 test('PUT /posts/{post} autosaves edits and returns the new baseline', function () {
     [$user, $workspace, $accounts] = actingMember(1);
     $created = test()->postJson('/posts', ['base_text' => 'a', 'destination' => ['kind' => 'all']])->json('post');

--- a/tests/Feature/Posts/DraftServiceCreateTest.php
+++ b/tests/Feature/Posts/DraftServiceCreateTest.php
@@ -57,3 +57,17 @@ test('createDraft with a set destination snapshots that set membership', functio
     expect($post->account_set_id)->toBe($set->id)
         ->and($post->targets()->count())->toBe(2);
 });
+
+test('createDraft with a custom accounts destination seeds the selected targets', function () {
+    [$user, $workspace, $accounts] = workspaceWithAccounts(3);
+
+    $post = app(DraftService::class)->createDraft($workspace->id, $user, [
+        'kind' => 'accounts',
+        'ids' => [$accounts[0]->id, $accounts[2]->id],
+    ], '');
+
+    expect($post->account_set_id)->toBeNull()
+        ->and($post->targets()->count())->toBe(2)
+        ->and($post->targets->pluck('connected_account_id')->sort()->values()->all())
+        ->toEqual(collect([$accounts[0]->id, $accounts[2]->id])->sort()->values()->all());
+});

--- a/tests/Feature/Posts/DraftServiceUpdateTest.php
+++ b/tests/Feature/Posts/DraftServiceUpdateTest.php
@@ -88,6 +88,31 @@ test('switching destination preserves surviving accounts edits (smart merge)', f
         ->and($narrowed->targets->first()->content_override)->toBe(['text' => 'kept text']);
 });
 
+test('switching to a custom accounts destination preserves selected account edits', function () {
+    [$user, $workspace, $accounts] = draftSetup(3);
+    $post = app(DraftService::class)->createDraft($workspace->id, $user, ['kind' => 'all'], 'base');
+    $keep = $accounts[0];
+    $add = $accounts[2];
+
+    app(DraftService::class)->updateDraft($post, DraftData::fromArray([
+        'base_text' => 'base',
+        'destination' => ['kind' => 'all'],
+        'targets' => [['connected_account_id' => $keep->id, 'content_override' => ['text' => 'kept text']]],
+        'expected_updated_at' => $post->fresh()->updated_at->toIso8601String(),
+    ]));
+
+    $updated = app(DraftService::class)->updateDraft($post->fresh(), DraftData::fromArray([
+        'base_text' => 'base',
+        'destination' => ['kind' => 'accounts', 'ids' => [$keep->id, $add->id]],
+        'targets' => [['connected_account_id' => $keep->id]],
+        'expected_updated_at' => $post->fresh()->updated_at->toIso8601String(),
+    ]));
+
+    expect($updated->account_set_id)->toBeNull()
+        ->and($updated->targets)->toHaveCount(2)
+        ->and($updated->targets->firstWhere('connected_account_id', $keep->id)->content_override)->toBe(['text' => 'kept text']);
+});
+
 test('updateDraft attaches and orders media', function () {
     [$user, $workspace, $accounts] = draftSetup(1);
     $post = app(DraftService::class)->createDraft($workspace->id, $user, ['kind' => 'all'], '');


### PR DESCRIPTION
## Summary
- Add support for selecting a custom group of posting accounts outside saved account sets.
- Persist and restore multi-account destinations across draft create, update, and compose hydration flows.
- Replace the destination selector with a multi-select popover for mixing sets and individual accounts.
- Add backend and composer state coverage for custom account destinations.