### PR TITLE
feat(workspaces): add invitation notification actions

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -5,6 +5,7 @@ namespace App\Actions\Fortify;
 use App\Concerns\PasswordValidationRules;
 use App\Concerns\ProfileValidationRules;
 use App\Models\User;
+use App\Models\WorkspaceInvitation;
 use App\Services\Workspace\WorkspaceProvisioningService;
 use App\Settings\InstanceSettings;
 use Illuminate\Support\Facades\DB;
@@ -26,10 +27,21 @@ class CreateNewUser implements CreatesNewUsers
      */
     public function create(array $input): User
     {
-        if (! $this->settings->registrationsAllowed(request()->input('invitation'))) {
+        $invitationToken = request()->input('invitation');
+        $invitationToken = is_string($invitationToken) ? $invitationToken : null;
+
+        if (! $this->settings->registrationsAllowed($invitationToken)) {
             throw ValidationException::withMessages([
                 'email' => 'Registration is disabled for this instance.',
             ]);
+        }
+
+        if ($invitationToken !== null) {
+            $invitation = WorkspaceInvitation::findByToken($invitationToken);
+
+            if ($invitation?->isValid()) {
+                $input['email'] = $invitation->email;
+            }
         }
 
         Validator::make($input, [

--- a/app/Enums/NotificationType.php
+++ b/app/Enums/NotificationType.php
@@ -18,7 +18,7 @@ enum NotificationType: string
     public function inAppAlwaysOn(): bool
     {
         return match ($this) {
-            self::PublishFailed, self::AccountNeedsAttention => true,
+            self::PublishFailed, self::WorkspaceInvite, self::AccountNeedsAttention => true,
             default => false,
         };
     }
@@ -26,7 +26,7 @@ enum NotificationType: string
     public function emailOnByDefault(): bool
     {
         return match ($this) {
-            self::PublishFailed, self::AccountNeedsAttention => true,
+            self::PublishFailed, self::WorkspaceInvite, self::AccountNeedsAttention => true,
             default => false,
         };
     }

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -47,9 +47,14 @@ class NotificationController extends Controller
      */
     public function markAllRead(Request $request): RedirectResponse
     {
+        $workspaceId = $request->user()->current_workspace_id;
+
         $request->user()
             ->unreadNotifications()
-            ->where('data->workspace_id', $request->user()->current_workspace_id)
+            ->where(function ($query) use ($workspaceId): void {
+                $query->where('data->workspace_id', $workspaceId)
+                    ->orWhereNull('data->workspace_id');
+            })
             ->update(['read_at' => now()]);
 
         return back();

--- a/app/Http/Controllers/WorkspaceInvitationResponseController.php
+++ b/app/Http/Controllers/WorkspaceInvitationResponseController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Enums\NotificationType;
+use App\Models\User;
+use App\Models\WorkspaceInvitation;
+use App\Services\Workspace\WorkspaceInvitationService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class WorkspaceInvitationResponseController extends Controller
+{
+    public function accept(Request $request, WorkspaceInvitation $invitation, WorkspaceInvitationService $service): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $this->abortUnlessInvitee($user, $invitation);
+
+        $result = $service->accept($invitation, $user);
+
+        if ($result->wasSuccessful()) {
+            $this->deleteInvitationNotifications($user, $invitation);
+
+            return redirect()->route('dashboard')->with('success', $result->message);
+        }
+
+        return back()->with($result->type, $result->message);
+    }
+
+    public function deny(Request $request, WorkspaceInvitation $invitation): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $this->abortUnlessInvitee($user, $invitation);
+        abort_unless($invitation->isValid(), 404);
+
+        $this->deleteInvitationNotifications($user, $invitation);
+        $invitation->delete();
+
+        return back()->with('success', 'Invitation declined.');
+    }
+
+    private function abortUnlessInvitee(User $user, WorkspaceInvitation $invitation): void
+    {
+        abort_unless(hash_equals(mb_strtolower($invitation->email), mb_strtolower($user->email)), 404);
+    }
+
+    private function deleteInvitationNotifications(User $user, WorkspaceInvitation $invitation): void
+    {
+        $user->notifications()
+            ->where('data->event', NotificationType::WorkspaceInvite->value)
+            ->where('data->invitation_id', $invitation->id)
+            ->delete();
+    }
+}

--- a/app/Notifications/Concerns/GatedByPreferences.php
+++ b/app/Notifications/Concerns/GatedByPreferences.php
@@ -22,10 +22,10 @@ trait GatedByPreferences
     }
 
     /**
-     * @param  array{event: string, title: string, body: string, href: ?string, icon: string}  $extra
+     * @param  array<string, mixed>  $extra
      * @return array<string, mixed>
      */
-    protected function databasePayload(string $workspaceId, array $extra): array
+    protected function databasePayload(?string $workspaceId, array $extra): array
     {
         return [...$extra, 'workspace_id' => $workspaceId];
     }

--- a/app/Notifications/WorkspaceInviteAcceptedNotification.php
+++ b/app/Notifications/WorkspaceInviteAcceptedNotification.php
@@ -25,6 +25,17 @@ class WorkspaceInviteAcceptedNotification extends Notification implements Should
     }
 
     /**
+     * @return array<string, string>
+     */
+    public function viaConnections(): array
+    {
+        return [
+            'database' => 'sync',
+            'mail' => 'sync',
+        ];
+    }
+
+    /**
      * In-app only — no mail for accepted events.
      *
      * @return array<int, string>

--- a/app/Notifications/WorkspaceInviteNotification.php
+++ b/app/Notifications/WorkspaceInviteNotification.php
@@ -25,6 +25,17 @@ class WorkspaceInviteNotification extends Notification implements ShouldQueue
     }
 
     /**
+     * @return array<string, string>
+     */
+    public function viaConnections(): array
+    {
+        return [
+            'database' => 'sync',
+            'mail' => 'sync',
+        ];
+    }
+
+    /**
      * @return array<int, string>
      */
     public function via(object $notifiable): array
@@ -37,12 +48,14 @@ class WorkspaceInviteNotification extends Notification implements ShouldQueue
      */
     public function toArray(object $notifiable): array
     {
-        return $this->databasePayload($this->invitation->workspace_id, [
+        return $this->databasePayload(null, [
             'event' => NotificationType::WorkspaceInvite->value,
             'title' => 'Workspace invitation',
             'body' => $this->invitation->workspace->name.' invited you to collaborate.',
             'href' => route('workspace.invitation', $this->plainToken),
             'icon' => 'users',
+            'invited_workspace_id' => $this->invitation->workspace_id,
+            'invitation_id' => $this->invitation->id,
         ]);
     }
 

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Actions\Fortify\CreateNewUser;
 use App\Actions\Fortify\ResetUserPassword;
 use App\Enums\SocialProvider;
+use App\Models\WorkspaceInvitation;
 use App\Settings\InstanceSettings;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -82,14 +83,22 @@ class FortifyServiceProvider extends ServiceProvider
         ]));
 
         Fortify::registerView(function (Request $request) {
-            if (! app(InstanceSettings::class)->registrationsAllowed($request->query('invitation'))) {
+            $invitationToken = $request->query('invitation');
+            $invitationToken = is_string($invitationToken) ? $invitationToken : null;
+
+            if (! app(InstanceSettings::class)->registrationsAllowed($invitationToken)) {
                 return redirect()->route('login');
             }
+
+            $invitation = $invitationToken !== null
+                ? WorkspaceInvitation::findByToken($invitationToken)
+                : null;
 
             return Inertia::render('auth/register', [
                 'passwordRules' => Password::defaults()->toPasswordRulesString(),
                 'providers' => SocialProvider::enabledProvidersWithLabels(),
-                'invitation' => $request->query('invitation'),
+                'invitation' => $invitationToken,
+                'invitationEmail' => $invitation?->isValid() ? $invitation->email : null,
             ]);
         });
 

--- a/app/Services/Workspace/WorkspaceInvitationService.php
+++ b/app/Services/Workspace/WorkspaceInvitationService.php
@@ -49,9 +49,7 @@ class WorkspaceInvitationService
                 'role' => $invitation->role,
             ]);
 
