### PR TITLE
fix(settings): separate instance settings layout

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -6,6 +6,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { initializeTheme } from '@/hooks/use-appearance';
 import AppLayout from '@/layouts/app-layout';
 import AuthLayout from '@/layouts/auth-layout';
+import InstanceSettingsLayout from '@/layouts/settings/instance-layout';
 import SettingsLayout from '@/layouts/settings/layout';
 import WorkspaceSettingsLayout from '@/layouts/settings/workspace-layout';
 
@@ -21,7 +22,7 @@ void createInertiaApp({
             case name.startsWith('auth/'):
                 return AuthLayout;
             case name === 'settings/instance':
-                return [AppLayout, WorkspaceSettingsLayout];
+                return [AppLayout, InstanceSettingsLayout];
             case name.startsWith('settings/workspace'):
                 return [AppLayout, WorkspaceSettingsLayout];
             case name.startsWith('settings/'):

--- a/resources/js/layouts/settings/__tests__/instance-layout.test.ts
+++ b/resources/js/layouts/settings/__tests__/instance-layout.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const readSource = (file: string) =>
+    readFileSync(resolve(process.cwd(), file), 'utf8');
+
+describe('instance settings layout', () => {
+    it('uses its own layout instead of the workspace settings layout', () => {
+        const app = readSource('resources/js/app.tsx');
+
+        expect(app).toContain(
+            "import InstanceSettingsLayout from '@/layouts/settings/instance-layout';",
+        );
+        expect(app).toContain(
+            "case name === 'settings/instance':\n                return [AppLayout, InstanceSettingsLayout];",
+        );
+    });
+
+    it('does not appear in the workspace settings sub navigation', () => {
+        const workspaceLayout = readSource(
+            'resources/js/layouts/settings/workspace-layout.tsx',
+        );
+
+        expect(workspaceLayout).not.toContain('InstanceSettingsController');
+        expect(workspaceLayout).not.toContain("title: 'Instance'");
+    });
+
+    it('breadcrumbs instance settings as a top-level settings area', () => {
+        const page = readSource('resources/js/pages/settings/instance.tsx');
+
+        expect(page).toContain("title: 'Instance settings'");
+        expect(page).not.toContain("title: 'Workspace settings'");
+    });
+});

--- a/resources/js/layouts/settings/instance-layout.tsx
+++ b/resources/js/layouts/settings/instance-layout.tsx
@@ -1,7 +1,7 @@
-import { Link, usePage } from '@inertiajs/react';
+import { Link } from '@inertiajs/react';
 import type { PropsWithChildren } from 'react';
 
-import WorkspaceSettingsController from '@/actions/App/Http/Controllers/Settings/WorkspaceSettingsController';
+import InstanceSettingsController from '@/actions/App/Http/Controllers/Settings/InstanceSettingsController';
 import Heading from '@/components/common/heading';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
@@ -9,21 +9,15 @@ import { useCurrentUrl } from '@/hooks/use-current-url';
 import { cn, toUrl } from '@/lib/utils';
 import type { NavItem } from '@/types';
 
-export default function WorkspaceSettingsLayout({
+export default function InstanceSettingsLayout({
     children,
 }: PropsWithChildren) {
-    const { isCurrentOrParentUrl, isCurrentUrl } = useCurrentUrl();
-    const { workspaces } = usePage().props;
+    const { isCurrentOrParentUrl } = useCurrentUrl();
 
     const sidebarNavItems: NavItem[] = [
         {
-            title: 'Overview',
-            href: WorkspaceSettingsController.showOverview(),
-            icon: null,
-        },
-        {
-            title: 'Members',
-            href: WorkspaceSettingsController.showMembers(),
+            title: 'General',
+            href: InstanceSettingsController.edit(),
             icon: null,
         },
     ];
@@ -31,19 +25,15 @@ export default function WorkspaceSettingsLayout({
     return (
         <div className="mx-auto w-full max-w-6xl px-4 pt-6 pb-16 sm:px-6">
             <Heading
-                title="Workspace settings"
-                description={
-                    workspaces.current
-                        ? `Manage ${workspaces.current.name} and its members`
-                        : 'Manage your workspace and its members'
-                }
+                title="Instance settings"
+                description="Manage settings that affect every user on this self-hosted instance"
             />
 
             <div className="flex flex-col lg:flex-row lg:space-x-12">
                 <aside className="w-full max-w-xl lg:w-48">
                     <nav
                         className="flex flex-col space-y-1 space-x-0"
-                        aria-label="Workspace settings"
+                        aria-label="Instance settings"
                     >
                         {sidebarNavItems.map((item, index) => (
                             <Button
@@ -52,10 +42,7 @@ export default function WorkspaceSettingsLayout({
                                 variant="ghost"
                                 asChild
                                 className={cn('w-full justify-start', {
-                                    'bg-muted':
-                                        item.title === 'Overview'
-                                            ? isCurrentUrl(item.href)
-                                            : isCurrentOrParentUrl(item.href),
+                                    'bg-muted': isCurrentOrParentUrl(item.href),
                                 })}
                             >
                                 <Link href={item.href}>

--- a/resources/js/pages/settings/instance.tsx
+++ b/resources/js/pages/settings/instance.tsx
@@ -40,8 +40,8 @@ export default function Instance({ settings, workspaces_enabled }: PageProps) {
             <div className="space-y-6">
                 <Heading
                     variant="small"
-                    title="Instance"
-                    description="Manage settings that affect every user on this self-hosted instance"
+                    title="General"
+                    description="Control signups and workspace creation for this instance"
                 />
 
                 <form onSubmit={handleSubmit} className="space-y-6">
@@ -105,11 +105,7 @@ export default function Instance({ settings, workspaces_enabled }: PageProps) {
 Instance.layout = {
     breadcrumbs: [
         {
-            title: 'Workspace settings',
-            href: '/settings/workspace',
-        },
-        {
-            title: 'Instance',
+            title: 'Instance settings',
             href: InstanceSettingsController.edit().url,
         },
     ],


### PR DESCRIPTION
## Summary
- Adds a dedicated layout for instance settings instead of nesting it under workspace settings.
- Removes instance settings from the workspace settings sub-navigation.
- Updates instance settings breadcrumbs and page heading to present it as a top-level settings area.
- Adds coverage to guard the instance settings layout behavior.