### PR TITLE
feat(instance): self-hosted instance settings and stuffs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ APP_URL=http://127.0.0.1:8000
 # Disable social login unless OAuth credentials are configured.
 SOCIALITE_ENABLED=false
 
+# Set true for self-hosted deployments. Future billing/subscription gates may use this.
+SELF_HOSTED=false
+
 # ----------------------------------------------------------------------
 # Optional production / deployment overrides
 # ----------------------------------------------------------------------

--- a/.env.example.prod
+++ b/.env.example.prod
@@ -6,6 +6,9 @@ SESSION_SECURE_COOKIE=true
 # Disable social login unless OAuth credentials are configured.
 SOCIALITE_ENABLED=false
 
+# Set true for self-hosted deployments. Future billing/subscription gates may use this.
+SELF_HOSTED=false
+
 # ----------------------------------------------------------------------
 # Optional production / deployment overrides
 # ----------------------------------------------------------------------

--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -6,21 +6,32 @@ use App\Concerns\PasswordValidationRules;
 use App\Concerns\ProfileValidationRules;
 use App\Models\User;
 use App\Services\Workspace\WorkspaceProvisioningService;
+use App\Settings\InstanceSettings;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 
 class CreateNewUser implements CreatesNewUsers
 {
     use PasswordValidationRules, ProfileValidationRules;
 
-    public function __construct(private WorkspaceProvisioningService $provisioning) {}
+    public function __construct(
+        private WorkspaceProvisioningService $provisioning,
+        private InstanceSettings $settings,
+    ) {}
 
     /**
      * @param  array<string, string>  $input
      */
     public function create(array $input): User
     {
+        if (! $this->settings->registrationsAllowed(request()->input('invitation'))) {
+            throw ValidationException::withMessages([
+                'email' => 'Registration is disabled for this instance.',
+            ]);
+        }
+
         Validator::make($input, [
             ...$this->profileRules(),
             'password' => $this->passwordRules(),
@@ -33,6 +44,7 @@ class CreateNewUser implements CreatesNewUsers
                 'password' => $input['password'],
             ]);
 
+            $this->settings->claimOwnerIfMissing($user);
             $this->provisioning->provisionForNewUser($user, request()->input('invitation'));
 
             return $user->refresh();

--- a/app/Enums/InstanceRole.php
+++ b/app/Enums/InstanceRole.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum InstanceRole: string
+{
+    case Owner = 'owner';
+}

--- a/app/Exceptions/SocialAuthException.php
+++ b/app/Exceptions/SocialAuthException.php
@@ -40,4 +40,9 @@ final class SocialAuthException extends Exception
             "We could not complete your {$providerLabel} sign-in. Please try again.",
         );
     }
+
+    public static function registrationsDisabled(): self
+    {
+        return new self('Registration is disabled for this instance.');
+    }
 }

--- a/app/Http/Controllers/Settings/InstanceSettingsController.php
+++ b/app/Http/Controllers/Settings/InstanceSettingsController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\UpdateInstanceSettingsRequest;
+use App\Models\User;
+use App\Settings\InstanceSettings;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class InstanceSettingsController extends Controller
+{
+    public function edit(Request $request, InstanceSettings $settings): Response
+    {
+        /** @var User|null $user */
+        $user = $request->user();
+        abort_unless($user?->isInstanceOwner(), 403);
+
+        $workspacesEnabled = (bool) config('kit.workspaces.enabled');
+        $instanceSettings = $settings->all();
+
+        if (! $workspacesEnabled) {
+            $instanceSettings['workspace_creation_enabled'] = false;
+        }
+
+        return Inertia::render('settings/instance', [
+            'settings' => $instanceSettings,
+            'workspaces_enabled' => $workspacesEnabled,
+        ]);
+    }
+
+    public function update(UpdateInstanceSettingsRequest $request, InstanceSettings $settings): RedirectResponse
+    {
+        $settings->update($request->instanceSettings());
+
+        return back()->with('success', 'Instance settings updated.');
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -8,6 +8,7 @@ use App\Models\AccountSet;
 use App\Models\ConnectedAccount;
 use App\Models\User;
 use App\Models\WorkspaceMembership;
+use App\Settings\InstanceSettings;
 use App\Support\Notifications\NotificationPresenter;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
@@ -65,6 +66,9 @@ class HandleInertiaRequests extends Middleware
             'notifications' => $this->notificationsData($request->user()),
             'features' => [
                 'analytics' => (bool) config('metrics.enabled'),
+            ],
+            'instance' => [
+                'isOwner' => $request->user()?->isInstanceOwner() ?? false,
             ],
         ];
     }