-            if (! $user->current_workspace_id) {
-                $user->forceFill(['current_workspace_id' => $invitation->workspace_id]);
-            }
+            $user->forceFill(['current_workspace_id' => $invitation->workspace_id]);
 
             if (! $user->email_verified_at) {
                 $user->forceFill(['email_verified_at' => now()]);

--- a/app/Services/Workspace/WorkspaceProvisioningService.php
+++ b/app/Services/Workspace/WorkspaceProvisioningService.php
@@ -15,20 +15,16 @@ class WorkspaceProvisioningService
     public function __construct(private readonly WorkspaceInvitationService $invitations) {}
 
     /**
-     * Provision workspace access for a freshly created user: accept a pending
-     * invitation when a token is present, then guarantee the user lands with at
-     * least one workspace. If the invitation was invalid or expired (acceptByToken
-     * fails silently by design), they still get a default workspace rather than
-     * being stranded with none.
+     * Provision workspace access for a freshly created user: always create their
+     * personal workspace, then accept a pending invitation when a token is present.
+     * Accepting last keeps the invited workspace as the current workspace.
      */
     public function provisionForNewUser(User $user, ?string $invitationToken): void
     {
+        $this->createDefaultWorkspace($user);
+
         if ($invitationToken) {
             $this->invitations->acceptByToken($invitationToken, $user);
-        }
-
-        if (! $user->workspaceMemberships()->exists()) {
-            $this->createDefaultWorkspace($user);
         }
     }
 

--- a/app/Support/Notifications/NotificationPresenter.php
+++ b/app/Support/Notifications/NotificationPresenter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Support\Notifications;
 
+use App\Enums\NotificationType;
 use App\Models\User;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Pagination\Cursor;
@@ -31,7 +32,10 @@ class NotificationPresenter
             return ['items' => [], 'unreadCount' => 0, 'nextCursor' => null];
         }
 
