### PR TITLE
feat(composer): support text-only platform mentions

### DIFF
--- a/app/Http/Controllers/WorkspaceMentionController.php
+++ b/app/Http/Controllers/WorkspaceMentionController.php
@@ -29,9 +29,7 @@ class WorkspaceMentionController extends Controller
         foreach ($allowedPlatforms as $platform) {
             $handle = trim((string) ($validated['handles'][$platform] ?? ''));
             if ($handle !== '') {
-                $handles[$platform] = str_starts_with($handle, '@')
-                    ? $handle
-                    : '@'.$handle;
+                $handles[$platform] = $handle;
             }
         }
 

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -15,8 +15,10 @@ import {
 } from '@/components/ui/popover';
 import {
     mentionInputValue,
+    setPlatformMentionMode,
     updateMentionHandle,
     updateMentionName,
+    usesPlatformMention,
 } from '@/lib/compose/mentions';
 import {
     baseTextToDoc,
@@ -384,46 +386,88 @@ export default function EditorBody({
                                 Platform handles
                             </div>
                             <div className="flex flex-col gap-2">
-                                {activePlatforms.map((platform, index) => (
-                                    <label
-                                        key={platform}
-                                        className="flex flex-col gap-1.5 text-xs"
-                                    >
-                                        <span className="inline-flex items-center gap-1.5 text-muted-foreground">
-                                            <PlatformGlyph
-                                                platform={platform}
-                                                size={14}
-                                                className="text-foreground"
-                                            />
-                                            <span className="capitalize">
-                                                {platform}
+                                {activePlatforms.map((platform, index) => {
+                                    const useMention = usesPlatformMention(
+                                        activeMention,
+                                        platform,
+                                    );
+                                    const value =
+                                        activeMention.handles[platform] ??
+                                        activeMention.label;
+
+                                    return (
+                                        <label
+                                            key={platform}
+                                            className="flex flex-col gap-1.5 text-xs"
+                                        >
+                                            <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                                                <PlatformGlyph
+                                                    platform={platform}
+                                                    size={14}
+                                                    className="text-foreground"
+                                                />
+                                                <span className="capitalize">
+                                                    {platform}
+                                                </span>
                                             </span>
-                                        </span>
-                                        <InputGroup className="h-9 rounded-lg border-border bg-background">
-                                            <InputGroupAddon>@</InputGroupAddon>
-                                            <InputGroupInput
-                                                value={mentionInputValue(
-                                                    activeMention.handles[
-                                                        platform
-                                                    ] ?? '',
-                                                )}
-                                                placeholder="handle"
-                                                aria-label={`${platform} handle for ${activeMention.label}`}
-                                                onChange={(event) =>
-                                                    updateMention(
-                                                        activeMention,
-                                                        updateMentionHandle(
+                                            <div className="flex gap-2">
+                                                <InputGroup className="h-9 min-w-0 flex-1 rounded-lg border-border bg-background">
+                                                    {useMention && (
+                                                        <InputGroupAddon>
+                                                            @
+                                                        </InputGroupAddon>
+                                                    )}
+                                                    <InputGroupInput
+                                                        value={mentionInputValue(
+                                                            value,
+                                                        )}
+                                                        placeholder={
+                                                            useMention
+                                                                ? 'handle'
+                                                                : 'display name'
+                                                        }
+                                                        aria-label={`${platform} ${
+                                                            useMention
+                                                                ? 'handle'
+                                                                : 'display text'
+                                                        } for ${activeMention.label}`}
+                                                        onChange={(event) =>
+                                                            updateMention(
+                                                                activeMention,
+                                                                updateMentionHandle(
+                                                                    activeMention,
+                                                                    platform,
+                                                                    event.target
+                                                                        .value,
+                                                                    useMention,
+                                                                ),
+                                                            )
+                                                        }
+                                                        autoFocus={index === 0}
+                                                    />
+                                                </InputGroup>
+                                                <button
+                                                    type="button"
+                                                    className="h-9 shrink-0 rounded-lg border border-border px-2.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+                                                    onClick={() =>
+                                                        updateMention(
                                                             activeMention,
-                                                            platform,
-                                                            event.target.value,
-                                                        ),
-                                                    )
-                                                }
-                                                autoFocus={index === 0}
-                                            />
-                                        </InputGroup>
-                                    </label>
-                                ))}
+                                                            setPlatformMentionMode(
+                                                                activeMention,
+                                                                platform,
+                                                                !useMention,
+                                                            ),
+                                                        )
+                                                    }
+                                                >
+                                                    {useMention
+                                                        ? 'Use text only'
+                                                        : 'Use @ mention'}
+                                                </button>
+                                            </div>
+                                        </label>
+                                    );
+                                })}
                             </div>
                             {onSaveMention && (
                                 <button

--- a/resources/js/lib/compose/__tests__/mentions.test.ts
+++ b/resources/js/lib/compose/__tests__/mentions.test.ts
@@ -5,8 +5,10 @@ import {
     mentionInputValue,
     mentionToken,
     replaceMentionTokens,
+    setPlatformMentionMode,
     updateMentionHandle,
     syncMentionsFromText,
+    usesPlatformMention,
     type MentionPlaceholder,
 } from '../mentions';
 
@@ -52,6 +54,41 @@ describe('mention helpers', () => {
         expect(updateMentionHandle(mention, 'x', 'guest_x').handles.x).toBe(
             '@guest_x',
         );
+    });
+
+    it('can store plain display text for a platform instead of an @ mention', () => {
+        const mention: MentionPlaceholder = {
+            id: 'guest',
+            label: '@guest',
+            handles: { linkedin: '@guest' },
+        };
+
+        const text = updateMentionHandle(
+            mention,
+            'linkedin',
+            'Guest LinkedIn',
+            false,
+        );
+
+        expect(text.handles.linkedin).toBe('Guest LinkedIn');
+        expect(usesPlatformMention(text, 'linkedin')).toBe(false);
+        expect(
+            replaceMentionTokens('Hi {{mention:guest}}', [text], 'linkedin'),
+        ).toBe('Hi Guest LinkedIn');
+    });
+
+    it('toggles a platform between @ mention and display text', () => {
+        const mention: MentionPlaceholder = {
+            id: 'guest',
+            label: '@guest',
+            handles: { linkedin: '@guest' },
+        };
+
+        const text = setPlatformMentionMode(mention, 'linkedin', false);
+        const atMention = setPlatformMentionMode(text, 'linkedin', true);
+
+        expect(text.handles.linkedin).toBe('guest');
+        expect(atMention.handles.linkedin).toBe('@guest');
     });
 
     it('shows mention inputs without the permanent @ prefix', () => {

--- a/resources/js/lib/compose/mentions.ts
+++ b/resources/js/lib/compose/mentions.ts
@@ -49,16 +49,41 @@ export function updateMentionHandle(
     mention: MentionPlaceholder,
     platform: PlatformName,
     handle: string,
+    useMention = true,
 ): MentionPlaceholder {
     const handles = { ...mention.handles };
     const trimmed = handle.trim();
     if (trimmed === '') {
         delete handles[platform];
     } else {
-        handles[platform] = normalizeMentionName(trimmed);
+        handles[platform] = useMention
+            ? normalizeMentionName(trimmed)
+            : trimmed;
     }
 
     return { ...mention, handles };
+}
+
+export function usesPlatformMention(
+    mention: MentionPlaceholder,
+    platform: PlatformName,
+): boolean {
+    return (mention.handles[platform] ?? mention.label).startsWith('@');
+}
+
+export function setPlatformMentionMode(
+    mention: MentionPlaceholder,
+    platform: PlatformName,
+    useMention: boolean,
+): MentionPlaceholder {
+    const current = mention.handles[platform] ?? mention.label;
+
+    return updateMentionHandle(
+        mention,
+        platform,
+        mentionInputValue(current),
+        useMention,
+    );
 }
 
 export function syncMentionsFromText(

--- a/tests/Feature/WorkspaceMentionTest.php
+++ b/tests/Feature/WorkspaceMentionTest.php
@@ -50,7 +50,7 @@ it('updates an existing saved mention by workspace and name', function () {
         ->and(WorkspaceMention::query()->first()->handles)->toBe(['x' => '@new']);
 });
 
-it('preadds at signs to saved handles', function () {
+it('preserves saved handles as submitted', function () {
     $user = User::factory()->create();
     $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
     $user->forceFill(['current_workspace_id' => $workspace->id])->save();
@@ -62,5 +62,20 @@ it('preadds at signs to saved handles', function () {
             'handles' => ['x' => 'taylorotwell'],
         ])
         ->assertSuccessful()
-        ->assertJsonPath('mention.handles.x', '@taylorotwell');
+        ->assertJsonPath('mention.handles.x', 'taylorotwell');
+});
+
+it('preserves saved display text for people without a platform mention', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    Context::add('workspace_id', $workspace->id);
+
+    $this->actingAs($user)
+        ->postJson(route('workspace-mentions.store'), [
+            'name' => '@taylor',
+            'handles' => ['linkedin' => 'Taylor Otwell'],
+        ])
+        ->assertSuccessful()
+        ->assertJsonPath('mention.handles.linkedin', 'Taylor Otwell');
 });


### PR DESCRIPTION
## Summary
- Add a per-platform composer option to use plain display text instead of an @ mention.
- Preserve saved mention handles exactly as submitted so text-only platform values are not forced to include @.
- Update mention helper and workspace mention tests for text-only fallback behavior.