### PR TITLE
feat(auth): gate email verification by mail delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
+APP_NAME=Shoutrrr
 APP_ENV=local
 APP_KEY=
-APP_URL=http://localhost
+APP_URL=http://127.0.0.1:8000
 
 # Disable social login unless OAuth credentials are configured.
 SOCIALITE_ENABLED=false

--- a/.env.example.prod
+++ b/.env.example.prod
@@ -1,3 +1,4 @@
+APP_NAME=Shoutrrr
 APP_KEY=
 APP_URL=https://your-app.example
 SESSION_SECURE_COOKIE=true

--- a/README.md
+++ b/README.md
@@ -211,6 +211,25 @@ composer dev     # serve + queue + scheduler + logs + Vite, all at once
 
 > Uses [Bun](https://bun.sh) for the frontend (`bun install`, `bun run …`) — not npm/pnpm.
 
+To test SMTP locally during development, run [Mailpit](https://github.com/axllent/mailpit):
+
+```bash
+docker run --rm --name mail --pull always -p 1025:1025 -p 8025:8025 axllent/mailpit:latest
+```
+
+Then set these mail values in your `.env` file:
+
+```dotenv
+MAIL_MAILER=smtp
+MAIL_HOST=127.0.0.1
+MAIL_PORT=1025
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_SCHEME=null
+MAIL_FROM_ADDRESS="hello@shoutrrr.local"
+MAIL_FROM_NAME="${APP_NAME}"
+```
+
 ### How publishing works
 
 A post is composed once, then split into one **target** per connected account. The scheduler dispatches due posts every minute; a queued `PublishPostTarget` job then publishes each target independently, with retries, idempotency, and a per-attempt audit trail. Hourly jobs refresh OAuth tokens before they expire, and (when enabled) metrics are captured every 15 minutes.

--- a/app/Http/Controllers/Settings/ProfileController.php
+++ b/app/Http/Controllers/Settings/ProfileController.php
@@ -25,7 +25,7 @@ class ProfileController extends Controller
     public function edit(Request $request): Response
     {
         return Inertia::render('settings/profile', [
-            'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
+            'mustVerifyEmail' => config('auth.email_verification.enabled', false) && $request->user() instanceof MustVerifyEmail,
             'status' => $request->session()->get('status'),
         ]);
     }
@@ -37,7 +37,7 @@ class ProfileController extends Controller
     {
         $request->user()->fill($request->validated());
 
-        if ($request->user()->isDirty('email')) {
+        if (config('auth.email_verification.enabled', false) && $request->user()->isDirty('email')) {
             $request->user()->email_verified_at = null;
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,11 +2,11 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Casts\NotificationPreferencesCast;
 use App\Enums\SocialProvider;
 use App\Support\Notifications\NotificationPreferences;
 use Database\Factories\UserFactory;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -39,7 +39,7 @@ use Override;
  */
 #[Fillable(['name', 'email', 'password', 'current_workspace_id', 'notification_preferences'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
-class User extends Authenticatable implements OAuthenticatable, PasskeyUser
+class User extends Authenticatable implements MustVerifyEmail, OAuthenticatable, PasskeyUser
 {
     /** @use HasFactory<UserFactory> */
     use HasApiTokens, HasFactory, HasUuids, Notifiable, PasskeyAuthenticatable, TwoFactorAuthenticatable;
@@ -82,6 +82,16 @@ class User extends Authenticatable implements OAuthenticatable, PasskeyUser
     public function socialAccounts(): HasMany
     {
         return $this->hasMany(SocialAccount::class);
+    }
+
+    #[Override]
+    public function hasVerifiedEmail(): bool
+    {
+        if (! config('auth.email_verification.enabled', false)) {
+            return true;
+        }
+
+        return ! is_null($this->email_verified_at);
     }
 
     public function hasPassword(): bool

--- a/config/auth.php
+++ b/config/auth.php
@@ -20,6 +20,10 @@ return [
         'passwords' => env('AUTH_PASSWORD_BROKER', 'users'),
     ],
 
+    'email_verification' => [
+        'enabled' => ! in_array(env('MAIL_MAILER', 'log'), ['array', 'log'], true),
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Authentication Guards

--- a/config/mail.php
+++ b/config/mail.php
@@ -115,4 +115,26 @@ return [
         'name' => env('MAIL_FROM_NAME', env('APP_NAME', 'Shoutrrr')),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Markdown Mail Settings
+    |--------------------------------------------------------------------------
+    |
+    | These options control the theme and component paths used by Laravel's
+    | Markdown email renderer for mailables and notifications.
+    |
+    */
+
+    'markdown' => [
+        'theme' => env('MAIL_MARKDOWN_THEME', 'default'),
+
+        'paths' => [
+            resource_path('views/vendor/mail'),
+        ],
+
+        'extensions' => [
+            // \League\CommonMark\Extension\Strikethrough\StrikethroughExtension::class,
+        ],
+    ],
+
 ];

--- a/resources/views/vendor/mail/html/header.blade.php
+++ b/resources/views/vendor/mail/html/header.blade.php
@@ -1,0 +1,8 @@
+@props(['url'])
+<tr>
+<td class="header">
+<a href="{{ $url }}" style="display: inline-block;">
+<img src="{{ rtrim((string) config('app.url'), '/') }}/shoutrrr.png" class="logo" alt="{{ config('app.name', 'Shoutrrr') }} Logo">
+</a>
+</td>
+</tr>

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -1,0 +1,299 @@
+/* Base */
+
+body,
+body *:not(html):not(style):not(br):not(tr):not(code) {
+    box-sizing: border-box;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
+        'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    position: relative;
+}
+
+body {
+    -webkit-text-size-adjust: none;
+    background-color: #f5f8ee;
+    color: #52525b;
+    height: 100%;
+    line-height: 1.4;
+    margin: 0;
+    padding: 0;
+    width: 100% !important;
+}
+
+p,
+ul,
+ol,
+blockquote {
+    line-height: 1.4;
+    text-align: start;
+}
+
+a {
+    color: #3d6500;
+}
+
+a img {
+    border: none;
+}
+
+/* Typography */
+
+h1 {
+    color: #18181b;
+    font-size: 18px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: start;
+}
+
+h2 {
+    font-size: 16px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: start;
+}
+
+h3 {
+    font-size: 14px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: left;
+}
+
+p {
+    font-size: 16px;
+    line-height: 1.5em;
+    margin-top: 0;
+    text-align: left;
+}
+
+p.sub {
+    font-size: 12px;
+}
+
+img {
+    max-width: 100%;
+}
+
+/* Layout */
+
+.wrapper {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    background-color: #f5f8ee;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+.content {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+/* Header */
+
+.header {
+    padding: 25px 0;
+    text-align: center;
+}
+
+.header a {
+    color: #18181b;
+    font-size: 19px;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+/* Logo */
+
+.logo {
+    height: 82px;
+    margin-top: 15px;
+    margin-bottom: 10px;
+    max-height: 82px;
+    width: 82px;
+}
+
+/* Body */
+
+.body {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    background-color: #f5f8ee;
+    border-bottom: 1px solid #f5f8ee;
+    border-top: 1px solid #f5f8ee;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+.inner-body {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 570px;
+    background-color: #ffffff;
+    border-color: #dbe8c9;
+    border-radius: 12px;
+    border-width: 1px;
+    box-shadow: 0 8px 24px 0 rgba(61, 101, 0, 0.12);
+    margin: 0 auto;
+    padding: 0;
+    width: 570px;
+}
+
+.inner-body a {
+    word-break: break-all;
+}
+
+/* Subcopy */
+
+.subcopy {
+    border-top: 1px solid #dbe8c9;
+    margin-top: 25px;
+    padding-top: 25px;
+}
+
+.subcopy p {
+    font-size: 14px;
+}
+
+/* Footer */
+
+.footer {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 570px;
+    margin: 0 auto;
+    padding: 0;
+    text-align: center;
+    width: 570px;
+}
+
+.footer p {
+    color: #a1a1aa;
+    font-size: 12px;
+    text-align: center;
+}
+
+.footer a {
+    color: #a1a1aa;
+    text-decoration: underline;
+}
+
+/* Tables */
+
+.table table {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    margin: 30px auto;
+    width: 100%;
+}
+
+.table th {
+    border-bottom: 1px solid #e4e4e7;
+    margin: 0;
+    padding-bottom: 8px;
+}
+
+.table td {
+    color: #52525b;
+    font-size: 15px;
+    line-height: 18px;
+    margin: 0;
+    padding: 10px 0;
+}
+
+.content-cell {
+    max-width: 100vw;
+    padding: 32px;
+}
+
+/* Buttons */
+
+.action {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    margin: 30px auto;
+    padding: 0;
+    text-align: center;
+    width: 100%;
+    float: unset;
+}
+
+.button {
+    -webkit-text-size-adjust: none;
+    border-radius: 999px;
+    color: #111827;
+    display: inline-block;
+    font-weight: 700;
+    overflow: hidden;
+    text-decoration: none;
+}
+
+.button-blue,
+.button-primary {
+    background-color: #7dd000;
+    border-bottom: 10px solid #7dd000;
+    border-left: 22px solid #7dd000;
+    border-right: 22px solid #7dd000;
+    border-top: 10px solid #7dd000;
+}
+
+.button-green,
+.button-success {
+    background-color: #3d6500;
+    border-bottom: 10px solid #3d6500;
+    border-left: 22px solid #3d6500;
+    border-right: 22px solid #3d6500;
+    border-top: 10px solid #3d6500;
+    color: #ffffff;
+}
+
+.button-red,
+.button-error {
+    background-color: #dc2626;
+    border-bottom: 8px solid #dc2626;
+    border-left: 18px solid #dc2626;
+    border-right: 18px solid #dc2626;
+    border-top: 8px solid #dc2626;
+}
+
+/* Panels */
+
+.panel {
+    border-left: #18181b solid 4px;
+    margin: 21px 0;
+}
+
+.panel-content {
+    background-color: #fafafa;
+    color: #52525b;
+    padding: 16px;
+}
+
+.panel-content p {
+    color: #52525b;
+}
+
+.panel-item {
+    padding: 0;
+}
+
+.panel-item p:last-of-type {
+    margin-bottom: 0;
+    padding-bottom: 0;
+}
+
+/* Utilities */
+
+.break-all {
+    word-break: break-all;
+}

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -8,6 +8,8 @@ use Laravel\Fortify\Features;
 
 beforeEach(function () {
     $this->skipUnlessFortifyHas(Features::emailVerification());
+
+    config(['auth.email_verification.enabled' => true]);
 });
 
 test('email verification screen can be rendered', function () {
@@ -98,4 +100,16 @@ test('already verified user visiting verification link is redirected without fir
 
     Event::assertNotDispatched(Verified::class);
     $this->assertTrue($user->fresh()->hasVerifiedEmail());
+});
+
+test('unverified users are treated as verified when mail delivery verification is disabled', function () {
+    config(['auth.email_verification.enabled' => false]);
+
+    $user = User::factory()->unverified()->create();
+
+    expect($user->hasVerifiedEmail())->toBeTrue();
+
+    $response = $this->actingAs($user)->get(route('dashboard'));
+
+    $response->assertOk();
 });

--- a/tests/Feature/Auth/VerificationNotificationTest.php
+++ b/tests/Feature/Auth/VerificationNotificationTest.php
@@ -7,6 +7,8 @@ use Laravel\Fortify\Features;
 
 beforeEach(function () {
     $this->skipUnlessFortifyHas(Features::emailVerification());
+
+    config(['auth.email_verification.enabled' => true]);
 });
 
 test('sends verification notification', function () {
@@ -25,6 +27,19 @@ test('does not send verification notification if email is verified', function ()
     Notification::fake();
 
     $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('verification.send'))
+        ->assertRedirect(route('dashboard', absolute: false));
+
+    Notification::assertNothingSent();
+});
+
+test('does not send verification notification when mail delivery verification is disabled', function () {
+    Notification::fake();
+    config(['auth.email_verification.enabled' => false]);
+
+    $user = User::factory()->unverified()->create();
 
     $this->actingAs($user)
         ->post(route('verification.send'))

--- a/tests/Feature/MailBrandingTest.php
+++ b/tests/Feature/MailBrandingTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\VerifyEmail;
+
+test('markdown notification emails use the Shoutrrr brand', function () {
+    config([
+        'app.name' => 'Shoutrrr',
+        'app.url' => 'https://shoutrrr.test',
+    ]);
+
+    $user = User::factory()->unverified()->create();
+
+    $html = (string) (new VerifyEmail)->toMail($user)->render();
+
+    expect($html)->toContain('https://shoutrrr.test/shoutrrr.png');
+    expect($html)->toContain('alt="Shoutrrr Logo"');
+    expect($html)->toContain('#7dd000');
+    expect($html)->not->toContain('laravel.com/img/notification-logo');
+    expect($html)->not->toContain('Laravel Logo');
+});

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -13,6 +13,8 @@ test('profile page is displayed', function () {
 });
 
 test('profile information can be updated', function () {
+    config(['auth.email_verification.enabled' => true]);
+
     $user = User::factory()->create();
 
     $response = $this
@@ -34,6 +36,8 @@ test('profile information can be updated', function () {
 });
 
 test('email verification status is unchanged when the email address is unchanged', function () {
+    config(['auth.email_verification.enabled' => true]);
+
     $user = User::factory()->create();
 
     $response = $this
@@ -44,6 +48,23 @@ test('email verification status is unchanged when the email address is unchanged
         ]);
 
     $response
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('profile.edit'));
+
+    $this->assertNotNull($user->refresh()->email_verified_at);
+});
+
+test('email verification status is unchanged when mail delivery verification is disabled', function () {
+    config(['auth.email_verification.enabled' => false]);
+
+    $user = User::factory()->create();
+
+    $this
+        ->actingAs($user)
+        ->patch(route('profile.update'), [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+        ])
         ->assertSessionHasNoErrors()
         ->assertRedirect(route('profile.edit'));
 


### PR DESCRIPTION
## Summary
- Enable `MustVerifyEmail` for users while treating accounts as verified when mail delivery verification is disabled.
- Reset email verification on profile email changes only when verification is enabled.
- Add Shoutrrr-branded Markdown mail header/theme and default app name/url values.
- Cover enabled/disabled verification behavior and branded verification emails with feature tests.