@@ -125,13 +129,14 @@ class HandleInertiaRequests extends Middleware
     private function workspacesData(?User $user): array
     {
         $enabled = (bool) config('kit.workspaces.enabled');
+        $canCreate = $enabled && app(InstanceSettings::class)->workspaceCreationEnabled();
 
         if (! $user) {
             return [
                 'enabled' => $enabled,
                 'all' => [],
                 'current' => null,
-                'canCreateWorkspaces' => (bool) config('kit.workspaces.can_create_workspaces'),
+                'canCreateWorkspaces' => $canCreate,
             ];
         }
 
@@ -164,7 +169,7 @@ class HandleInertiaRequests extends Middleware
             'enabled' => $enabled,
             'all' => $all,
             'current' => $current,
-            'canCreateWorkspaces' => (bool) config('kit.workspaces.can_create_workspaces'),
+            'canCreateWorkspaces' => $canCreate,
         ];
     }
 

--- a/app/Http/Requests/Settings/UpdateInstanceSettingsRequest.php
+++ b/app/Http/Requests/Settings/UpdateInstanceSettingsRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use App\Models\User;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateInstanceSettingsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        /** @var User|null $user */
+        $user = $this->user();
+
+        return $user?->isInstanceOwner() ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'registrations_enabled' => ['required', 'boolean'],
+            'workspace_creation_enabled' => ['required', 'boolean'],
+        ];
+    }
+
+    /**
+     * @return array{registrations_enabled: bool, workspace_creation_enabled: bool}
+     */
+    public function instanceSettings(): array
+    {
+        /** @var array{registrations_enabled: bool, workspace_creation_enabled: bool} $settings */
+        $settings = $this->validated();
+
+        if (! (bool) config('kit.workspaces.enabled')) {
+            $settings['workspace_creation_enabled'] = false;
+        }
+
+        return $settings;
+    }
+}

--- a/app/Http/Requests/Workspace/StoreWorkspaceRequest.php
+++ b/app/Http/Requests/Workspace/StoreWorkspaceRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Workspace;
 
