### PR TITLE
Composer: paste-to-upload, always-visible composer, X remove icon

### DIFF
--- a/resources/js/components/compose/__tests__/editor-body.test.ts
+++ b/resources/js/components/compose/__tests__/editor-body.test.ts
@@ -1,11 +1,58 @@
 import { describe, expect, it } from 'vitest';
 
-import { shouldFocusEditorOnMount } from '../editor-body';
+import {
+    hasPasteableMedia,
+    isPasteableMediaFile,
+    shouldFocusEditorOnMount,
+} from '../editor-body';
+
+function file(type: string): File {
+    return new File(['x'], 'clip', { type });
+}
+
+function fileList(...files: File[]): FileList {
+    const indexed: Record<number, File> = {};
+    files.forEach((f, i) => {
+        indexed[i] = f;
+    });
+
+    return {
+        ...indexed,
+        length: files.length,
+        item: (i: number) => files[i] ?? null,
+        [Symbol.iterator]: () => files[Symbol.iterator](),
+    } as unknown as FileList;
+}
 
 describe('shouldFocusEditorOnMount', () => {
     it('focuses only when autofocus is requested and the editor is editable', () => {
         expect(shouldFocusEditorOnMount(true, true)).toBe(true);
         expect(shouldFocusEditorOnMount(false, true)).toBe(false);
         expect(shouldFocusEditorOnMount(true, false)).toBe(false);
+    });
+});
+
+describe('isPasteableMediaFile', () => {
+    it('accepts images and videos, rejects everything else', () => {
+        expect(isPasteableMediaFile(file('image/png'))).toBe(true);
+        expect(isPasteableMediaFile(file('video/mp4'))).toBe(true);
+        expect(isPasteableMediaFile(file('text/plain'))).toBe(false);
+        expect(isPasteableMediaFile(file('application/pdf'))).toBe(false);
+    });
+});
+
+describe('hasPasteableMedia', () => {
+    it('is true when at least one pasted file is an image or video', () => {
+        expect(hasPasteableMedia(fileList(file('image/jpeg')))).toBe(true);
+        expect(
+            hasPasteableMedia(fileList(file('text/plain'), file('video/mp4'))),
+        ).toBe(true);
+    });
+
+    it('is false for an empty, null, or text-only clipboard', () => {
+        expect(hasPasteableMedia(fileList())).toBe(false);
+        expect(hasPasteableMedia(null)).toBe(false);
+        expect(hasPasteableMedia(undefined)).toBe(false);
+        expect(hasPasteableMedia(fileList(file('text/html')))).toBe(false);
     });
 });

--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -1,10 +1,9 @@
 import { Image as ImageIcon, Shuffle, Split } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
-import { useMediaUploads } from '@/hooks/compose/use-media-uploads';
 import { cn } from '@/lib/utils';
-import type { MediaView, PlatformLimits, PlatformName } from '@/types/compose';
+import type { MediaView, PendingUpload, PlatformName } from '@/types/compose';
 
 import { MediaChips } from './media-chips';
 