-        $base = $user->notifications()->where('data->workspace_id', $workspaceId);
+        $base = $user->notifications()->where(function ($query) use ($workspaceId): void {
+            $query->where('data->workspace_id', $workspaceId)
+                ->orWhereNull('data->workspace_id');
+        });
 
         $paginator = (clone $base)
             ->orderByDesc('created_at')
@@ -62,7 +66,7 @@ class NotificationPresenter
         /** @var array<string, mixed> $data */
         $data = $notification->data;
 
-        return [
+        $item = [
             'id' => $notification->id,
             'event' => $data['event'] ?? '',
             'title' => $data['title'] ?? '',
@@ -71,6 +75,44 @@ class NotificationPresenter
             'icon' => $data['icon'] ?? 'bell',
             'read' => $notification->read_at !== null,
             'timeLabel' => $notification->created_at?->diffForHumans() ?? '',
+        ];
+
+        $actions = self::actions($data);
+
+        return $actions === [] ? $item : [...$item, 'actions' => $actions];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<int, array{key: string, label: string, variant: string, method: string, href: string}>
+     */
+    private static function actions(array $data): array
+    {
+        if (($data['event'] ?? null) !== NotificationType::WorkspaceInvite->value) {
+            return [];
+        }
+
+        if (! is_string($data['invitation_id'] ?? null)) {
+            return [];
+        }
+
+        $invitationId = $data['invitation_id'];
+
+        return [
+            [
+                'key' => 'accept',
+                'label' => 'Accept',
+                'variant' => 'primary',
+                'method' => 'post',
+                'href' => route('workspace.invitations.accept', $invitationId, absolute: false),
+            ],
+            [
+                'key' => 'deny',
+                'label' => 'Deny',
+                'variant' => 'secondary',
+                'method' => 'delete',
+                'href' => route('workspace.invitations.deny', $invitationId, absolute: false),
+            ],
         ];
     }
 }

--- a/resources/js/components/notifications/notification-bell.tsx
+++ b/resources/js/components/notifications/notification-bell.tsx
@@ -15,6 +15,7 @@ import {
     readAll as markAllRead,
 } from '@/routes/notifications';
 import type {
+    NotificationAction,
     NotificationItem,
     NotificationsData,
 } from '@/types/notifications';
@@ -109,6 +110,23 @@ export function NotificationBell() {
         );
     }
 
