### PR TITLE
feat(settings): manage instance owners

### DIFF
--- a/app/Http/Controllers/Settings/InstanceSettingsController.php
+++ b/app/Http/Controllers/Settings/InstanceSettingsController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers\Settings;
 
+use App\Enums\InstanceRole;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\StoreInstanceOwnerRequest;
 use App\Http\Requests\Settings\UpdateInstanceSettingsRequest;
 use App\Models\User;
 use App\Settings\InstanceSettings;
@@ -32,10 +34,81 @@ class InstanceSettingsController extends Controller
         ]);
     }
 
+    public function admins(Request $request): Response
+    {
+        /** @var User|null $user */
+        $user = $request->user();
+        abort_unless($user?->isInstanceOwner(), 403);
+
+        $search = $request->string('search')->trim()->toString();
+
+        $users = $search === ''
+            ? collect()
+            : User::query()
+                ->select(['id', 'name', 'email'])
+                ->whereNull('instance_role')
+                ->where('email', 'like', "%{$search}%")
+                ->orderBy('email')
+                ->limit(10)
+                ->get()
+                ->map(fn (User $user): array => [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                    'avatar' => "https://api.dicebear.com/9.x/glass/svg?seed={$user->id}",
+                ]);
+
+        return Inertia::render('settings/instance-admins', [
+            'owners' => User::query()
+                ->select(['id', 'name', 'email', 'created_at'])
+                ->where('instance_role', InstanceRole::Owner->value)
+                ->orderBy('email')
+                ->get()
+                ->map(fn (User $owner): array => [
+                    'id' => $owner->id,
+                    'name' => $owner->name,
+                    'email' => $owner->email,
+                    'avatar' => "https://api.dicebear.com/9.x/glass/svg?seed={$owner->id}",
+                    'created_at' => $owner->created_at,
+                ]),
+            'users' => $users,
+            'search' => $search,
+        ]);
+    }
+
     public function update(UpdateInstanceSettingsRequest $request, InstanceSettings $settings): RedirectResponse
     {
         $settings->update($request->instanceSettings());
 
         return back()->with('success', 'Instance settings updated.');
+    }
+
+    public function destroyAdmin(Request $request, User $owner): RedirectResponse
+    {
+        /** @var User|null $user */
+        $user = $request->user();
+        abort_unless($user?->isInstanceOwner(), 403);
+        abort_unless($owner->isInstanceOwner(), 404);
+
+        if ($owner->is($user)) {
+            return back()->withErrors(['owner' => 'You cannot remove yourself as an instance owner.']);
+        }
+
+        if (User::query()->where('instance_role', InstanceRole::Owner->value)->count() <= 1) {
+            return back()->withErrors(['owner' => 'At least one instance owner is required.']);
+        }
+
+        $owner->update(['instance_role' => null]);
+
+        return back()->with('success', 'Instance owner removed.');
+    }
+
+    public function storeAdmin(StoreInstanceOwnerRequest $request): RedirectResponse
+    {
+        User::query()
+            ->where('email', $request->email())
+            ->update(['instance_role' => InstanceRole::Owner->value]);
+
+        return back()->with('success', 'Instance owner added.');
     }
 }

--- a/app/Http/Requests/Settings/StoreInstanceOwnerRequest.php
+++ b/app/Http/Requests/Settings/StoreInstanceOwnerRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use App\Models\User;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreInstanceOwnerRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        /** @var User|null $user */
+        $user = $this->user();
+
+        return $user?->isInstanceOwner() ?? false;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => [
+                'required',
+                'email',
+                'max:255',
+                Rule::exists('users', 'email')->where(
+                    fn ($query) => $query->whereNull('instance_role')
+                ),
+            ],
+        ];
+    }
+
+    public function email(): string
+    {
+        return (string) $this->validated('email');
+    }
+}

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -21,7 +21,8 @@ void createInertiaApp({
                 return null;
             case name.startsWith('auth/'):
                 return AuthLayout;
-            case name === 'settings/instance':
+            case name === 'settings/instance' ||
+                name === 'settings/instance-admins':
                 return [AppLayout, InstanceSettingsLayout];
             case name.startsWith('settings/workspace'):
                 return [AppLayout, WorkspaceSettingsLayout];

--- a/resources/js/components/layout/__tests__/app-sidebar.test.ts
+++ b/resources/js/components/layout/__tests__/app-sidebar.test.ts
@@ -15,6 +15,22 @@ describe('workspaceSettingsLabel', () => {
     });
 });
 