@@ -16,20 +15,20 @@ type Props = {
     /** When false, hides Override + Auto-split (generic tab has no platform). */
     showSplitControls?: boolean;
     media: MediaView[];
-    onAddMedia: (media: MediaView) => void;
     onRemove: (mediaId: string) => void;
     onReorder: (ids: string[]) => void;
     onToggleAutoSplit: () => void;
     onToggleOverride: () => void;
     isExcluded: (mediaId: string) => boolean;
     onToggleExclude: (mediaId: string) => void;
-    /** Guarantee a persisted post id before uploading; returns the post id. */
-    onEnsurePost: () => Promise<string>;
     /** Read-only post: show attached media, hide all editing controls. */
     readOnly?: boolean;
-    videoLimits: PlatformLimits[];
-    /** Reports whether any media upload is currently in flight. */
-    onUploadingChange?: (uploading: boolean) => void;
+    /** In-flight uploads (owned by the parent's useMediaUploads). */
+    pending: PendingUpload[];
+    /** Validate + upload a picked/dropped batch. */
+    handleFiles: (files: FileList) => Promise<void>;
+    /** Drop a failed/pending upload chip. */
+    dismissPending: (tempId: string) => void;
 };
 
 export function ComposerToolbar({
@@ -38,28 +37,18 @@ export function ComposerToolbar({
     overrideActive,
     showSplitControls = true,
     media,
-    onAddMedia,
     onRemove,
     onReorder,
     onToggleAutoSplit,
     onToggleOverride,
     isExcluded,
     onToggleExclude,
-    onEnsurePost,
     readOnly = false,
-    videoLimits,
-    onUploadingChange,
+    pending,
+    handleFiles,
+    dismissPending,
 }: Props) {
     const input = useRef<HTMLInputElement | null>(null);
-    const { pending, isUploading, handleFiles, dismissPending } =
-        useMediaUploads({ media, videoLimits, onEnsurePost, onAddMedia });
-
-    // Surface in-flight uploads so the parent can block publish/schedule until
-    // every attachment has finished (a still-uploading file isn't yet in `media`,
-    // so publishing mid-upload would omit it).
-    useEffect(() => {
-        onUploadingChange?.(isUploading);
-    }, [isUploading, onUploadingChange]);
 
     // Process a picked/dropped batch, then reset the input so re-picking the same
     // file fires onChange again.

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useReducer, useRef, useState } from 'react';
 
 import WorkspaceMentionController from '@/actions/App/Http/Controllers/WorkspaceMentionController';
 import { useAutosave } from '@/hooks/compose/use-autosave';
+import { useMediaUploads } from '@/hooks/compose/use-media-uploads';
 import { useNextSlot } from '@/hooks/compose/use-next-slot';
 import { usePublishStatus } from '@/hooks/compose/use-publish-status';
 import { useSchedulingTimezone } from '@/hooks/posts/use-scheduling-timezone';
@@ -106,8 +107,6 @@ export default function Composer({
     useEffect(() => {
         setSavedMentions(initialSavedMentions);
     }, [initialSavedMentions]);
-    // True while any attachment is still uploading — blocks publish/schedule.
-    const [mediaUploading, setMediaUploading] = useState(false);
     const [state, dispatch] = useReducer(composerReducer, post, (p) =>
         p
             ? composerReducer(initialComposerState(), {
@@ -156,6 +155,16 @@ export default function Composer({
         dispatch,
     });
     const publishStatus = usePublishStatus({ pagePost: post });
+
+    // Owns the media-upload pipeline (image/video validation + upload). Lifted
+    // here so both the editor (⌘/Ctrl+V paste) and the toolbar (picker/drop)
+    // feed the same handleFiles and share one in-flight `pending` list.
+    const mediaUploads = useMediaUploads({
+        media: state.media,
+        videoLimits: selectedVideoLimits,
+        onEnsurePost: ensurePost,
+        onAddMedia: (m) => dispatch({ type: 'addMedia', media: m }),
+    });
 
     // Persist a destination change immediately rather than waiting out the
     // autosave debounce. This MUST run in an effect — AFTER the reducer commits
@@ -388,6 +397,7 @@ export default function Composer({
                 onBlur={flush}
                 editable={!readOnly}
                 autoFocus={autoFocusEditor}
+                onPasteFiles={readOnly ? undefined : mediaUploads.handleFiles}
                 overrideBanner={overrideActive}
                 activePlatformLabel={activeAccount?.platform ?? null}
                 onResetOverride={() =>
@@ -467,7 +477,6 @@ export default function Composer({
                     overrideActive={overrideActive}
                     showSplitControls={activeAccount !== null}
                     media={state.media}
-                    onAddMedia={(m) => dispatch({ type: 'addMedia', media: m })}
                     onRemove={(id) =>
                         dispatch({ type: 'removeMedia', mediaId: id })
                     }
@@ -514,9 +523,9 @@ export default function Composer({
                             accountId: activeAccount.id,
                         })
                     }
-                    onEnsurePost={ensurePost}
-                    videoLimits={selectedVideoLimits}
-                    onUploadingChange={setMediaUploading}
+                    pending={mediaUploads.pending}
+                    handleFiles={mediaUploads.handleFiles}
+                    dismissPending={mediaUploads.dismissPending}
                 />
             )}
 
@@ -536,7 +545,7 @@ export default function Composer({
                         postId={state.postId}
                         disabled={accounts.length === 0}
                         queueDisabled={queueState.status !== 'found'}
-                        uploading={mediaUploading}
+                        uploading={mediaUploads.isUploading}
                         onSaveDraft={flush}
                         onEnsurePost={ensurePost}
                         onOptimisticSubmit={publishStatus.applyOptimistic}

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -47,6 +47,11 @@ type EditorBodyProps = {
     /** Focus the editor when it mounts. */
     autoFocus?: boolean;
     /**
+     * Handle image/video files pasted (⌘/Ctrl+V) into the editor. Omit on a
+     * read-only post to disable paste-to-upload.
+     */
+    onPasteFiles?: (files: FileList) => void;
+    /**
      * Active platform + splitting config pushed into the section-markers plugin
      * whenever the active tab changes. Omit to leave markers at their defaults.
      */
@@ -79,12 +84,23 @@ export function shouldFocusEditorOnMount(
     return autoFocus && editable;
 }
 
+/** A file we attach on paste/drop — images and videos only. */
+export function isPasteableMediaFile(file: File): boolean {
+    return file.type.startsWith('image/') || file.type.startsWith('video/');
+}
+
+/** True when a paste carries at least one image/video we should intercept. */
+export function hasPasteableMedia(files: FileList | null | undefined): boolean {
+    return !!files && Array.from(files).some(isPasteableMediaFile);
+}
+
 export default function EditorBody({
     value,
     onChange,
     onBlur,
     placeholder,
     autoFocus = false,
+    onPasteFiles,
     overrideBanner = false,
     activePlatformLabel,
     onResetOverride,
@@ -102,10 +118,27 @@ export default function EditorBody({
     const [activeMentionId, setActiveMentionId] = useState<string | null>(null);
     const previousMentionCount = useRef(mentions.length);
     const mentionNameInput = useRef<HTMLInputElement>(null);
+    // editorProps is captured once at editor creation, but onPasteFiles is a
+    // fresh closure each render (it reads the current media/limits). Route through
+    // a ref so handlePaste always enforces the latest one-video / no-mixing rule.
+    const onPasteFilesRef = useRef(onPasteFiles);
+    onPasteFilesRef.current = onPasteFiles;
     const editor = useEditor({
         extensions: composerExtensions({ placeholder }),
         content: baseTextToDoc(value) as object,
         editable,
+        editorProps: {
+            handlePaste: (_view, event) => {
+                const files = event.clipboardData?.files;
+                if (!onPasteFilesRef.current || !hasPasteableMedia(files)) {
+                    return false;
+                }
+                event.preventDefault();
+                onPasteFilesRef.current(files as FileList);
+
+                return true;
+            },
+        },
         onUpdate: ({ editor }) =>
             onChange(docToBaseText(editor.getJSON() as DocNode)),
         onBlur,

--- a/resources/js/components/compose/media-chips.tsx
+++ b/resources/js/components/compose/media-chips.tsx
@@ -1,3 +1,4 @@
+import { X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 
@@ -188,7 +189,10 @@ export function MediaChips({
                                     label="Remove"
                                     onClick={() => onRemove(m.id)}
                                 >
-                                    ×
+                                    <X
+                                        className="size-2.5 text-black"
+                                        aria-hidden="true"
+                                    />
                                 </CornerButton>
                             </div>
                         </TooltipTrigger>
@@ -253,7 +257,10 @@ export function MediaChips({
                                     onClick={() => onDismissPending(p.tempId)}
                                     always
                                 >
-                                    ×
+                                    <X
+                                        className="size-2.5 text-black"
+                                        aria-hidden="true"
+                                    />
                                 </CornerButton>
                             )}
                         </div>

--- a/resources/js/lib/dashboard/accounts.ts
+++ b/resources/js/lib/dashboard/accounts.ts
@@ -1,9 +1,3 @@
-export function shouldShowDashboardPublishingSection(
-    accounts: unknown[],
-): boolean {
-    return accounts.length > 0;
-}
-
 export function canManageConnectedAccounts(permissions: string[]): boolean {
     return permissions.includes('workspace.accounts.manage');
 }

--- a/resources/js/pages/__tests__/dashboard.test.ts
+++ b/resources/js/pages/__tests__/dashboard.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
     canManageConnectedAccounts,
     shouldShowDashboardNoAccountsNotice,
-    shouldShowDashboardPublishingSection,
 } from '@/lib/dashboard/accounts';
 
 describe('canManageConnectedAccounts', () => {
@@ -14,15 +13,6 @@ describe('canManageConnectedAccounts', () => {
                 'workspace.read',
                 'workspace.accounts.manage',
             ]),
-        ).toBe(true);
-    });
-});
-
-describe('shouldShowDashboardPublishingSection', () => {
-    it('shows the composer only when the workspace has accounts', () => {
-        expect(shouldShowDashboardPublishingSection([])).toBe(false);
-        expect(
-            shouldShowDashboardPublishingSection([{ id: 'account-1' }]),
         ).toBe(true);
     });
 });

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -16,10 +16,7 @@ import {
     EmptyTitle,
 } from '@/components/ui/empty';
 import { parseDestinationParam } from '@/lib/compose/composer-state';
-import {
-    shouldShowDashboardNoAccountsNotice,
-    shouldShowDashboardPublishingSection,
-} from '@/lib/dashboard/accounts';
+import { shouldShowDashboardNoAccountsNotice } from '@/lib/dashboard/accounts';
 import { dashboard } from '@/routes';
 import { index as accountsRoute } from '@/routes/accounts';
 import type { OnboardingData } from '@/types';
@@ -73,9 +70,6 @@ export default function Dashboard({ posts, onboarding, savedMentions }: Props) {
     const page = usePage();
     const { auth, shell, workspaces } = page.props;
     const firstName = (auth.user?.name ?? '').split(/\s+/)[0] || 'there';
-    const showPublishingSection = shouldShowDashboardPublishingSection(
-        shell.accounts,
-    );
     const showNoAccountsNotice = shouldShowDashboardNoAccountsNotice(
         shell.accounts,
         workspaces.current?.permissions ?? [],
@@ -117,18 +111,16 @@ export default function Dashboard({ posts, onboarding, savedMentions }: Props) {
 
                 {showNoAccountsNotice && <NoAccountsNotice />}
 
-                {showPublishingSection && (
-                    <Composer
-                        post={null}
-                        accounts={shell.accounts}
-                        sets={shell.sets}
-                        limits={shell.limits}
-                        initialScheduleAt={initialScheduleAt}
-                        initialDestination={initialDestination}
-                        initialSavedMentions={savedMentions}
-                        autoFocusEditor
-                    />
-                )}
+                <Composer
+                    post={null}
+                    accounts={shell.accounts}
+                    sets={shell.sets}
+                    limits={shell.limits}
+                    initialScheduleAt={initialScheduleAt}
+                    initialDestination={initialDestination}
+                    initialSavedMentions={savedMentions}
+                    autoFocusEditor
+                />
 
                 <Deferred data="posts" fallback={<RecentFeedSkeleton />}>
                     <RecentFeed posts={posts ?? []} />


### PR DESCRIPTION
Three composer/dashboard QoL fixes (one commit each).

## 1. Paste images/videos with ⌘/Ctrl+V
Pasting an image (e.g. a screenshot) or video file into the editor now attaches it, matching the file picker and drag-and-drop.

- Lifted `useMediaUploads` from `ComposerToolbar` up to `Composer`, so the editor (paste) and the toolbar (picker/drop) share one upload pipeline and `pending` list.
- Added a TipTap `handlePaste` handler that intercepts image/video files on the clipboard and routes them through the existing `handleFiles` — same validation, the one-video/no-mixing rule, progress chips, and publish-blocking while uploading. Plain-text paste is untouched; paste is disabled on read-only posts.
- `handlePaste` reads the callback through a ref so it always enforces the latest media/limits, not a stale editor-creation closure.
- Added unit tests for the new `isPasteableMediaFile` / `hasPasteableMedia` helpers.

## 2. Always render the dashboard composer
`ef17adff` removed the `accounts.length > 0` gate so the composer shows even with no connected accounts, but the `platform-mention-selector` merge branched off before it and restored the gated version — re-hiding the composer. Dropped the gate again and removed the now-dead `shouldShowDashboardPublishingSection` helper + test. The read-only no-accounts notice is unchanged; Publish stays disabled when there are no accounts.

## 3. Black X icon on the media remove button
Replaced the low-contrast `×` glyph with the lucide `X` icon, forced black so it reads against the red destructive button in both themes. Applied to both the remove and dismiss-failed-upload buttons.

## Verification
- `tsc` clean, `oxlint` clean, `oxfmt` clean
- vitest 176/176 (incl. new helper tests)
- Not browser-verified locally (no chromium in this env) — paste/visual changes need an eyeball in the running app.