+use App\Settings\InstanceSettings;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreWorkspaceRequest extends FormRequest
@@ -11,7 +12,7 @@ class StoreWorkspaceRequest extends FormRequest
     public function authorize(): bool
     {
         return (bool) config('kit.workspaces.enabled')
-            && (bool) config('kit.workspaces.can_create_workspaces');
+            && app(InstanceSettings::class)->workspaceCreationEnabled();
     }
 
     /**

--- a/app/Models/InstanceSetting.php
+++ b/app/Models/InstanceSetting.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property string $key
+ * @property mixed $value
+ */
+#[Fillable(['key', 'value'])]
+class InstanceSetting extends Model
+{
+    public $incrementing = false;
+
+    protected $primaryKey = 'key';
+
+    protected $keyType = 'string';
+
+    /**
+     * @return array<string, string>
+     */
+    #[\Override]
+    protected function casts(): array
+    {
+        return [
+            'value' => 'json',
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Casts\NotificationPreferencesCast;
+use App\Enums\InstanceRole;
 use App\Enums\SocialProvider;
 use App\Support\Notifications\NotificationPreferences;
 use Database\Factories\UserFactory;
@@ -33,11 +34,12 @@ use Override;
  * @property string|null $two_factor_recovery_codes
  * @property Carbon|null $two_factor_confirmed_at
  * @property string|null $remember_token
+ * @property InstanceRole|null $instance_role
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property NotificationPreferences|null $notification_preferences
  */
-#[Fillable(['name', 'email', 'password', 'current_workspace_id', 'notification_preferences'])]
+#[Fillable(['name', 'email', 'password', 'current_workspace_id', 'notification_preferences', 'instance_role'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
 class User extends Authenticatable implements MustVerifyEmail, OAuthenticatable, PasskeyUser
 {
@@ -57,6 +59,7 @@ class User extends Authenticatable implements MustVerifyEmail, OAuthenticatable,
             'password' => 'hashed',
             'two_factor_confirmed_at' => 'datetime',
             'notification_preferences' => NotificationPreferencesCast::class,
+            'instance_role' => InstanceRole::class,
         ];
     }
 
@@ -137,6 +140,11 @@ class User extends Authenticatable implements MustVerifyEmail, OAuthenticatable,
     public function isOwnerOfWorkspace(?string $workspaceId): bool
     {
         return $this->getMembershipForWorkspace($workspaceId)?->isOwner() ?? false;
+    }
+
+    public function isInstanceOwner(): bool
+    {
+        return $this->instance_role === InstanceRole::Owner;
     }
 
     /**

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Actions\Fortify\CreateNewUser;
 use App\Actions\Fortify\ResetUserPassword;
 use App\Enums\SocialProvider;
+use App\Settings\InstanceSettings;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
@@ -51,13 +52,20 @@ class FortifyServiceProvider extends ServiceProvider
      */
     private function configureViews(): void
     {
-        Fortify::loginView(fn (Request $request) => Inertia::render('auth/login', [
-            'canResetPassword' => Features::enabled(Features::resetPasswords()),
-            'status' => $request->session()->get('status'),
-            'providers' => SocialProvider::enabledProvidersWithLabels(),
-            'invitation' => $request->query('invitation'),
-            ...$this->defaultLoginCredentials(),
-        ]));
+        Fortify::loginView(function (Request $request) {
+            $settings = app(InstanceSettings::class);
+            $canRegister = $settings->registrationsAllowed($request->query('invitation'));
+
+            return Inertia::render('auth/login', [
+                'canResetPassword' => Features::enabled(Features::resetPasswords()),
+                'canRegister' => $canRegister,
+                'registrationDisabledMessage' => $canRegister ? null : 'Registration is disabled for this instance.',
+                'status' => $request->session()->get('status'),
+                'providers' => SocialProvider::enabledProvidersWithLabels(),
+                'invitation' => $request->query('invitation'),
+                ...$this->defaultLoginCredentials(),
+            ]);
+        });
 
         Fortify::resetPasswordView(fn (Request $request) => Inertia::render('auth/reset-password', [
             'email' => $request->email,
@@ -73,11 +81,17 @@ class FortifyServiceProvider extends ServiceProvider
             'status' => $request->session()->get('status'),
         ]));
 
-        Fortify::registerView(fn (Request $request) => Inertia::render('auth/register', [
-            'passwordRules' => Password::defaults()->toPasswordRulesString(),
-            'providers' => SocialProvider::enabledProvidersWithLabels(),
-            'invitation' => $request->query('invitation'),
-        ]));
+        Fortify::registerView(function (Request $request) {
+            if (! app(InstanceSettings::class)->registrationsAllowed($request->query('invitation'))) {
+                return redirect()->route('login');
+            }
+
+            return Inertia::render('auth/register', [
+                'passwordRules' => Password::defaults()->toPasswordRulesString(),
+                'providers' => SocialProvider::enabledProvidersWithLabels(),
+                'invitation' => $request->query('invitation'),
+            ]);
+        });
 
         Fortify::twoFactorChallengeView(fn () => Inertia::render('auth/two-factor-challenge'));
 

--- a/app/Services/Auth/SocialiteService.php
+++ b/app/Services/Auth/SocialiteService.php
@@ -9,6 +9,7 @@ use App\Exceptions\SocialAuthException;
 use App\Models\SocialAccount;
 use App\Models\User;
 use App\Services\Workspace\WorkspaceProvisioningService;
+use App\Settings\InstanceSettings;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -16,7 +17,10 @@ use Laravel\Socialite\Contracts\User as SocialiteUser;
 
 class SocialiteService
 {
-    public function __construct(private readonly WorkspaceProvisioningService $provisioning) {}
+    public function __construct(
+        private readonly WorkspaceProvisioningService $provisioning,
+        private readonly InstanceSettings $settings,
+    ) {}
 
     /**
      * Guest path: log in an existing identity, link-and-login an existing
@@ -63,6 +67,10 @@ class SocialiteService
             return new SocialiteResult($byEmail, wasRegistered: false);
         }
 
+        if (! $this->settings->registrationsAllowed($invitationToken)) {
+            throw SocialAuthException::registrationsDisabled();
+        }
+
         try {
             $user = DB::transaction(function () use ($provider, $oauthUser, $email, $invitationToken): User {
                 $user = User::create([
@@ -76,6 +84,7 @@ class SocialiteService
                 }
 
                 $this->linkAccount($user, $provider, $oauthUser);
+                $this->settings->claimOwnerIfMissing($user);
                 $this->provisioning->provisionForNewUser($user, $invitationToken);
 
                 return $user;

--- a/app/Settings/InstanceSettings.php
+++ b/app/Settings/InstanceSettings.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Settings;
+
+use App\Enums\InstanceRole;
+use App\Models\InstanceSetting;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+
+class InstanceSettings
+{
+    private const string CacheKey = 'instance_settings';
+
+    public function registrationsEnabled(): bool
+    {
+        return $this->boolean('registrations_enabled');
+    }
+
+    public function workspaceCreationEnabled(): bool
+    {
+        return $this->boolean('workspace_creation_enabled');
+    }
+
+    public function registrationsAllowed(?string $invitationToken = null): bool
+    {
+        if (! $this->ownerExists()) {
+            return true;
+        }
+
+        if ($invitationToken !== null && $invitationToken !== '') {
+            return true;
+        }
+
+        return $this->registrationsEnabled();
+    }
+
+    public function ownerExists(): bool
+    {
+        return User::query()->where('instance_role', InstanceRole::Owner->value)->exists();
+    }
+
+    public function claimOwnerIfMissing(User $user): void
+    {
+        if ($this->ownerExists()) {
+            return;
+        }
+
+        $user->forceFill(['instance_role' => InstanceRole::Owner])->save();
+    }
+
+    /**
+     * @return array{registrations_enabled: bool, workspace_creation_enabled: bool}
+     */
+    public function all(): array
+    {
+        return [
+            'registrations_enabled' => $this->registrationsEnabled(),
+            'workspace_creation_enabled' => $this->workspaceCreationEnabled(),
+        ];
+    }
+
+    /**
+     * @param  array{registrations_enabled?: bool, workspace_creation_enabled?: bool}  $values
+     */
+    public function update(array $values): void
+    {
+        foreach ($values as $key => $value) {
+            InstanceSetting::query()->updateOrCreate(
+                ['key' => $key],
+                ['value' => $value],
+            );
+        }
+
+        Cache::forget(self::CacheKey);
+    }
+
+    private function boolean(string $key): bool
+    {
+        /** @var array<string, mixed> $settings */
+        $settings = Cache::rememberForever(self::CacheKey, fn (): array => InstanceSetting::query()
+            ->get()
+            ->mapWithKeys(fn (InstanceSetting $setting): array => [$setting->key => $setting->value])
+            ->all());
+
+        return (bool) ($settings[$key] ?? config("instance.defaults.{$key}"));
+    }
+}

--- a/config/instance.php
+++ b/config/instance.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'self_hosted' => env('SELF_HOSTED', false),
+
+    'defaults' => [
+        'registrations_enabled' => env('INSTANCE_REGISTRATIONS_ENABLED', false),
+        'workspace_creation_enabled' => env(
+            'INSTANCE_WORKSPACE_CREATION_ENABLED',
+            env('WORKSPACES_CAN_CREATE_WORKSPACE', true),
+        ),
+    ],
+];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\InstanceRole;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
@@ -55,6 +56,13 @@ class UserFactory extends Factory
             'two_factor_secret' => encrypt('secret'),
             'two_factor_recovery_codes' => encrypt(json_encode(['recovery-code-1'])),
             'two_factor_confirmed_at' => now(),
+        ]);
+    }
+
+    public function instanceOwner(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'instance_role' => InstanceRole::Owner,
         ]);
     }
 }