+describe('settings sidebar active states', () => {
+    it('keeps instance settings active on child pages', () => {
+        const source = readFileSync(
+            resolve(
+                process.cwd(),
+                'resources/js/components/layout/app-sidebar.tsx',
+            ),
+            'utf8',
+        );
+
+        expect(source).toContain(
+            'isActive={isCurrentOrParentUrl(\n                                                InstanceSettingsController.edit(),\n                                            )}',
+        );
+    });
+});
+
 describe('sidebar nav click targets', () => {
     it('lets sidebar links receive clicks from their SVG icons', () => {
         const source = readFileSync(

--- a/resources/js/components/layout/app-sidebar.tsx
+++ b/resources/js/components/layout/app-sidebar.tsx
@@ -229,7 +229,7 @@ export function AppSidebar() {
                                         <SidebarMenuButton
                                             asChild
                                             tooltip={instanceSettingsLabel}
-                                            isActive={isCurrentUrl(
+                                            isActive={isCurrentOrParentUrl(
                                                 InstanceSettingsController.edit(),
                                             )}
                                         >

--- a/resources/js/components/settings/remove-instance-owner-dialog.tsx
+++ b/resources/js/components/settings/remove-instance-owner-dialog.tsx
@@ -1,0 +1,53 @@
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+
+type Owner = {
+    name: string;
+};
+
+export default function RemoveInstanceOwnerDialog({
+    owner,
+    onClose,
+    onConfirm,
+}: {
+    owner: Owner | null;
+    onClose: () => void;
+    onConfirm: () => void;
+}) {
+    return (
+        <Dialog
+            open={owner !== null}
+            onOpenChange={(open) => !open && onClose()}
+        >
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Remove instance owner</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to remove {owner?.name} as an
+                        instance owner? They will no longer be able to manage
+                        instance-wide settings.
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter>
+                    <Button type="button" variant="outline" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="destructive"
+                        onClick={onConfirm}
+                    >
+                        Remove owner
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/resources/js/layouts/settings/__tests__/instance-layout.test.ts
+++ b/resources/js/layouts/settings/__tests__/instance-layout.test.ts
@@ -13,9 +13,9 @@ describe('instance settings layout', () => {
         expect(app).toContain(
             "import InstanceSettingsLayout from '@/layouts/settings/instance-layout';",
         );
-        expect(app).toContain(
-            "case name === 'settings/instance':\n                return [AppLayout, InstanceSettingsLayout];",
-        );
+        expect(app).toContain("case name === 'settings/instance' ||");
+        expect(app).toContain("name === 'settings/instance-admins':");
+        expect(app).toContain('return [AppLayout, InstanceSettingsLayout];');
     });
 
     it('does not appear in the workspace settings sub navigation', () => {
@@ -25,6 +25,15 @@ describe('instance settings layout', () => {
 
         expect(workspaceLayout).not.toContain('InstanceSettingsController');
         expect(workspaceLayout).not.toContain("title: 'Instance'");
+    });
+
+    it('includes an admins sub navigation item', () => {
+        const layout = readSource(
+            'resources/js/layouts/settings/instance-layout.tsx',
+        );
+
+        expect(layout).toContain("title: 'Admins'");
+        expect(layout).toContain('InstanceSettingsController.admins()');
     });
 
     it('breadcrumbs instance settings as a top-level settings area', () => {

--- a/resources/js/layouts/settings/instance-layout.tsx
+++ b/resources/js/layouts/settings/instance-layout.tsx
@@ -12,12 +12,17 @@ import type { NavItem } from '@/types';
 export default function InstanceSettingsLayout({
     children,
 }: PropsWithChildren) {
-    const { isCurrentOrParentUrl } = useCurrentUrl();
+    const { isCurrentOrParentUrl, isCurrentUrl } = useCurrentUrl();
 
     const sidebarNavItems: NavItem[] = [
         {
             title: 'General',
             href: InstanceSettingsController.edit(),
+            icon: null,
+        },
+        {
+            title: 'Admins',
+            href: InstanceSettingsController.admins(),
             icon: null,
         },
     ];
@@ -42,7 +47,10 @@ export default function InstanceSettingsLayout({
                                 variant="ghost"
                                 asChild
                                 className={cn('w-full justify-start', {
-                                    'bg-muted': isCurrentOrParentUrl(item.href),
+                                    'bg-muted':
+                                        item.title === 'General'
+                                            ? isCurrentUrl(item.href)
+                                            : isCurrentOrParentUrl(item.href),
                                 })}
                             >
                                 <Link href={item.href}>

--- a/resources/js/pages/settings/__tests__/instance-admins.test.ts
+++ b/resources/js/pages/settings/__tests__/instance-admins.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const readSource = (file: string) =>
+    readFileSync(resolve(process.cwd(), file), 'utf8');
+
+describe('instance admins page', () => {
+    it('uses the workspace member removal interaction style', () => {
+        const page = readSource(
+            'resources/js/pages/settings/instance-admins.tsx',
+        );
+
+        expect(page).toContain('DropdownMenu');
+        expect(page).toContain('RemoveInstanceOwnerDialog');
+        expect(page).not.toContain('useConfirm');
+    });
+});

--- a/resources/js/pages/settings/instance-admins.tsx
+++ b/resources/js/pages/settings/instance-admins.tsx
@@ -1,0 +1,322 @@
+import { Form, Head, router, usePage } from '@inertiajs/react';
+import { Crown, MoreVertical, Search, Trash2, UserPlus } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import InstanceSettingsController from '@/actions/App/Http/Controllers/Settings/InstanceSettingsController';
+import Heading from '@/components/common/heading';
+import InputError from '@/components/common/input-error';
+import RemoveInstanceOwnerDialog from '@/components/settings/remove-instance-owner-dialog';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+import { removeById } from '@/lib/optimistic';
+
+type InstanceUser = {
+    id: string;
+    name: string;
+    email: string;
+    avatar: string;
+    created_at?: string;
+};
+
+type Props = {
+    owners: InstanceUser[];
+    users: InstanceUser[];
+    search: string;
+};
+
+export default function InstanceAdmins({ owners, users, search }: Props) {
+    const { auth } = usePage().props;
+    const [query, setQuery] = useState(search);
+    const [ownerToRemove, setOwnerToRemove] = useState<InstanceUser | null>(
+        null,
+    );
+
+    function confirmRemoveOwner() {
+        if (!ownerToRemove) {
+            return;
+        }
+
+        const removedId = ownerToRemove.id;
+
+        router.delete(InstanceSettingsController.destroyAdmin.url(removedId), {
+            preserveScroll: true,
+            optimistic: (props) => ({
+                owners: removeById(
+                    (props as { owners?: InstanceUser[] }).owners,
+                    removedId,
+                ),
+            }),
+            onSuccess: () => {
+                toast.success('Instance owner removed');
+                setOwnerToRemove(null);
+            },
+            onError: () => setOwnerToRemove(null),
+        });
+    }
+
+    function handleSearch(event: React.FormEvent) {
+        event.preventDefault();
+
+        router.get(
+            InstanceSettingsController.admins({
+                query: { search: query },
+            }).url,
+            {},
+            {
+                preserveState: true,
+                preserveScroll: true,
+            },
+        );
+    }
+
+    return (
+        <>
+            <Head title="Instance admins" />
+
+            <div className="space-y-8">
+                <Heading
+                    variant="small"
+                    title="Admins"
+                    description="Add registered users as instance owners. No invitation or acceptance is required."
+                />
+
+                <section className="space-y-4">
+                    <div className="space-y-1">
+                        <h2 className="text-sm font-medium">Instance owners</h2>
+                        <p className="text-sm text-muted-foreground">
+                            These users can manage instance-wide settings.
+                        </p>
+                    </div>
+
+                    <div className="rounded-md border">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>User</TableHead>
+                                    <TableHead>Role</TableHead>
+                                    <TableHead className="w-32 text-right">
+                                        <span className="sr-only">Actions</span>
+                                    </TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {owners.map((owner) => (
+                                    <TableRow key={owner.id}>
+                                        <TableCell>
+                                            <UserSummary user={owner} />
+                                        </TableCell>
+                                        <TableCell>
+                                            <Badge>
+                                                <span className="flex items-center gap-1">
+                                                    <Crown className="size-3" />
+                                                    Owner
+                                                </span>
+                                            </Badge>
+                                        </TableCell>
+                                        <TableCell className="text-right">
+                                            {owner.id !== auth.user.id &&
+                                                owners.length > 1 && (
+                                                    <DropdownMenu>
+                                                        <DropdownMenuTrigger
+                                                            asChild
+                                                        >
+                                                            <Button
+                                                                size="icon"
+                                                                variant="ghost"
+                                                            >
+                                                                <MoreVertical className="size-4" />
+                                                                <span className="sr-only">
+                                                                    Owner
+                                                                    actions
+                                                                </span>
+                                                            </Button>
+                                                        </DropdownMenuTrigger>
+                                                        <DropdownMenuContent align="end">
+                                                            <DropdownMenuItem
+                                                                variant="destructive"
+                                                                onClick={() =>
+                                                                    setOwnerToRemove(
+                                                                        owner,
+                                                                    )
+                                                                }
+                                                            >
+                                                                <Trash2 className="size-4" />
+                                                                Remove
+                                                            </DropdownMenuItem>
+                                                        </DropdownMenuContent>
+                                                    </DropdownMenu>
+                                                )}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </div>
+                </section>
+
+                <section className="space-y-4">
+                    <div className="space-y-1">
+                        <h2 className="text-sm font-medium">Add owner</h2>
+                        <p className="text-sm text-muted-foreground">
+                            Search registered users by email, then grant the
+                            instance owner role.
+                        </p>
+                    </div>
+
+                    <form onSubmit={handleSearch} className="flex gap-2">
+                        <div className="grid flex-1 gap-2">
+                            <Label htmlFor="search" className="sr-only">
+                                Search users by email
+                            </Label>
+                            <Input
+                                id="search"
+                                type="search"
+                                value={query}
+                                onChange={(event) =>
+                                    setQuery(event.target.value)
+                                }
+                                placeholder="Search by email"
+                            />
+                        </div>
+                        <Button type="submit" variant="outline">
+                            <Search className="size-4" />
+                            Search
+                        </Button>
+                    </form>
+
+                    <div className="rounded-md border">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>User</TableHead>
+                                    <TableHead className="w-32 text-right">
+                                        <span className="sr-only">Actions</span>
+                                    </TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {users.length === 0 ? (
+                                    <TableRow>
+                                        <TableCell
+                                            colSpan={2}
+                                            className="py-6 text-center text-sm text-muted-foreground"
+                                        >
+                                            {search
+                                                ? 'No registered users match this email search.'
+                                                : 'Search by email to find a registered user.'}
+                                        </TableCell>
+                                    </TableRow>
+                                ) : (
+                                    users.map((user) => (
+                                        <TableRow key={user.id}>
+                                            <TableCell>
+                                                <UserSummary user={user} />
+                                            </TableCell>
+                                            <TableCell className="text-right">
+                                                <Form
+                                                    {...InstanceSettingsController.storeAdmin.form()}
+                                                    options={{
+                                                        preserveScroll: true,
+                                                    }}
+                                                    onSuccess={() =>
+                                                        toast.success(
+                                                            'Instance owner added',
+                                                        )
+                                                    }
+                                                >
+                                                    {({
+                                                        errors,
+                                                        processing,
+                                                    }) => (
+                                                        <>
+                                                            <input
+                                                                type="hidden"
+                                                                name="email"
+                                                                value={
+                                                                    user.email
+                                                                }
+                                                            />
+                                                            <Button
+                                                                type="submit"
+                                                                size="sm"
+                                                                disabled={
+                                                                    processing
+                                                                }
+                                                            >
+                                                                <UserPlus className="size-4" />
+                                                                Add owner
+                                                            </Button>
+                                                            <InputError
+                                                                message={
+                                                                    errors.email
+                                                                }
+                                                            />
+                                                        </>
+                                                    )}
+                                                </Form>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))
+                                )}
+                            </TableBody>
+                        </Table>
+                    </div>
+                </section>
+            </div>
+
+            <RemoveInstanceOwnerDialog
+                owner={ownerToRemove}
+                onClose={() => setOwnerToRemove(null)}
+                onConfirm={confirmRemoveOwner}
+            />
+        </>
+    );
+}
+
+function UserSummary({ user }: { user: InstanceUser }) {
+    return (
+        <div className="flex items-center gap-3">
+            <Avatar className="size-8">
+                <AvatarImage src={user.avatar} alt={user.name} />
+                <AvatarFallback>{user.name.charAt(0)}</AvatarFallback>
+            </Avatar>
+            <div className="min-w-0">
+                <p className="truncate font-medium">{user.name}</p>
+                <p className="truncate text-sm text-muted-foreground">
+                    {user.email}
+                </p>
+            </div>
+        </div>
+    );
+}
+
+InstanceAdmins.layout = {
+    breadcrumbs: [
+        {
+            title: 'Instance settings',
+            href: InstanceSettingsController.edit().url,
+        },
+        {
+            title: 'Admins',
+            href: InstanceSettingsController.admins().url,
+        },
+    ],
+};

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -32,6 +32,9 @@ Route::middleware(['auth'])->group(function () {
 
     Route::get('settings/instance', [InstanceSettingsController::class, 'edit'])->name('instance-settings.edit');
     Route::put('settings/instance', [InstanceSettingsController::class, 'update'])->name('instance-settings.update');
+    Route::get('settings/instance/admins', [InstanceSettingsController::class, 'admins'])->name('instance-settings.admins');
+    Route::post('settings/instance/admins', [InstanceSettingsController::class, 'storeAdmin'])->name('instance-settings.admins.store');
+    Route::delete('settings/instance/admins/{owner}', [InstanceSettingsController::class, 'destroyAdmin'])->name('instance-settings.admins.destroy');
 });
 
 Route::middleware(['auth', 'verified'])->group(function () {

--- a/tests/Feature/InstanceSettingsTest.php
+++ b/tests/Feature/InstanceSettingsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\InstanceRole;
 use App\Models\User;
 use App\Settings\InstanceSettings;
 use Inertia\Testing\AssertableInertia;
@@ -62,4 +63,90 @@ test('workspace creation setting cannot be enabled when workspaces are globally 
         ->assertRedirect();
 
     expect(app(InstanceSettings::class)->workspaceCreationEnabled())->toBeFalse();
+});
+
+test('instance owner can view instance admins and search registered users by email', function () {
+    $owner = User::factory()->instanceOwner()->create(['email' => 'owner@example.com']);
+    $matchingUser = User::factory()->create(['email' => 'admin-candidate@example.com']);
+    User::factory()->create(['email' => 'other@example.com']);
+
+    $this->actingAs($owner)
+        ->get(route('instance-settings.admins', ['search' => 'candidate']))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('settings/instance-admins')
+            ->where('owners.0.email', 'owner@example.com')
+            ->where('search', 'candidate')
+            ->where('users.0.id', $matchingUser->id)
+            ->where('users.0.email', 'admin-candidate@example.com')
+            ->missing('users.1'));
+});
+
+test('regular users cannot view instance admins', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('instance-settings.admins'))
+        ->assertForbidden();
+});
+
+test('instance owner can add another registered user as an instance owner', function () {
+    $owner = User::factory()->instanceOwner()->create();
+    $candidate = User::factory()->create(['email' => 'candidate@example.com']);
+
+    $this->actingAs($owner)
+        ->post(route('instance-settings.admins.store'), [
+            'email' => 'candidate@example.com',
+        ])
+        ->assertRedirect();
+
+    expect($candidate->fresh()->instance_role)->toBe(InstanceRole::Owner);
+});
+
+test('instance owner cannot add a missing user as an instance owner', function () {
+    $owner = User::factory()->instanceOwner()->create();
+
+    $this->actingAs($owner)
+        ->from(route('instance-settings.admins'))
+        ->post(route('instance-settings.admins.store'), [
+            'email' => 'missing@example.com',
+        ])
+        ->assertRedirect(route('instance-settings.admins'))
+        ->assertSessionHasErrors('email');
+});
+
+test('instance owner can remove another instance owner', function () {
+    $owner = User::factory()->instanceOwner()->create();
+    $otherOwner = User::factory()->instanceOwner()->create();
+
+    $this->actingAs($owner)
+        ->delete(route('instance-settings.admins.destroy', $otherOwner))
+        ->assertRedirect();
+
+    expect($otherOwner->fresh()->instance_role)->toBeNull();
+});
+
+test('instance owner cannot remove the last instance owner', function () {
+    $owner = User::factory()->instanceOwner()->create();
+
+    $this->actingAs($owner)
+        ->from(route('instance-settings.admins'))
+        ->delete(route('instance-settings.admins.destroy', $owner))
+        ->assertRedirect(route('instance-settings.admins'))
+        ->assertSessionHasErrors('owner');
+
+    expect($owner->fresh()->instance_role)->toBe(InstanceRole::Owner);
+});
+
+test('instance owner cannot remove themselves while another owner exists', function () {
+    $owner = User::factory()->instanceOwner()->create();
+    User::factory()->instanceOwner()->create();
+
+    $this->actingAs($owner)
+        ->from(route('instance-settings.admins'))
+        ->delete(route('instance-settings.admins.destroy', $owner))
+        ->assertRedirect(route('instance-settings.admins'))
+        ->assertSessionHasErrors('owner');
+
+    expect($owner->fresh()->instance_role)->toBe(InstanceRole::Owner);
 });


### PR DESCRIPTION
## Summary
- Add an Instance settings Admins page for owners to view current instance owners and search registered users by email.
- Allow instance owners to grant and remove the owner role with safeguards against self-removal and removing the last owner.
- Update instance settings navigation/layout behavior and add coverage for admin management flows.