+    function handleAction(
+        notification: NotificationItem,
+        action: NotificationAction,
+    ) {
+        if (!notification.read) {
+            setUnread((count) => Math.max(0, count - 1));
+        }
+
+        setItems((prev) => prev.filter((n) => n.id !== notification.id));
+
+        router.visit(action.href, {
+            method: action.method,
+            preserveScroll: true,
+            preserveState: action.method === 'delete',
+        });
+    }
+
     return (
         <Popover>
             <PopoverTrigger asChild>
@@ -166,6 +184,7 @@ export function NotificationBell() {
                                     key={notification.id}
                                     notification={notification}
                                     onRead={markOneRead}
+                                    onAction={handleAction}
                                 />
                             ))}
                             {processing && (
@@ -184,10 +203,17 @@ export function NotificationBell() {
 function NotificationRow({
     notification,
     onRead,
+    onAction,
 }: {
     notification: NotificationItem;
     onRead: (id: string) => void;
+    onAction: (
+        notification: NotificationItem,
+        action: NotificationAction,
+    ) => void;
 }) {
+    const hasActions =
+        notification.actions !== undefined && notification.actions.length > 0;
     const body = (
         <div className="flex gap-2.5 px-3 py-2.5 text-left transition-colors hover:bg-muted/50">
             <span
@@ -209,11 +235,29 @@ function NotificationRow({
                 <p className="mt-1 text-[11px] text-muted-foreground/70">
                     {notification.timeLabel}
                 </p>
+                {hasActions && (
+                    <div className="mt-2 flex flex-wrap gap-2">
+                        {notification.actions?.map((action) => (
+                            <Button
+                                key={action.key}
+                                type="button"
+                                size="xs"
+                                variant={buttonVariant(action.variant)}
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    onAction(notification, action);
+                                }}
+                            >
+                                {action.label}
+                            </Button>
+                        ))}
+                    </div>
+                )}
             </div>
         </div>
     );
 
-    if (notification.href) {
+    if (notification.href && !hasActions) {
         return (
             <Link
                 href={notification.href}
@@ -243,4 +287,14 @@ function NotificationRow({
             {body}
         </div>
     );
+}
+
+function buttonVariant(
+    variant: NotificationAction['variant'],
+): React.ComponentProps<typeof Button>['variant'] {
+    if (variant === 'primary') {
+        return 'default';
+    }
+
+    return variant;
 }

--- a/resources/js/components/settings/__tests__/member-role-helpers.test.ts
+++ b/resources/js/components/settings/__tests__/member-role-helpers.test.ts
@@ -1,0 +1,17 @@
+import { isValidElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { roleIcon } from '../member-role-helpers';
+
+const roles = ['owner', 'admin', 'member'];
+
+describe('roleIcon', () => {
+    it('uses neutral role icons everywhere', () => {
+        for (const role of roles) {
+            const icon = roleIcon(role);
+
+            expect(isValidElement(icon)).toBe(true);
+            expect(icon.props.className).toBe('size-4');
+        }
+    });
+});

--- a/resources/js/components/settings/member-role-helpers.tsx
+++ b/resources/js/components/settings/member-role-helpers.tsx
@@ -3,11 +3,11 @@ import { Crown, Shield, User } from 'lucide-react';
 export function roleIcon(role: string) {
     switch (role) {
         case 'owner':
-            return <Crown className="size-4 text-yellow-600" />;
+            return <Crown className="size-4" />;
         case 'admin':
-            return <Shield className="size-4 text-blue-600" />;
+            return <Shield className="size-4" />;
         default:
-            return <User className="size-4 text-muted-foreground" />;
+            return <User className="size-4" />;
     }
 }
 

--- a/resources/js/pages/auth/__tests__/register-invitation.test.ts
+++ b/resources/js/pages/auth/__tests__/register-invitation.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const source = () =>
+    readFileSync(
+        resolve(process.cwd(), 'resources/js/pages/auth/register.tsx'),
+        'utf8',
+    );
+
+const loginSource = () =>
+    readFileSync(
+        resolve(process.cwd(), 'resources/js/pages/auth/login.tsx'),
+        'utf8',
+    );
+
+describe('invitation registration form', () => {
+    it('prefills and locks the invited email address', () => {
+        const register = source();
+
+        expect(register).toContain('invitationEmail?: string | null;');
+        expect(register).toContain(
+            'defaultValue={invitationEmail ?? undefined}',
+        );
+        expect(register).toContain('readOnly={Boolean(invitationEmail)}');
+    });
+
+    it('keeps the invitation token on register and login routes', () => {
+        const register = source();
+        const login = loginSource();
+
+        expect(register).toContain('store.form(');
+        expect(register).toContain('login(');
+        expect(register.match(/query: \{ invitation \}/g)).toHaveLength(2);
+        expect(login).toContain('register(');
+        expect(login.match(/query: \{ invitation \}/g)).toHaveLength(1);
+    });
+});

--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -131,7 +131,14 @@ export default function Login({
                         {canRegister ? (
                             <div className="text-center text-sm text-muted-foreground">
                                 Don't have an account?{' '}
-                                <TextLink href={register()} tabIndex={5}>
+                                <TextLink
+                                    href={register(
+                                        invitation
+                                            ? { query: { invitation } }
+                                            : undefined,
+                                    )}
+                                    tabIndex={5}
+                                >
                                     Sign up
                                 </TextLink>
                             </div>

--- a/resources/js/pages/auth/register.tsx
+++ b/resources/js/pages/auth/register.tsx
@@ -17,12 +17,14 @@ type Props = {
     passwordRules: string;
     providers?: SocialProviderOption[];
     invitation?: string;
+    invitationEmail?: string | null;
 };
 
 export default function Register({
     passwordRules,
     providers = [],
     invitation,
+    invitationEmail,
 }: Props) {
     return (
         <>
@@ -39,7 +41,9 @@ export default function Register({
             )}
 
             <Form
-                {...store.form()}
+                {...store.form(
+                    invitation ? { query: { invitation } } : undefined,
+                )}
                 resetOnSuccess={['password', 'password_confirmation']}
                 disableWhileProcessing
                 className="flex flex-col gap-6"
@@ -75,6 +79,8 @@ export default function Register({
                                     autoComplete="email"
                                     name="email"
                                     placeholder="email@example.com"
+                                    defaultValue={invitationEmail ?? undefined}
+                                    readOnly={Boolean(invitationEmail)}
                                 />
                                 <InputError message={errors.email} />
                             </div>
@@ -124,7 +130,14 @@ export default function Register({
 
                         <div className="text-center text-sm text-muted-foreground">
                             Already have an account?{' '}
-                            <TextLink href={login()} tabIndex={6}>
+                            <TextLink
+                                href={login(
+                                    invitation
+                                        ? { query: { invitation } }
+                                        : undefined,
+                                )}
+                                tabIndex={6}
+                            >
                                 Log in
                             </TextLink>
                         </div>

--- a/resources/js/types/notifications.ts
+++ b/resources/js/types/notifications.ts
@@ -1,3 +1,11 @@
+export type NotificationAction = {
+    key: string;
+    label: string;
+    variant: 'primary' | 'secondary' | 'destructive';
+    method: 'post' | 'delete';
+    href: string;
+};
+
 export type NotificationItem = {
     id: string;
     event: string;
@@ -7,6 +15,7 @@ export type NotificationItem = {
     icon: string;
     read: boolean;
     timeLabel: string;
+    actions?: NotificationAction[];
 };
 
 export type NotificationsData = {

--- a/routes/workspace.php
+++ b/routes/workspace.php
@@ -4,11 +4,19 @@ declare(strict_types=1);
 
 use App\Http\Controllers\OnboardingController;
 use App\Http\Controllers\WorkspaceController;
+use App\Http\Controllers\WorkspaceInvitationResponseController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('invitation/{token}', [WorkspaceController::class, 'showInvitation'])
     ->middleware('throttle:5,1')
     ->name('workspace.invitation');
+
+Route::middleware('auth')->group(function (): void {
+    Route::post('workspace-invitations/{invitation}/accept', [WorkspaceInvitationResponseController::class, 'accept'])
+        ->name('workspace.invitations.accept');
+    Route::delete('workspace-invitations/{invitation}', [WorkspaceInvitationResponseController::class, 'deny'])
+        ->name('workspace.invitations.deny');
+});
 
 Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::post('workspaces', [WorkspaceController::class, 'store'])->name('workspaces.store');

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use App\Models\WorkspaceInvitation;
 use App\Settings\InstanceSettings;
 use Inertia\Testing\AssertableInertia as Assert;
 use Laravel\Fortify\Features;
@@ -13,6 +14,20 @@ test('registration screen can be rendered', function () {
     $response = $this->get(route('register'));
 
     $response->assertOk();
+});
+
+test('registration screen preloads the email for a valid invitation', function () {
+    [$plain, $hash] = WorkspaceInvitation::generateToken();
+    WorkspaceInvitation::factory()->create([
+        'email' => 'invited@example.com',
+        'token' => $hash,
+    ]);
+
+    $this->get(route('register', ['invitation' => $plain]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('auth/register')
+            ->where('invitation', $plain)
+            ->where('invitationEmail', 'invited@example.com'));
 });
 
 test('new users can register', function () {

--- a/tests/Feature/NotificationChannelsTest.php
+++ b/tests/Feature/NotificationChannelsTest.php
@@ -10,6 +10,7 @@ use App\Notifications\PostPublishedNotification;
 use App\Notifications\PublishFailedNotification;
 use App\Notifications\WorkspaceInviteNotification;
 use App\Support\Notifications\NotificationPreferences;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Support\Facades\Notification;
 
@@ -54,6 +55,19 @@ test('post published respects disabled preferences', function () {
     Notification::assertSentTo($user, PostPublishedNotification::class, function ($notification) use ($user) {
         return $notification->via($user) === ['database'];
     });
+});
+
+test('workspace invite to an existing user resolves to in-app and mail channels by default', function () {
+    $user = User::factory()->create();
+    $invitation = WorkspaceInvitation::factory()->create();
+    $notification = new WorkspaceInviteNotification($invitation, 'plain-token');
+
+    expect($notification)->toBeInstanceOf(ShouldQueue::class)
+        ->and($notification->via($user))->toBe(['database', 'mail'])
+        ->and($notification->viaConnections())->toBe([
+            'database' => 'sync',
+            'mail' => 'sync',
+        ]);
 });
 
 test('workspace invite to an unregistered email resolves to the mail channel', function () {

--- a/tests/Feature/NotificationReadTest.php
+++ b/tests/Feature/NotificationReadTest.php
@@ -6,7 +6,7 @@ use App\Models\User;
 use App\Models\Workspace;
 use Illuminate\Support\Str;
 
-function makeNotification(User $user, string $workspaceId, ?string $readAt = null): string
+function makeNotification(User $user, ?string $workspaceId, ?string $readAt = null): string
 {
     $id = (string) Str::uuid();
     $user->notifications()->create([
@@ -41,12 +41,13 @@ test('a user cannot mark another users notification read', function () {
     expect($owner->notifications()->find($id)->read_at)->toBeNull();
 });
 
-test('mark-all-read clears unread for the current workspace only', function () {
+test('mark-all-read clears unread for the current workspace and global notifications only', function () {
     $user = User::factory()->create();
     $wsA = Workspace::factory()->create();
     $wsB = Workspace::factory()->create();
     $user->forceFill(['current_workspace_id' => $wsA->id])->save();
     makeNotification($user, $wsA->id);
+    makeNotification($user, null);
     $bId = makeNotification($user, $wsB->id);
 
     $this->actingAs($user)->post(route('notifications.read-all'))->assertRedirect();

--- a/tests/Feature/NotificationSharedPropTest.php
+++ b/tests/Feature/NotificationSharedPropTest.php
@@ -36,6 +36,26 @@ test('shared notifications prop only includes current-workspace notifications', 
         );
 });
 
+test('shared notifications prop includes global notifications in the current workspace feed', function () {
+    $user = User::factory()->create();
+    $ws = Workspace::factory()->create();
+    $user->forceFill(['current_workspace_id' => $ws->id])->save();
+
+    $user->notifications()->create([
+        'id' => (string) Str::uuid(),
+        'type' => PostPublishedNotification::class,
+        'data' => ['event' => 'workspace_invite', 'title' => 'Workspace invitation', 'body' => '', 'href' => null, 'icon' => 'users', 'workspace_id' => null],
+        'read_at' => null,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertInertia(fn ($page) => $page
+            ->where('notifications.unreadCount', 1)
+            ->where('notifications.items.0.title', 'Workspace invitation')
+        );
+});
+
 test('notifications are ordered by id desc when created_at is identical', function () {
     $user = User::factory()->create();
     $ws = Workspace::factory()->create();

--- a/tests/Feature/Workspace/RegistrationWorkspaceTest.php
+++ b/tests/Feature/Workspace/RegistrationWorkspaceTest.php
@@ -21,7 +21,7 @@ test('registration creates a default owned workspace', function () {
     $this->assertSame(WorkspaceRole::Owner, $user->getMembershipForWorkspace($workspace->id)->role);
 });
 
-test('registration with invitation joins instead and verifies email', function () {
+test('registration with invitation creates a personal workspace and joins the invited workspace', function () {
     $workspace = Workspace::factory()->create();
     [$plain, $hash] = WorkspaceInvitation::generateToken();
     WorkspaceInvitation::factory()->create([
@@ -41,6 +41,36 @@ test('registration with invitation joins instead and verifies email', function (
     $user = User::where('email', 'invitee@example.com')->firstOrFail();
 
     $this->assertTrue($user->isMemberOfWorkspace($workspace->id));
-    $this->assertSame(1, Workspace::count()); // no personal workspace created
+    $this->assertSame($workspace->id, $user->current_workspace_id);
+    $this->assertSame(2, Workspace::count());
+
+    $personalWorkspace = Workspace::query()
+        ->where('owner_id', $user->id)
+        ->whereKeyNot($workspace->id)
+        ->firstOrFail();
+
+    $this->assertSame(WorkspaceRole::Owner, $user->getMembershipForWorkspace($personalWorkspace->id)->role);
     $this->assertNotNull($user->email_verified_at);
+});
+
+test('registration with invitation uses the invited email address', function () {
+    $workspace = Workspace::factory()->create();
+    [$plain, $hash] = WorkspaceInvitation::generateToken();
+    WorkspaceInvitation::factory()->create([
+        'workspace_id' => $workspace->id,
+        'email' => 'invited@example.com',
+        'token' => $hash,
+    ]);
+
+    $this->post(route('register', ['invitation' => $plain]), [
+        'name' => 'Invitee',
+        'email' => 'changed@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ]);
+
+    $user = User::where('email', 'invited@example.com')->firstOrFail();
+
+    expect(User::where('email', 'changed@example.com')->exists())->toBeFalse()
+        ->and($user->isMemberOfWorkspace($workspace->id))->toBeTrue();
 });

--- a/tests/Feature/Workspace/WorkspaceInvitationFlowTest.php
+++ b/tests/Feature/Workspace/WorkspaceInvitationFlowTest.php
@@ -3,20 +3,30 @@
 use App\Models\User;
 use App\Models\Workspace;
 use App\Models\WorkspaceInvitation;
+use App\Models\WorkspaceMembership;
 
 test('logged in invitee accepts via link', function () {
     $workspace = Workspace::factory()->create();
+    $currentWorkspace = Workspace::factory()->create();
     [$plain, $hash] = WorkspaceInvitation::generateToken();
     WorkspaceInvitation::factory()->create([
         'workspace_id' => $workspace->id,
         'email' => 'guest@example.com',
         'token' => $hash,
     ]);
-    $user = User::factory()->create(['email' => 'guest@example.com']);
+    $user = User::factory()->create([
+        'email' => 'guest@example.com',
+        'current_workspace_id' => $currentWorkspace->id,
+    ]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $currentWorkspace->id,
+        'user_id' => $user->id,
+    ]);
 
     $this->actingAs($user)->get(route('workspace.invitation', $plain))->assertRedirect(route('dashboard'));
 
     $this->assertTrue($user->fresh()->isMemberOfWorkspace($workspace->id));
+    $this->assertSame($workspace->id, $user->fresh()->current_workspace_id);
 });
 
 test('guest invitee sees acceptance page', function () {

--- a/tests/Feature/Workspace/WorkspaceMembersTest.php
+++ b/tests/Feature/Workspace/WorkspaceMembersTest.php
@@ -84,6 +84,26 @@ test('inviting an existing user sends an in-app notification to that user', func
     Notification::assertSentTo($existingUser, WorkspaceInviteNotification::class);
 });
 
+test('inviting an existing user stores the in-app notification immediately with the database queue default', function () {
+    config(['queue.default' => 'database', 'mail.default' => 'array']);
+    [$workspace, $owner] = ownerInWorkspace();
+    $existingUser = User::factory()->create(['email' => 'stored@example.com']);
+
+    $this->actingAs($owner)->post(route('settings.workspace.invite'), [
+        'email' => 'stored@example.com',
+        'role' => 'member',
+    ])->assertRedirect();
+
+    $notification = $existingUser->notifications()->first();
+
+    expect($existingUser->notifications()->count())->toBe(1)
+        ->and($notification?->data['title'])->toBe('Workspace invitation')
+        ->and($notification?->data['workspace_id'])->toBeNull()
+        ->and($notification?->data['invited_workspace_id'])->toBe($workspace->id);
+
+    $this->assertDatabaseCount('jobs', 0);
+});
+
 test('inviting an unknown email sends an on-demand mail notification without a model notification', function () {
     Notification::fake();
     [$workspace, $owner] = ownerInWorkspace();

--- a/tests/Feature/WorkspaceInvitationNotificationActionsTest.php
+++ b/tests/Feature/WorkspaceInvitationNotificationActionsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\NotificationType;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceInvitation;
+use App\Models\WorkspaceMembership;
+use App\Notifications\WorkspaceInviteNotification;
+use App\Support\Notifications\NotificationPresenter;
+use Illuminate\Support\Str;
+
+function inviteeWithWorkspaceInvitation(): array
+{
+    $workspace = Workspace::factory()->create();
+    $currentWorkspace = Workspace::factory()->create();
+    $invitee = User::factory()->create([
+        'email' => 'guest@example.com',
+        'current_workspace_id' => $currentWorkspace->id,
+    ]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $currentWorkspace->id,
+        'user_id' => $invitee->id,
+    ]);
+    $invitation = WorkspaceInvitation::factory()->create([
+        'workspace_id' => $workspace->id,
+        'email' => $invitee->email,
+    ]);
+    $notificationId = (string) Str::uuid();
+
+    $invitee->notifications()->create([
+        'id' => $notificationId,
+        'type' => WorkspaceInviteNotification::class,
+        'data' => [
+            'event' => NotificationType::WorkspaceInvite->value,
+            'title' => 'Workspace invitation',
+            'body' => $workspace->name.' invited you to collaborate.',
+            'href' => null,
+            'icon' => 'users',
+            'workspace_id' => null,
+            'invited_workspace_id' => $workspace->id,
+            'invitation_id' => $invitation->id,
+        ],
+        'read_at' => null,
+    ]);
+
+    return [$invitee, $workspace, $invitation, $notificationId];
+}
+
+test('workspace invite notifications include accept and deny actions', function () {
+    [$invitee, , $invitation] = inviteeWithWorkspaceInvitation();
+
+    $item = NotificationPresenter::item($invitee->notifications()->first());
+
+    expect($item['actions'])->toBe([
+        [
+            'key' => 'accept',
+            'label' => 'Accept',
+            'variant' => 'primary',
+            'method' => 'post',
+            'href' => route('workspace.invitations.accept', $invitation, absolute: false),
+        ],
+        [
+            'key' => 'deny',
+            'label' => 'Deny',
+            'variant' => 'secondary',
+            'method' => 'delete',
+            'href' => route('workspace.invitations.deny', $invitation, absolute: false),
+        ],
+    ]);
+});
+
+test('invitee can accept a workspace invitation from a notification action', function () {
+    [$invitee, $workspace, $invitation, $notificationId] = inviteeWithWorkspaceInvitation();
+
+    $this->actingAs($invitee)
+        ->post(route('workspace.invitations.accept', $invitation))
+        ->assertRedirect(route('dashboard'));
+
+    expect($invitee->fresh()->isMemberOfWorkspace($workspace->id))->toBeTrue()
+        ->and($invitee->fresh()->current_workspace_id)->toBe($workspace->id)
+        ->and($invitation->fresh()->accepted_at)->not->toBeNull()
+        ->and($invitee->notifications()->find($notificationId))->toBeNull();
+});
+
+test('invitee can deny a workspace invitation from a notification action', function () {
+    [$invitee, , $invitation, $notificationId] = inviteeWithWorkspaceInvitation();
+
+    $this->actingAs($invitee)
+        ->delete(route('workspace.invitations.deny', $invitation))
+        ->assertRedirect();
+
+    expect(WorkspaceInvitation::find($invitation->id))->toBeNull()
+        ->and($invitee->notifications()->find($notificationId))->toBeNull();
+});
+
+test('another user cannot answer someone elses invitation notification', function () {
+    [, , $invitation] = inviteeWithWorkspaceInvitation();
+    $other = User::factory()->create(['email' => 'other@example.com']);
+
+    $this->actingAs($other)
+        ->post(route('workspace.invitations.accept', $invitation))
+        ->assertNotFound();
+
+    expect(WorkspaceMembership::where('workspace_id', $invitation->workspace_id)->exists())->toBeFalse()
+        ->and($invitation->fresh())->not->toBeNull();
+});


### PR DESCRIPTION
## Summary
- Add in-app Accept and Deny actions for workspace invitation notifications.
- Ensure invitation notifications are delivered immediately and shown across the current workspace notification feed.
- Preserve invitation tokens through login/register, lock registration to the invited email, and land invitees in the invited workspace after acceptance.
- Add coverage for invitation registration, notification actions, delivery channels, and read-state behavior.