--- a/database/migrations/2026_06_23_110055_add_instance_role_to_users_table.php
+++ b/database/migrations/2026_06_23_110055_add_instance_role_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('instance_role')->nullable()->index()->after('current_workspace_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['instance_role']);
+            $table->dropColumn('instance_role');
+        });
+    }
+};

--- a/database/migrations/2026_06_23_110055_create_instance_settings_table.php
+++ b/database/migrations/2026_06_23_110055_create_instance_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('instance_settings', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->json('value');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('instance_settings');
+    }
+};

--- a/database/seeders/DefaultUserSeeder.php
+++ b/database/seeders/DefaultUserSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Enums\InstanceRole;
 use App\Enums\WorkspaceRole;
 use App\Models\User;
 use App\Models\Workspace;
@@ -21,8 +22,13 @@ class DefaultUserSeeder extends Seeder
                 'name' => 'Test User',
                 'password' => 'password',
                 'email_verified_at' => now(),
+                'instance_role' => InstanceRole::Owner,
             ],
         );
+
+        if (! $user->isInstanceOwner()) {
+            $user->forceFill(['instance_role' => InstanceRole::Owner])->save();
+        }
 
         $workspace = Workspace::query()->firstOrCreate(
             ['slug' => 'test-workspace'],

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -20,6 +20,8 @@ void createInertiaApp({
                 return null;
             case name.startsWith('auth/'):
                 return AuthLayout;
+            case name === 'settings/instance':
+                return [AppLayout, WorkspaceSettingsLayout];
             case name.startsWith('settings/workspace'):
                 return [AppLayout, WorkspaceSettingsLayout];
             case name.startsWith('settings/'):

--- a/resources/js/components/layout/__tests__/app-sidebar.test.ts
+++ b/resources/js/components/layout/__tests__/app-sidebar.test.ts
@@ -3,11 +3,15 @@ import { resolve } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { workspaceSettingsLabel } from '../app-sidebar';
+import { instanceSettingsLabel, workspaceSettingsLabel } from '../app-sidebar';
 
 describe('workspaceSettingsLabel', () => {
     it('identifies the sidebar destination as workspace settings', () => {
         expect(workspaceSettingsLabel).toBe('Workspace settings');
+    });
+
+    it('identifies the owner-only instance settings destination', () => {
+        expect(instanceSettingsLabel).toBe('Instance settings');
     });
 });
 

--- a/resources/js/components/layout/app-sidebar.tsx
+++ b/resources/js/components/layout/app-sidebar.tsx
@@ -7,11 +7,13 @@ import {
     Pencil,
     Settings,
     Share2,
+    Wrench,
     type LucideIcon,
 } from 'lucide-react';
 import { useEffect } from 'react';
 
 import PostingScheduleController from '@/actions/App/Http/Controllers/Posts/PostingScheduleController';
+import InstanceSettingsController from '@/actions/App/Http/Controllers/Settings/InstanceSettingsController';
 import WorkspaceSettingsController from '@/actions/App/Http/Controllers/Settings/WorkspaceSettingsController';
 import AppLogo from '@/components/layout/app-logo';
 import { NavUser } from '@/components/layout/nav-user';
@@ -48,6 +50,7 @@ type NavItem = {
 };
 
 export const workspaceSettingsLabel = 'Workspace settings';
+export const instanceSettingsLabel = 'Instance settings';
 
 const postsNavItems: NavItem[] = [
     { title: 'Posts', href: postsRoute(), icon: Inbox },
@@ -61,8 +64,8 @@ const postsNavItems: NavItem[] = [
 ];
 
 export function AppSidebar() {
-    const { workspaces, features } = usePage().props;
-    const { isCurrentUrl } = useCurrentUrl();
+    const { workspaces, features, instance } = usePage().props;
+    const { isCurrentOrParentUrl, isCurrentUrl } = useCurrentUrl();
     const { state, setOpenMobile } = useSidebar();
     const collapsed = state === 'collapsed';
 
@@ -205,7 +208,7 @@ export function AppSidebar() {
                                     <SidebarMenuButton
                                         asChild
                                         tooltip={workspaceSettingsLabel}
-                                        isActive={isCurrentUrl(
+                                        isActive={isCurrentOrParentUrl(
                                             WorkspaceSettingsController.showOverview(),
                                         )}
                                     >
@@ -221,6 +224,28 @@ export function AppSidebar() {
                                         </Link>
                                     </SidebarMenuButton>
                                 </SidebarMenuItem>
+                                {instance.isOwner && (
+                                    <SidebarMenuItem>
+                                        <SidebarMenuButton
+                                            asChild
+                                            tooltip={instanceSettingsLabel}
+                                            isActive={isCurrentUrl(
+                                                InstanceSettingsController.edit(),
+                                            )}
+                                        >
+                                            <Link
+                                                href={InstanceSettingsController.edit()}
+                                                prefetch={['mount', 'hover']}
+                                                cacheFor={['30s', '1m']}
+                                            >
+                                                <Wrench aria-hidden="true" />
+                                                <span>
+                                                    {instanceSettingsLabel}
+                                                </span>
+                                            </Link>
+                                        </SidebarMenuButton>
+                                    </SidebarMenuItem>
+                                )}
                             </SidebarMenu>
                         </SidebarGroupContent>
                     </SidebarGroup>

--- a/resources/js/components/layout/command-palette.tsx
+++ b/resources/js/components/layout/command-palette.tsx
@@ -10,10 +10,12 @@ import {
     Plug,
     Settings,
     Share2,
+    Wrench,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import PostingScheduleController from '@/actions/App/Http/Controllers/Posts/PostingScheduleController';
+import InstanceSettingsController from '@/actions/App/Http/Controllers/Settings/InstanceSettingsController';
 import WorkspaceSettingsController from '@/actions/App/Http/Controllers/Settings/WorkspaceSettingsController';
 import {
     Command,
@@ -59,7 +61,7 @@ export function openCommandPalette() {
 }
 
 export function CommandPalette() {
-    const { workspaces, shell } = usePage().props;
+    const { instance, workspaces, shell } = usePage().props;
     const [open, setOpen] = useState(false);
     const [query, setQuery] = useState('');
     const [recents, setRecents] = useState<RecentItem[]>([]);
@@ -302,6 +304,23 @@ export function CommandPalette() {
                                             aria-hidden
                                         />
                                         Workspace settings
+                                    </CommandItem>
+                                )}
+                                {showSettings && instance.isOwner && (
+                                    <CommandItem
+                                        value="instance settings"
+                                        onSelect={run(() =>
+                                            router.visit(
+                                                InstanceSettingsController.edit()
+                                                    .url,
+                                            ),
+                                        )}
+                                    >
+                                        <Wrench
+                                            className="size-4"
+                                            aria-hidden
+                                        />
+                                        Instance settings
                                     </CommandItem>
                                 )}
                             </CommandGroup>

--- a/resources/js/layouts/settings/workspace-layout.tsx
+++ b/resources/js/layouts/settings/workspace-layout.tsx
@@ -1,6 +1,7 @@
 import { Link, usePage } from '@inertiajs/react';
 import type { PropsWithChildren } from 'react';
 
+import InstanceSettingsController from '@/actions/App/Http/Controllers/Settings/InstanceSettingsController';
 import WorkspaceSettingsController from '@/actions/App/Http/Controllers/Settings/WorkspaceSettingsController';
 import Heading from '@/components/common/heading';
 import { Button } from '@/components/ui/button';
@@ -9,24 +10,33 @@ import { useCurrentUrl } from '@/hooks/use-current-url';
 import { cn, toUrl } from '@/lib/utils';
 import type { NavItem } from '@/types';
 
-const sidebarNavItems: NavItem[] = [
-    {
-        title: 'Overview',
-        href: WorkspaceSettingsController.showOverview(),
-        icon: null,
-    },
-    {
-        title: 'Members',
-        href: WorkspaceSettingsController.showMembers(),
-        icon: null,
-    },
-];
-
 export default function WorkspaceSettingsLayout({
     children,
 }: PropsWithChildren) {
-    const { isCurrentUrl } = useCurrentUrl();
-    const { workspaces } = usePage().props;
+    const { isCurrentOrParentUrl, isCurrentUrl } = useCurrentUrl();
+    const { instance, workspaces } = usePage().props;
+
+    const sidebarNavItems: NavItem[] = [
+        {
+            title: 'Overview',
+            href: WorkspaceSettingsController.showOverview(),
+            icon: null,
+        },
+        {
+            title: 'Members',
+            href: WorkspaceSettingsController.showMembers(),
+            icon: null,
+        },
+        ...(instance.isOwner
+            ? [
+                  {
+                      title: 'Instance',
+                      href: InstanceSettingsController.edit(),
+                      icon: null,
+                  },
+              ]
+            : []),
+    ];
 
     return (
         <div className="mx-auto w-full max-w-6xl px-4 pt-6 pb-16 sm:px-6">
@@ -52,7 +62,10 @@ export default function WorkspaceSettingsLayout({
                                 variant="ghost"
                                 asChild
                                 className={cn('w-full justify-start', {
-                                    'bg-muted': isCurrentUrl(item.href),
+                                    'bg-muted':
+                                        item.title === 'Overview'
+                                            ? isCurrentUrl(item.href)
+                                            : isCurrentOrParentUrl(item.href),
                                 })}
                             >
                                 <Link href={item.href}>

--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -19,6 +19,8 @@ import type { SocialProviderOption } from '@/types/auth';
 type Props = {
     status?: string;
     canResetPassword: boolean;
+    canRegister?: boolean;
+    registrationDisabledMessage?: string | null;
     providers?: SocialProviderOption[];
     invitation?: string;
     defaultLogin?: {
@@ -30,6 +32,8 @@ type Props = {
 export default function Login({
     status,
     canResetPassword,
+    canRegister = true,
+    registrationDisabledMessage,
     providers = [],
     invitation,
     defaultLogin,
@@ -124,12 +128,18 @@ export default function Login({
                             </Button>
                         </div>
 
-                        <div className="text-center text-sm text-muted-foreground">
-                            Don't have an account?{' '}
-                            <TextLink href={register()} tabIndex={5}>
-                                Sign up
-                            </TextLink>
-                        </div>
+                        {canRegister ? (
+                            <div className="text-center text-sm text-muted-foreground">
+                                Don't have an account?{' '}
+                                <TextLink href={register()} tabIndex={5}>
+                                    Sign up
+                                </TextLink>
+                            </div>
+                        ) : (
+                            <div className="text-center text-sm text-muted-foreground">
+                                {registrationDisabledMessage}
+                            </div>
+                        )}
                     </>
                 )}
             </Form>

--- a/resources/js/pages/settings/instance.tsx
+++ b/resources/js/pages/settings/instance.tsx
@@ -1,0 +1,116 @@
+import { Head, useForm } from '@inertiajs/react';
+
+import InstanceSettingsController from '@/actions/App/Http/Controllers/Settings/InstanceSettingsController';
+import Heading from '@/components/common/heading';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+
+type InstanceSettings = {
+    registrations_enabled: boolean;
+    workspace_creation_enabled: boolean;
+};
+
+type PageProps = {
+    settings: InstanceSettings;
+    workspaces_enabled: boolean;
+};
+
+export default function Instance({ settings, workspaces_enabled }: PageProps) {
+    const { data, setData, put, processing } = useForm<InstanceSettings>({
+        registrations_enabled: settings.registrations_enabled,
+        workspace_creation_enabled:
+            workspaces_enabled && settings.workspace_creation_enabled,
+    });
+
+    function handleSubmit(event: React.FormEvent) {
+        event.preventDefault();
+
+        put(InstanceSettingsController.update().url, {
+            preserveScroll: true,
+        });
+    }
+
+    return (
+        <>
+            <Head title="Instance settings" />
+
+            <h1 className="sr-only">Instance settings</h1>
+
+            <div className="space-y-6">
+                <Heading
+                    variant="small"
+                    title="Instance"
+                    description="Manage settings that affect every user on this self-hosted instance"
+                />
+
+                <form onSubmit={handleSubmit} className="space-y-6">
+                    <div className="space-y-4">
+                        <div className="flex items-start gap-3">
+                            <Checkbox
+                                id="registrations_enabled"
+                                checked={data.registrations_enabled}
+                                onCheckedChange={(checked) =>
+                                    setData(
+                                        'registrations_enabled',
+                                        checked === true,
+                                    )
+                                }
+                            />
+                            <div className="space-y-1">
+                                <Label htmlFor="registrations_enabled">
+                                    Allow public registration
+                                </Label>
+                                <p className="text-sm text-muted-foreground">
+                                    When disabled, new users can only join with
+                                    a workspace invitation.
+                                </p>
+                            </div>
+                        </div>
+
+                        <div className="flex items-start gap-3">
+                            <Checkbox
+                                id="workspace_creation_enabled"
+                                checked={data.workspace_creation_enabled}
+                                disabled={!workspaces_enabled}
+                                onCheckedChange={(checked) =>
+                                    setData(
+                                        'workspace_creation_enabled',
+                                        checked === true,
+                                    )
+                                }
+                            />
+                            <div className="space-y-1">
+                                <Label htmlFor="workspace_creation_enabled">
+                                    Allow users to create workspaces
+                                </Label>
+                                <p className="text-sm text-muted-foreground">
+                                    {workspaces_enabled
+                                        ? 'When disabled, users can still access workspaces they already belong to.'
+                                        : 'Workspace creation is unavailable because workspaces are disabled by the WORKSPACES_ENABLED environment setting.'}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <Button type="submit" disabled={processing}>
+                        Save
+                    </Button>
+                </form>
+            </div>
+        </>
+    );
+}
+
+Instance.layout = {
+    breadcrumbs: [
+        {
+            title: 'Workspace settings',
+            href: '/settings/workspace',
+        },
+        {
+            title: 'Instance',
+            href: InstanceSettingsController.edit().url,
+        },
+    ],
+};

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -26,6 +26,7 @@ declare module '@inertiajs/core' {
             };
             notifications: NotificationsData;
             features?: { analytics: boolean };
+            instance: { isOwner: boolean };
             [key: string]: unknown;
         };
     }

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Settings\ConnectionsController;
+use App\Http\Controllers\Settings\InstanceSettingsController;
 use App\Http\Controllers\Settings\NotificationPreferencesController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\SecurityController;
@@ -28,6 +29,9 @@ Route::middleware(['auth'])->group(function () {
 
     Route::get('settings/notifications', [NotificationPreferencesController::class, 'edit'])->name('notifications.preferences');
     Route::put('settings/notifications', [NotificationPreferencesController::class, 'update'])->name('notifications.preferences.update');
+
+    Route::get('settings/instance', [InstanceSettingsController::class, 'edit'])->name('instance-settings.edit');
+    Route::put('settings/instance', [InstanceSettingsController::class, 'update'])->name('instance-settings.update');
 });
 
 Route::middleware(['auth', 'verified'])->group(function () {

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Models\User;
+use App\Settings\InstanceSettings;
+use Inertia\Testing\AssertableInertia as Assert;
 use Laravel\Fortify\Features;
 
 beforeEach(function () {
@@ -22,4 +25,76 @@ test('new users can register', function () {
 
     $this->assertAuthenticated();
     $response->assertRedirect(route('dashboard', absolute: false));
+});
+
+test('first registered user becomes the instance owner', function () {
+    $this->post(route('register.store'), [
+        'name' => 'Instance Owner',
+        'email' => 'owner@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ]);
+
+    expect(auth()->user()->isInstanceOwner())->toBeTrue();
+});
+
+test('public registration is disabled by default after the first user registers', function () {
+    $this->post(route('register.store'), [
+        'name' => 'Instance Owner',
+        'email' => 'owner@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ]);
+
+    auth()->logout();
+
+    $this->post(route('register.store'), [
+        'name' => 'Blocked User',
+        'email' => 'blocked@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertSessionHasErrors('email');
+
+    expect(User::where('email', 'blocked@example.com')->exists())->toBeFalse();
+});
+
+test('registration can be disabled after the instance owner exists', function () {
+    User::factory()->instanceOwner()->create();
+
+    app(InstanceSettings::class)->update([
+        'registrations_enabled' => false,
+    ]);
+
+    $this->post(route('register.store'), [
+        'name' => 'Blocked User',
+        'email' => 'blocked@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertSessionHasErrors('email');
+});
+
+test('registration screen redirects to login when public registration is disabled', function () {
+    User::factory()->instanceOwner()->create();
+
+    app(InstanceSettings::class)->update([
+        'registrations_enabled' => false,
+    ]);
+
+    $this->get(route('register'))
+        ->assertRedirect(route('login', absolute: false))
+        ->assertSessionMissing('status');
+});
+
+test('login screen knows public registration is disabled', function () {
+    User::factory()->instanceOwner()->create();
+
+    app(InstanceSettings::class)->update([
+        'registrations_enabled' => false,
+    ]);
+
+    $this->get(route('login'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('auth/login')
+            ->where('canRegister', false)
+            ->where('registrationDisabledMessage', 'Registration is disabled for this instance.'));
 });

--- a/tests/Feature/DefaultDevelopmentUserTest.php
+++ b/tests/Feature/DefaultDevelopmentUserTest.php
@@ -14,6 +14,7 @@ it('seeds the default user with a current workspace in development', function ()
     $user = User::query()->where('email', 'test@example.com')->firstOrFail();
 
     expect($user->name)->toBe('Test User')
+        ->and($user->isInstanceOwner())->toBeTrue()
         ->and($user->current_workspace_id)->not->toBeNull()
         ->and(Workspace::query()->whereKey($user->current_workspace_id)->exists())->toBeTrue()
         ->and(WorkspaceMembership::query()

--- a/tests/Feature/InstanceConfigTest.php
+++ b/tests/Feature/InstanceConfigTest.php
@@ -1,0 +1,5 @@
+<?php
+
+test('instance self hosted mode is disabled by default', function () {
+    expect(config('instance.self_hosted'))->toBeFalse();
+});

--- a/tests/Feature/InstanceSettingsTest.php
+++ b/tests/Feature/InstanceSettingsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Models\User;
+use App\Settings\InstanceSettings;
+use Inertia\Testing\AssertableInertia;
+
+test('instance owner can view instance settings', function () {
+    $owner = User::factory()->instanceOwner()->create();
+
+    $this->actingAs($owner)
+        ->get(route('instance-settings.edit'))
+        ->assertOk();
+});
+
+test('regular users cannot view instance settings', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('instance-settings.edit'))
+        ->assertForbidden();
+});
+
+test('instance owner can update instance settings', function () {
+    $owner = User::factory()->instanceOwner()->create();
+
+    $this->actingAs($owner)
+        ->put(route('instance-settings.update'), [
+            'registrations_enabled' => false,
+            'workspace_creation_enabled' => false,
+        ])
+        ->assertRedirect();
+
+    expect(app(InstanceSettings::class)->registrationsEnabled())->toBeFalse()
+        ->and(app(InstanceSettings::class)->workspaceCreationEnabled())->toBeFalse();
+});
+
+test('workspace creation setting is disabled when workspaces are globally disabled', function () {
+    config(['kit.workspaces.enabled' => false]);
+
+    $owner = User::factory()->instanceOwner()->create();
+    app(InstanceSettings::class)->update([
+        'workspace_creation_enabled' => true,
+    ]);
+
+    $this->actingAs($owner)
+        ->get(route('instance-settings.edit'))
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('workspaces_enabled', false)
+            ->where('settings.workspace_creation_enabled', false));
+});
+
+test('workspace creation setting cannot be enabled when workspaces are globally disabled', function () {
+    config(['kit.workspaces.enabled' => false]);
+
+    $owner = User::factory()->instanceOwner()->create();
+
+    $this->actingAs($owner)
+        ->put(route('instance-settings.update'), [
+            'registrations_enabled' => true,
+            'workspace_creation_enabled' => true,
+        ])
+        ->assertRedirect();
+
+    expect(app(InstanceSettings::class)->workspaceCreationEnabled())->toBeFalse();
+});

--- a/tests/Feature/Workspace/InertiaWorkspaceShareTest.php
+++ b/tests/Feature/Workspace/InertiaWorkspaceShareTest.php
@@ -5,6 +5,10 @@ use App\Models\Workspace;
 use App\Models\WorkspaceMembership;
 use Inertia\Testing\AssertableInertia;
 
+beforeEach(function () {
+    config(['kit.workspaces.enabled' => true]);
+});
+
 test('dashboard shares current workspace and list', function () {
     $workspace = Workspace::factory()->create(['name' => 'Acme']);
     $user = User::factory()->create(['current_workspace_id' => $workspace->id]);
@@ -16,5 +20,17 @@ test('dashboard shares current workspace and list', function () {
             ->where('workspaces.current.role', 'owner')
             ->has('workspaces.all', 1)
             ->where('workspaces.enabled', true)
+        );
+});
+
+test('dashboard does not allow workspace creation when workspaces are globally disabled', function () {
+    config(['kit.workspaces.enabled' => false]);
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user)->get(route('dashboard'))
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('workspaces.enabled', false)
+            ->where('workspaces.canCreateWorkspaces', false)
         );
 });


### PR DESCRIPTION
## Summary
- Adds instance-level settings for public registration and workspace creation, managed by the instance owner.
- Assigns the first registered or seeded development user as the instance owner.
- Blocks public email and social registrations when disabled while still allowing invitation-based onboarding.
- Adds owner-only instance settings UI, sidebar/command palette navigation, shared Inertia owner state, and coverage for registration/config/settings behavior.