### PR TITLE
Automatic per-platform image compression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,8 @@ RUN docker-php-serversideup-set-id www-data ${USER_ID}:${GROUP_ID} \
     && docker-php-serversideup-set-file-permissions --owner ${USER_ID}:${GROUP_ID}
 
 # Redis extension for optional Redis cache/queue (pdo_pgsql ships in the image)
-RUN install-php-extensions redis
+# gd + exif: required by intervention/image for runtime image compression
+RUN install-php-extensions redis gd exif
 
 # System packages + Bun (needed when SSR is toggled on: inertia:start-ssr --runtime=bun)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/app/Http/Requests/Post/StorePostMediaRequest.php
+++ b/app/Http/Requests/Post/StorePostMediaRequest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Post;
 
+use App\Services\Media\ImageCompressor;
+use Closure;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\UploadedFile;
 
 class StorePostMediaRequest extends FormRequest
 {
@@ -24,8 +27,29 @@ class StorePostMediaRequest extends FormRequest
                 'file',
                 'mimetypes:image/jpeg,image/png,image/webp,image/gif',
                 'max:8192', // KiB (8 MiB, LinkedIn's cap — the most permissive)
+                $this->withinPixelCeiling(...),
             ],
             'alt_text' => ['nullable', 'string', 'max:1000'],
         ];
+    }
+
+    /**
+     * Reject images whose pixel count exceeds the compressor's decode ceiling. Reads the
+     * header only (no canvas allocation), so a decompression-bomb is refused at the gate
+     * with a clear error rather than failing opaquely when a platform later rejects it.
+     */
+    private function withinPixelCeiling(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! $value instanceof UploadedFile) {
+            return;
+        }
+
+        $ceiling = (int) config('media.max_image_pixels', ImageCompressor::DEFAULT_MAX_PIXELS);
+
+        $info = @getimagesize($value->getRealPath());
+
+        if (is_array($info) && ($info[0] * $info[1]) > $ceiling) {
+            $fail('The image resolution is too large.');
+        }
     }
 }

--- a/app/Services/Media/CompressionResult.php
+++ b/app/Services/Media/CompressionResult.php
@@ -17,8 +17,8 @@ final class CompressionResult
         return new self($bytes, $mime, false);
     }
 
-    public static function compressed(string $bytes): self
+    public static function compressed(string $bytes, string $mime): self
     {
-        return new self($bytes, 'image/jpeg', true);
+        return new self($bytes, $mime, true);
     }
 }

--- a/app/Services/Media/CompressionResult.php
+++ b/app/Services/Media/CompressionResult.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Media;
+
+final class CompressionResult
+{
+    public function __construct(
+        public readonly string $bytes,
+        public readonly string $mime,
+        public readonly bool $wasCompressed,
+    ) {}
+
+    public static function untouched(string $bytes, string $mime): self
+    {
+        return new self($bytes, $mime, false);
+    }
+
+    public static function compressed(string $bytes): self
+    {
+        return new self($bytes, 'image/jpeg', true);
+    }
+}

--- a/app/Services/Media/ImageCompressor.php
+++ b/app/Services/Media/ImageCompressor.php
@@ -14,7 +14,7 @@ use Throwable;
  * Images already within the limit (or GIFs, or undecodable bytes) are
  * returned untouched.
  */
-final class ImageCompressor
+class ImageCompressor
 {
     private const int QUALITY_START = 82;
 

--- a/app/Services/Media/ImageCompressor.php
+++ b/app/Services/Media/ImageCompressor.php
@@ -10,17 +10,21 @@ use Intervention\Image\ImageManager;
 use Throwable;
 
 /**
- * Re-encodes an oversized image to JPEG so it fits a target byte limit.
- * Images already within the limit (or GIFs, or undecodable bytes) are
- * returned untouched.
+ * Re-encodes an oversized image to fit a target byte limit while keeping as much quality
+ * as the budget allows: it picks the highest encoder quality that fits before downscaling,
+ * and prefers WebP over JPEG when the target platform accepts it (WebP is smaller at equal
+ * quality and preserves alpha). Images already within the limit (or GIFs, oversized-canvas
+ * images, or undecodable bytes) are returned untouched.
  */
 class ImageCompressor
 {
-    private const int QUALITY_START = 82;
+    public const int DEFAULT_MAX_PIXELS = 50_000_000;
 
-    private const int QUALITY_FLOOR = 40;
+    private const int QUALITY_CEIL = 92;
 
-    private const int QUALITY_STEP = 7;
+    private const int QUALITY_FLOOR = 50;
+
+    private const int QUALITY_STEP = 6;
 
     private const int DIMENSION_FLOOR = 640;
 
@@ -32,9 +36,14 @@ class ImageCompressor
      *                          file, enormous canvas) cannot OOM the publish worker. The
      *                          default comfortably exceeds every platform's max dimensions.
      */
-    public function __construct(private readonly int $maxPixels = 50_000_000) {}
+    public function __construct(private readonly int $maxPixels = self::DEFAULT_MAX_PIXELS) {}
 
-    public function compressToFit(string $bytes, int $maxBytes, string $mime): CompressionResult
+    /**
+     * @param  list<string>  $allowedMimes  The target platform's accepted image mime types,
+     *                                      used to choose the output format (WebP when the
+     *                                      platform allows it, otherwise JPEG).
+     */
+    public function compressToFit(string $bytes, int $maxBytes, string $mime, array $allowedMimes): CompressionResult
     {
         if (strlen($bytes) <= $maxBytes) {
             return CompressionResult::untouched($bytes, $mime);
@@ -57,14 +66,23 @@ class ImageCompressor
             return CompressionResult::untouched($bytes, $mime);
         }
 
+        // Prefer WebP where the platform accepts it: at a given byte budget it keeps
+        // noticeably more quality than JPEG (and preserves alpha). Otherwise use JPEG.
+        $useWebp = in_array('image/webp', $allowedMimes, true) && function_exists('imagewebp');
+        $format = $useWebp ? Format::WEBP : Format::JPEG;
+        $outMime = $useWebp ? 'image/webp' : 'image/jpeg';
+
         $longestEdge = max($image->width(), $image->height());
 
         while (true) {
-            for ($quality = self::QUALITY_START; $quality >= self::QUALITY_FLOOR; $quality -= self::QUALITY_STEP) {
-                $encoded = (string) $image->encodeUsingFormat(Format::JPEG, quality: $quality);
+            // Walk quality down from the ceiling and take the first (highest) encoding that
+            // fits, so we preserve as much quality as the byte budget allows before resorting
+            // to downscaling.
+            for ($quality = self::QUALITY_CEIL; $quality >= self::QUALITY_FLOOR; $quality -= self::QUALITY_STEP) {
+                $encoded = (string) $image->encodeUsingFormat($format, quality: $quality);
 
                 if (strlen($encoded) <= $maxBytes) {
-                    return CompressionResult::compressed($encoded);
+                    return CompressionResult::compressed($encoded, $outMime);
                 }
             }
 

--- a/app/Services/Media/ImageCompressor.php
+++ b/app/Services/Media/ImageCompressor.php
@@ -26,6 +26,14 @@ class ImageCompressor
 
     private const float DOWNSCALE_FACTOR = 0.85;
 
+    /**
+     * @param  int  $maxPixels  Decode guard: images whose pixel count exceeds this are left
+     *                          untouched rather than decoded, so a decompression-bomb (tiny
+     *                          file, enormous canvas) cannot OOM the publish worker. The
+     *                          default comfortably exceeds every platform's max dimensions.
+     */
+    public function __construct(private readonly int $maxPixels = 50_000_000) {}
+
     public function compressToFit(string $bytes, int $maxBytes, string $mime): CompressionResult
     {
         if (strlen($bytes) <= $maxBytes) {
@@ -33,6 +41,13 @@ class ImageCompressor
         }
 
         if ($mime === 'image/gif') {
+            return CompressionResult::untouched($bytes, $mime);
+        }
+
+        // Read dimensions from the header only (no canvas allocation) and refuse to decode
+        // pathologically large images, guarding the worker against decompression bombs.
+        $info = @getimagesizefromstring($bytes);
+        if (is_array($info) && ($info[0] * $info[1]) > $this->maxPixels) {
             return CompressionResult::untouched($bytes, $mime);
         }
 

--- a/app/Services/Media/ImageCompressor.php
+++ b/app/Services/Media/ImageCompressor.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Media;
+
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Format;
+use Intervention\Image\ImageManager;
+use Throwable;
+
+/**
+ * Re-encodes an oversized image to JPEG so it fits a target byte limit.
+ * Images already within the limit (or GIFs, or undecodable bytes) are
+ * returned untouched.
+ */
+final class ImageCompressor
+{
+    private const int QUALITY_START = 82;
+
+    private const int QUALITY_FLOOR = 40;
+
+    private const int QUALITY_STEP = 7;
+
+    private const int DIMENSION_FLOOR = 640;
+
+    private const float DOWNSCALE_FACTOR = 0.85;
+
+    public function compressToFit(string $bytes, int $maxBytes, string $mime): CompressionResult
+    {
+        if (strlen($bytes) <= $maxBytes) {
+            return CompressionResult::untouched($bytes, $mime);
+        }
+
+        if ($mime === 'image/gif') {
+            return CompressionResult::untouched($bytes, $mime);
+        }
+
+        try {
+            $image = ImageManager::usingDriver(GdDriver::class)->decodeBinary($bytes);
+        } catch (Throwable) {
+            return CompressionResult::untouched($bytes, $mime);
+        }
+
+        $longestEdge = max($image->width(), $image->height());
+
+        while (true) {
+            for ($quality = self::QUALITY_START; $quality >= self::QUALITY_FLOOR; $quality -= self::QUALITY_STEP) {
+                $encoded = (string) $image->encodeUsingFormat(Format::JPEG, quality: $quality);
+
+                if (strlen($encoded) <= $maxBytes) {
+                    return CompressionResult::compressed($encoded);
+                }
+            }
+
+            $longestEdge = (int) floor($longestEdge * self::DOWNSCALE_FACTOR);
+
+            if ($longestEdge < self::DIMENSION_FLOOR) {
+                return CompressionResult::untouched($bytes, $mime);
+            }
+
+            $image->scaleDown($longestEdge, $longestEdge);
+        }
+    }
+}

--- a/app/Services/Publishing/Connectors/BlueskyPublishConnector.php
+++ b/app/Services/Publishing/Connectors/BlueskyPublishConnector.php
@@ -11,6 +11,7 @@ use App\Enums\ErrorKind;
 use App\Enums\Platform;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
+use App\Services\Media\ImageCompressor;
 use App\Services\Publishing\Connectors\Concerns\MapsHttpErrors;
 use App\Services\Publishing\Contracts\PublishConnector;
 use GuzzleHttp\Psr7\Utils;
@@ -28,7 +29,10 @@ class BlueskyPublishConnector implements PublishConnector
 
     private const string VIDEO_SERVICE = 'https://video.bsky.app';
 
-    public function __construct(private readonly HttpFactory $http) {}
+    public function __construct(
+        private readonly HttpFactory $http,
+        private readonly ImageCompressor $imageCompressor,
+    ) {}
 
     public function publish(PublishContext $context): PublishResult
     {
@@ -303,10 +307,11 @@ class BlueskyPublishConnector implements PublishConnector
 
         foreach ($media as $item) {
             $bytes = (string) Storage::disk($item->disk)->get($item->path);
+            $compressed = $this->imageCompressor->compressToFit($bytes, Platform::Bluesky->maxMediaBytes(), $item->mime);
 
             $response = $this->http
                 ->withToken($jwt)
-                ->withBody($bytes, $item->mime)
+                ->withBody($compressed->bytes, $compressed->mime)
                 ->post($pds.'/xrpc/com.atproto.repo.uploadBlob');
 
             if ($response->failed()) {

--- a/app/Services/Publishing/Connectors/BlueskyPublishConnector.php
+++ b/app/Services/Publishing/Connectors/BlueskyPublishConnector.php
@@ -307,7 +307,7 @@ class BlueskyPublishConnector implements PublishConnector
 
         foreach ($media as $item) {
             $bytes = (string) Storage::disk($item->disk)->get($item->path);
-            $compressed = $this->imageCompressor->compressToFit($bytes, Platform::Bluesky->maxMediaBytes(), $item->mime);
+            $compressed = $this->imageCompressor->compressToFit($bytes, Platform::Bluesky->maxMediaBytes(), $item->mime, Platform::Bluesky->allowedMime());
 
             $response = $this->http
                 ->withToken($jwt)

--- a/app/Services/Publishing/Connectors/LinkedInConnector.php
+++ b/app/Services/Publishing/Connectors/LinkedInConnector.php
@@ -329,7 +329,7 @@ class LinkedInConnector implements PublishConnector
             $urn = (string) $register->json('value.image');
 
             $bytes = (string) Storage::disk($item->disk)->get($item->path);
-            $compressed = $this->imageCompressor->compressToFit($bytes, Platform::LinkedIn->maxMediaBytes(), $item->mime);
+            $compressed = $this->imageCompressor->compressToFit($bytes, Platform::LinkedIn->maxMediaBytes(), $item->mime, Platform::LinkedIn->allowedMime());
 
             $upload = $this->http
                 ->withToken($token)

--- a/app/Services/Publishing/Connectors/LinkedInConnector.php
+++ b/app/Services/Publishing/Connectors/LinkedInConnector.php
@@ -11,6 +11,7 @@ use App\Enums\ErrorKind;
 use App\Enums\Platform;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
+use App\Services\Media\ImageCompressor;
 use App\Services\Publishing\Connectors\Concerns\MapsHttpErrors;
 use App\Services\Publishing\Contracts\PublishConnector;
 use Illuminate\Http\Client\ConnectionException;
@@ -41,7 +42,10 @@ class LinkedInConnector implements PublishConnector
      */
     public const string DEFAULT_VERSION = '202605';
 
-    public function __construct(private readonly HttpFactory $http) {}
+    public function __construct(
+        private readonly HttpFactory $http,
+        private readonly ImageCompressor $imageCompressor,
+    ) {}
 
     private function apiVersion(): string
     {
@@ -325,10 +329,11 @@ class LinkedInConnector implements PublishConnector
             $urn = (string) $register->json('value.image');
 
             $bytes = (string) Storage::disk($item->disk)->get($item->path);
+            $compressed = $this->imageCompressor->compressToFit($bytes, Platform::LinkedIn->maxMediaBytes(), $item->mime);
 
             $upload = $this->http
                 ->withToken($token)
-                ->withBody($bytes, $item->mime)
+                ->withBody($compressed->bytes, $compressed->mime)
                 ->put($uploadUrl);
 
             if ($upload->failed()) {

--- a/app/Services/Publishing/Connectors/XConnector.php
+++ b/app/Services/Publishing/Connectors/XConnector.php
@@ -229,7 +229,7 @@ class XConnector implements PublishConnector
 
         foreach ($media as $item) {
             $bytes = (string) Storage::disk($item->disk)->get($item->path);
-            $compressed = $this->imageCompressor->compressToFit($bytes, Platform::X->maxMediaBytes(), $item->mime);
+            $compressed = $this->imageCompressor->compressToFit($bytes, Platform::X->maxMediaBytes(), $item->mime, Platform::X->allowedMime());
             $response = $this->http
                 ->withToken($token)
                 ->asMultipart()

--- a/app/Services/Publishing/Connectors/XConnector.php
+++ b/app/Services/Publishing/Connectors/XConnector.php
@@ -8,8 +8,10 @@ use App\Dto\Publishing\MediaUploadState;
 use App\Dto\Publishing\PublishContext;
 use App\Dto\Publishing\PublishResult;
 use App\Enums\ErrorKind;
+use App\Enums\Platform;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
+use App\Services\Media\ImageCompressor;
 use App\Services\Publishing\Connectors\Concerns\MapsHttpErrors;
 use App\Services\Publishing\Contracts\PublishConnector;
 use Illuminate\Http\Client\ConnectionException;
@@ -32,7 +34,10 @@ class XConnector implements PublishConnector
 
     private const int APPEND_CHUNK = 4 * 1024 * 1024;
 
-    public function __construct(private readonly HttpFactory $http) {}
+    public function __construct(
+        private readonly HttpFactory $http,
+        private readonly ImageCompressor $imageCompressor,
+    ) {}
 
     public function publish(PublishContext $context): PublishResult
     {
@@ -223,11 +228,12 @@ class XConnector implements PublishConnector
         $ids = [];
 
         foreach ($media as $item) {
-            $bytes = Storage::disk($item->disk)->get($item->path);
+            $bytes = (string) Storage::disk($item->disk)->get($item->path);
+            $compressed = $this->imageCompressor->compressToFit($bytes, Platform::X->maxMediaBytes(), $item->mime);
             $response = $this->http
                 ->withToken($token)
                 ->asMultipart()
-                ->attach('media', (string) $bytes, 'upload')
+                ->attach('media', $compressed->bytes, 'upload')
                 ->post(self::MEDIA_URL, ['media_category' => 'tweet_image']);
 
             if ($response->failed()) {

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": "^8.5",
         "inertiajs/inertia-laravel": "^3.0",
+        "intervention/image": "^4.0",
         "laravel/chisel": "^0.1.0",
         "laravel/fortify": "^1.37.2",
         "laravel/framework": "^13.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b0fa7172a99580ef48879ba6a425d7d",
+    "content-hash": "5f1f671ec38885daff3cca4f58ad815a",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -1414,6 +1414,150 @@
                 "source": "https://github.com/inertiajs/inertia-laravel/tree/v3.1.0"
             },
             "time": "2026-04-30T15:30:29+00:00"
+        },
+        {
+            "name": "intervention/gif",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/gif.git",
+                "reference": "bb395af960deffe64d70c976b4df9283f68e762d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/gif/zipball/bb395af960deffe64d70c976b4df9283f68e762d",
+                "reference": "bb395af960deffe64d70c976b4df9283f68e762d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^12.0",
+                "slevomat/coding-standard": "~8.0",
+                "squizlabs/php_codesniffer": "^4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Gif\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@intervention.io",
+                    "homepage": "https://intervention.io/"
+                }
+            ],
+            "description": "PHP GIF Encoder/Decoder",
+            "homepage": "https://github.com/intervention/gif",
+            "keywords": [
+                "animation",
+                "gd",
+                "gif",
+                "image"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/gif/issues",
+                "source": "https://github.com/Intervention/gif/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/interventionio",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                },
+                {
+                    "url": "https://ko-fi.com/interventionphp",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2026-05-03T06:04:47+00:00"
+        },
+        {
+            "name": "intervention/image",
+            "version": "4.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image.git",
+                "reference": "e5256d3e5884d97fd9c6eada513a8f7a1d1027fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/e5256d3e5884d97fd9c6eada513a8f7a1d1027fa",
+                "reference": "e5256d3e5884d97fd9c6eada513a8f7a1d1027fa",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "intervention/gif": "^5",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^12.0",
+                "slevomat/coding-standard": "~8.0",
+                "squizlabs/php_codesniffer": "^4"
+            },
+            "suggest": {
+                "ext-exif": "Recommended to be able to read EXIF data properly."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@intervention.io",
+                    "homepage": "https://intervention.io"
+                }
+            ],
+            "description": "PHP Image Processing",
+            "homepage": "https://image.intervention.io",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "resize",
+                "thumbnail",
+                "watermark"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/image/issues",
+                "source": "https://github.com/Intervention/image/tree/4.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/interventionio",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                },
+                {
+                    "url": "https://ko-fi.com/interventionphp",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2026-06-23T13:22:48+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",

--- a/tests/Feature/Posts/MediaApiTest.php
+++ b/tests/Feature/Posts/MediaApiTest.php
@@ -46,6 +46,21 @@ test('it rejects a non-image upload', function () {
     ], ['Accept' => 'application/json'])->assertStatus(422);
 });
 
+test('it rejects an image whose resolution exceeds the pixel ceiling', function () {
+    Storage::fake('public');
+    [$user, $workspace, $post] = memberWithDraft();
+
+    // Lower the ceiling so a normal fake image trips it without allocating a
+    // genuine 50-megapixel canvas; the rule reads the header only.
+    config(['media.max_image_pixels' => 100]);
+
+    test()->post("/posts/{$post['id']}/media", [
+        'file' => UploadedFile::fake()->image('huge.jpg', 800, 600)->size(300),
+    ], ['Accept' => 'application/json'])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('file');
+});
+
 test('it rejects an upload to a post that is no longer editable', function () {
     Storage::fake('public');
     [$user, $workspace, $post] = memberWithDraft();

--- a/tests/Feature/Publishing/BlueskyPublishConnectorTest.php
+++ b/tests/Feature/Publishing/BlueskyPublishConnectorTest.php
@@ -220,5 +220,6 @@ test('bluesky compresses oversized images via the compressor before upload', fun
     app(BlueskyPublishConnector::class)->publish(bskyContext(['look'], [$media]));
 
     Http::assertSent(fn ($request) => str_contains($request->url(), 'com.atproto.repo.uploadBlob')
-        && $request->body() === 'small-bytes');
+        && $request->body() === 'small-bytes'
+        && $request->hasHeader('Content-Type', 'image/jpeg'));
 });

--- a/tests/Feature/Publishing/BlueskyPublishConnectorTest.php
+++ b/tests/Feature/Publishing/BlueskyPublishConnectorTest.php
@@ -6,6 +6,8 @@ use App\Enums\Platform;
 use App\Models\ConnectedAccount;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
+use App\Services\Media\CompressionResult;
+use App\Services\Media\ImageCompressor;
 use App\Services\Publishing\Connectors\BlueskyPublishConnector;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
@@ -191,4 +193,32 @@ test('bluesky maps 401 to AuthExpired', function () {
 
     expect(app(BlueskyPublishConnector::class)->publish(bskyContext(['hi']))->errorKind)
         ->toBe(ErrorKind::AuthExpired);
+});
+
+test('bluesky compresses oversized images via the compressor before upload', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/big.jpg', 'image-bytes');
+
+    $compressor = Mockery::mock(ImageCompressor::class);
+    $compressor->shouldReceive('compressToFit')
+        ->once()
+        ->with('image-bytes', Platform::Bluesky->maxMediaBytes(), 'image/jpeg')
+        ->andReturn(CompressionResult::compressed('small-bytes'));
+    app()->instance(ImageCompressor::class, $compressor);
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public', 'path' => 'media/big.jpg', 'mime' => 'image/jpeg', 'alt_text' => 'big',
+    ]);
+
+    Http::fake([
+        '*com.atproto.repo.uploadBlob' => Http::response([
+            'blob' => ['$type' => 'blob', 'ref' => ['$link' => 'bafblob'], 'mimeType' => 'image/jpeg', 'size' => 11],
+        ]),
+        '*com.atproto.repo.createRecord' => Http::response(['uri' => 'at://r/1', 'cid' => 'cid1']),
+    ]);
+
+    app(BlueskyPublishConnector::class)->publish(bskyContext(['look'], [$media]));
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'com.atproto.repo.uploadBlob')
+        && $request->body() === 'small-bytes');
 });

--- a/tests/Feature/Publishing/BlueskyPublishConnectorTest.php
+++ b/tests/Feature/Publishing/BlueskyPublishConnectorTest.php
@@ -202,8 +202,8 @@ test('bluesky compresses oversized images via the compressor before upload', fun
     $compressor = Mockery::mock(ImageCompressor::class);
     $compressor->shouldReceive('compressToFit')
         ->once()
-        ->with('image-bytes', Platform::Bluesky->maxMediaBytes(), 'image/jpeg')
-        ->andReturn(CompressionResult::compressed('small-bytes'));
+        ->with('image-bytes', Platform::Bluesky->maxMediaBytes(), 'image/jpeg', Platform::Bluesky->allowedMime())
+        ->andReturn(CompressionResult::compressed('small-bytes', 'image/webp'));
     app()->instance(ImageCompressor::class, $compressor);
 
     $media = PostMedia::factory()->create([
@@ -221,5 +221,5 @@ test('bluesky compresses oversized images via the compressor before upload', fun
 
     Http::assertSent(fn ($request) => str_contains($request->url(), 'com.atproto.repo.uploadBlob')
         && $request->body() === 'small-bytes'
-        && $request->hasHeader('Content-Type', 'image/jpeg'));
+        && $request->hasHeader('Content-Type', 'image/webp'));
 });

--- a/tests/Feature/Publishing/LinkedInConnectorTest.php
+++ b/tests/Feature/Publishing/LinkedInConnectorTest.php
@@ -210,8 +210,8 @@ test('linkedin compresses oversized images via the compressor before upload', fu
     $compressor = Mockery::mock(ImageCompressor::class);
     $compressor->shouldReceive('compressToFit')
         ->once()
-        ->with('image-bytes', Platform::LinkedIn->maxMediaBytes(), 'image/jpeg')
-        ->andReturn(CompressionResult::compressed('small-bytes'));
+        ->with('image-bytes', Platform::LinkedIn->maxMediaBytes(), 'image/jpeg', Platform::LinkedIn->allowedMime())
+        ->andReturn(CompressionResult::compressed('small-bytes', 'image/jpeg'));
     app()->instance(ImageCompressor::class, $compressor);
 
     $media = PostMedia::factory()->create([

--- a/tests/Feature/Publishing/LinkedInConnectorTest.php
+++ b/tests/Feature/Publishing/LinkedInConnectorTest.php
@@ -6,6 +6,8 @@ use App\Enums\Platform;
 use App\Models\ConnectedAccount;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
+use App\Services\Media\CompressionResult;
+use App\Services\Media\ImageCompressor;
 use App\Services\Publishing\Connectors\LinkedInConnector;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
@@ -199,4 +201,33 @@ test('linkedin maps 401 to AuthExpired', function () {
 
     expect(app(LinkedInConnector::class)->publish(liContext(['hi']))->errorKind)
         ->toBe(ErrorKind::AuthExpired);
+});
+
+test('linkedin compresses oversized images via the compressor before upload', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/big.jpg', 'image-bytes');
+
+    $compressor = Mockery::mock(ImageCompressor::class);
+    $compressor->shouldReceive('compressToFit')
+        ->once()
+        ->with('image-bytes', Platform::LinkedIn->maxMediaBytes(), 'image/jpeg')
+        ->andReturn(CompressionResult::compressed('small-bytes'));
+    app()->instance(ImageCompressor::class, $compressor);
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public', 'path' => 'media/big.jpg', 'mime' => 'image/jpeg',
+    ]);
+
+    Http::fake([
+        'https://api.linkedin.com/rest/images?action=initializeUpload' => Http::response([
+            'value' => ['uploadUrl' => 'https://upload.example/abc', 'image' => 'urn:li:image:1'],
+        ]),
+        'https://upload.example/abc' => Http::response('', 201),
+        'https://api.linkedin.com/rest/posts' => Http::response('', 201, ['x-restli-id' => 'urn:li:share:1']),
+    ]);
+
+    app(LinkedInConnector::class)->publish(liContext(['look'], [$media]));
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://upload.example/abc'
+        && $request->body() === 'small-bytes');
 });

--- a/tests/Feature/Publishing/LinkedInConnectorTest.php
+++ b/tests/Feature/Publishing/LinkedInConnectorTest.php
@@ -229,5 +229,6 @@ test('linkedin compresses oversized images via the compressor before upload', fu
     app(LinkedInConnector::class)->publish(liContext(['look'], [$media]));
 
     Http::assertSent(fn ($request) => $request->url() === 'https://upload.example/abc'
-        && $request->body() === 'small-bytes');
+        && $request->body() === 'small-bytes'
+        && $request->hasHeader('Content-Type', 'image/jpeg'));
 });

--- a/tests/Feature/Publishing/XConnectorTest.php
+++ b/tests/Feature/Publishing/XConnectorTest.php
@@ -248,8 +248,8 @@ test('x compresses oversized images via the compressor before upload', function 
     $compressor = Mockery::mock(ImageCompressor::class);
     $compressor->shouldReceive('compressToFit')
         ->once()
-        ->with('image-bytes', Platform::X->maxMediaBytes(), 'image/jpeg')
-        ->andReturn(CompressionResult::compressed('small-bytes'));
+        ->with('image-bytes', Platform::X->maxMediaBytes(), 'image/jpeg', Platform::X->allowedMime())
+        ->andReturn(CompressionResult::compressed('small-bytes', 'image/webp'));
     app()->instance(ImageCompressor::class, $compressor);
 
     $media = PostMedia::factory()->create([

--- a/tests/Feature/Publishing/XConnectorTest.php
+++ b/tests/Feature/Publishing/XConnectorTest.php
@@ -6,6 +6,8 @@ use App\Enums\Platform;
 use App\Models\ConnectedAccount;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
+use App\Services\Media\CompressionResult;
+use App\Services\Media\ImageCompressor;
 use App\Services\Publishing\Connectors\XConnector;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
@@ -237,4 +239,30 @@ test('x omits an empty text field for a media-only post', function () {
     Http::assertSent(fn ($request) => $request->url() === 'https://api.twitter.com/2/tweets'
         && ! array_key_exists('text', $request->data())
         && ($request['media']['media_ids'] ?? null) === ['99001']);
+});
+
+test('x compresses oversized images via the compressor before upload', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/big.jpg', 'image-bytes');
+
+    $compressor = Mockery::mock(ImageCompressor::class);
+    $compressor->shouldReceive('compressToFit')
+        ->once()
+        ->with('image-bytes', Platform::X->maxMediaBytes(), 'image/jpeg')
+        ->andReturn(CompressionResult::compressed('small-bytes'));
+    app()->instance(ImageCompressor::class, $compressor);
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public', 'path' => 'media/big.jpg', 'mime' => 'image/jpeg',
+    ]);
+
+    Http::fake([
+        'https://api.x.com/2/media/upload' => Http::response(['data' => ['id' => '123']]),
+        'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => 'tweet1']]),
+    ]);
+
+    app(XConnector::class)->publish(xContext(['look'], [$media]));
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'media/upload')
+        && str_contains((string) $request->body(), 'small-bytes'));
 });

--- a/tests/Unit/ImageCompressorTest.php
+++ b/tests/Unit/ImageCompressorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Services\Media\ImageCompressor;
+
+/**
+ * Build a non-trivial JPEG so it does not compress to a near-zero size.
+ */
+function compressorJpeg(int $width = 1200, int $height = 1200): string
+{
+    $img = imagecreatetruecolor($width, $height);
+
+    for ($y = 0; $y < $height; $y += 2) {
+        for ($x = 0; $x < $width; $x += 2) {
+            $color = imagecolorallocate($img, ($x * $y) % 256, ($x + $y) % 256, ($x ^ $y) % 256);
+            imagesetpixel($img, $x, $y, $color);
+        }
+    }
+
+    ob_start();
+    imagejpeg($img, null, 100);
+    $bytes = (string) ob_get_clean();
+    imagedestroy($img);
+
+    return $bytes;
+}
+
+test('image within the limit is returned byte-identical and untouched', function () {
+    $bytes = compressorJpeg();
+
+    $result = app(ImageCompressor::class)->compressToFit($bytes, strlen($bytes) + 1024, 'image/jpeg');
+
+    expect($result->wasCompressed)->toBeFalse()
+        ->and($result->bytes)->toBe($bytes)
+        ->and($result->mime)->toBe('image/jpeg');
+});
+
+test('oversized image is compressed under the limit as jpeg', function () {
+    $bytes = compressorJpeg();
+    $limit = (int) (strlen($bytes) * 0.6);
+
+    $result = app(ImageCompressor::class)->compressToFit($bytes, $limit, 'image/jpeg');
+
+    expect($result->wasCompressed)->toBeTrue()
+        ->and($result->mime)->toBe('image/jpeg')
+        ->and(strlen($result->bytes))->toBeLessThanOrEqual($limit)
+        ->and(strlen($result->bytes))->toBeGreaterThan(0);
+});
+
+test('pathologically tiny limit falls back to the original untouched', function () {
+    $bytes = compressorJpeg();
+
+    $result = app(ImageCompressor::class)->compressToFit($bytes, 10, 'image/jpeg');
+
+    expect($result->wasCompressed)->toBeFalse()
+        ->and($result->bytes)->toBe($bytes);
+});
+
+test('gif is skipped and returned untouched', function () {
+    $gif = "GIF89a\x01\x00\x01\x00\x00\x00\x00;";
+
+    $result = app(ImageCompressor::class)->compressToFit($gif, 1, 'image/gif');
+
+    expect($result->wasCompressed)->toBeFalse()
+        ->and($result->bytes)->toBe($gif)
+        ->and($result->mime)->toBe('image/gif');
+});
+
+test('undecodable bytes over the limit fall back to the original', function () {
+    $junk = str_repeat('not-an-image', 200);
+
+    $result = app(ImageCompressor::class)->compressToFit($junk, 10, 'image/jpeg');
+
+    expect($result->wasCompressed)->toBeFalse()
+        ->and($result->bytes)->toBe($junk);
+});

--- a/tests/Unit/ImageCompressorTest.php
+++ b/tests/Unit/ImageCompressorTest.php
@@ -73,3 +73,15 @@ test('undecodable bytes over the limit fall back to the original', function () {
     expect($result->wasCompressed)->toBeFalse()
         ->and($result->bytes)->toBe($junk);
 });
+
+test('an image exceeding the pixel guard is left untouched without decoding', function () {
+    $bytes = compressorJpeg(1200, 1200); // 1.44M pixels
+
+    // maxPixels below the image's pixel count -> the decode guard trips before any canvas
+    // allocation, so the oversized image is returned untouched rather than compressed.
+    $result = (new ImageCompressor(maxPixels: 100))->compressToFit($bytes, (int) (strlen($bytes) * 0.6), 'image/jpeg');
+
+    expect($result->wasCompressed)->toBeFalse()
+        ->and($result->bytes)->toBe($bytes)
+        ->and($result->mime)->toBe('image/jpeg');
+});

--- a/tests/Unit/ImageCompressorTest.php
+++ b/tests/Unit/ImageCompressorTest.php
@@ -24,32 +24,66 @@ function compressorJpeg(int $width = 1200, int $height = 1200): string
     return $bytes;
 }
 
+/** Platforms that accept WebP (X, Bluesky). */
+const WEBP_ALLOWED = ['image/jpeg', 'image/png', 'image/webp'];
+
+/** Platforms that do not accept WebP (LinkedIn). */
+const NO_WEBP_ALLOWED = ['image/jpeg', 'image/png', 'image/gif'];
+
 test('image within the limit is returned byte-identical and untouched', function () {
     $bytes = compressorJpeg();
 
-    $result = app(ImageCompressor::class)->compressToFit($bytes, strlen($bytes) + 1024, 'image/jpeg');
+    $result = app(ImageCompressor::class)->compressToFit($bytes, strlen($bytes) + 1024, 'image/jpeg', WEBP_ALLOWED);
 
     expect($result->wasCompressed)->toBeFalse()
         ->and($result->bytes)->toBe($bytes)
         ->and($result->mime)->toBe('image/jpeg');
 });
 
-test('oversized image is compressed under the limit as jpeg', function () {
+test('oversized image is compressed under the limit as jpeg when webp is not allowed', function () {
     $bytes = compressorJpeg();
     $limit = (int) (strlen($bytes) * 0.6);
 
-    $result = app(ImageCompressor::class)->compressToFit($bytes, $limit, 'image/jpeg');
+    $result = app(ImageCompressor::class)->compressToFit($bytes, $limit, 'image/jpeg', NO_WEBP_ALLOWED);
 
     expect($result->wasCompressed)->toBeTrue()
         ->and($result->mime)->toBe('image/jpeg')
         ->and(strlen($result->bytes))->toBeLessThanOrEqual($limit)
-        ->and(strlen($result->bytes))->toBeGreaterThan(0);
+        ->and(strlen($result->bytes))->toBeGreaterThan(0)
+        ->and(bin2hex(substr($result->bytes, 0, 2)))->toBe('ffd8'); // JPEG SOI marker
+});
+
+test('oversized image is compressed as webp when the platform allows it', function () {
+    $bytes = compressorJpeg();
+    $limit = (int) (strlen($bytes) * 0.6);
+
+    $result = app(ImageCompressor::class)->compressToFit($bytes, $limit, 'image/jpeg', WEBP_ALLOWED);
+
+    expect($result->wasCompressed)->toBeTrue()
+        ->and($result->mime)->toBe('image/webp')
+        ->and(strlen($result->bytes))->toBeLessThanOrEqual($limit)
+        ->and(substr($result->bytes, 0, 4))->toBe('RIFF')
+        ->and(substr($result->bytes, 8, 4))->toBe('WEBP');
+});
+
+test('the highest quality that fits is chosen (quality is not capped low)', function () {
+    $bytes = compressorJpeg();
+    // A generous-but-shrinking limit: clearly compressible, yet not so tight that quality
+    // must crater. The chosen encoding should land at/under the limit while staying close
+    // to it — i.e. we did not needlessly over-compress past the budget.
+    $limit = (int) (strlen($bytes) * 0.8);
+
+    $result = app(ImageCompressor::class)->compressToFit($bytes, $limit, 'image/jpeg', NO_WEBP_ALLOWED);
+
+    expect($result->wasCompressed)->toBeTrue()
+        ->and(strlen($result->bytes))->toBeLessThanOrEqual($limit)
+        ->and(strlen($result->bytes))->toBeGreaterThan((int) ($limit * 0.5));
 });
 
 test('pathologically tiny limit falls back to the original untouched', function () {
     $bytes = compressorJpeg();
 
-    $result = app(ImageCompressor::class)->compressToFit($bytes, 10, 'image/jpeg');
+    $result = app(ImageCompressor::class)->compressToFit($bytes, 10, 'image/jpeg', WEBP_ALLOWED);
 
     expect($result->wasCompressed)->toBeFalse()
         ->and($result->bytes)->toBe($bytes);
@@ -58,7 +92,7 @@ test('pathologically tiny limit falls back to the original untouched', function 
 test('gif is skipped and returned untouched', function () {
     $gif = "GIF89a\x01\x00\x01\x00\x00\x00\x00;";
 
-    $result = app(ImageCompressor::class)->compressToFit($gif, 1, 'image/gif');
+    $result = app(ImageCompressor::class)->compressToFit($gif, 1, 'image/gif', NO_WEBP_ALLOWED);
 
     expect($result->wasCompressed)->toBeFalse()
         ->and($result->bytes)->toBe($gif)
@@ -68,7 +102,7 @@ test('gif is skipped and returned untouched', function () {
 test('undecodable bytes over the limit fall back to the original', function () {
     $junk = str_repeat('not-an-image', 200);
 
-    $result = app(ImageCompressor::class)->compressToFit($junk, 10, 'image/jpeg');
+    $result = app(ImageCompressor::class)->compressToFit($junk, 10, 'image/jpeg', WEBP_ALLOWED);
 
     expect($result->wasCompressed)->toBeFalse()
         ->and($result->bytes)->toBe($junk);
@@ -79,7 +113,7 @@ test('an image exceeding the pixel guard is left untouched without decoding', fu
 
     // maxPixels below the image's pixel count -> the decode guard trips before any canvas
     // allocation, so the oversized image is returned untouched rather than compressed.
-    $result = (new ImageCompressor(maxPixels: 100))->compressToFit($bytes, (int) (strlen($bytes) * 0.6), 'image/jpeg');
+    $result = (new ImageCompressor(maxPixels: 100))->compressToFit($bytes, (int) (strlen($bytes) * 0.6), 'image/jpeg', WEBP_ALLOWED);
 
     expect($result->wasCompressed)->toBeFalse()
         ->and($result->bytes)->toBe($bytes)


### PR DESCRIPTION
## What

Automatically compress an attached **image** to fit a target social platform's byte-size limit at publish time — but **only when it exceeds that platform's limit**. Images already within a platform's limit are sent **byte-identical, untouched**. Compression is **per-platform** and transient (generated in memory just before upload, never stored). Videos are unchanged.

Bluesky's tight **1 MB** image cap is the limit that bites most often; X (5 MB) and LinkedIn (8 MB) rarely trigger it.

## How

- New `App\Services\Media\ImageCompressor::compressToFit(bytes, maxBytes, mime, allowedMimes)` (intervention/image v4, **GD driver pinned**).
  - **Quality-first:** picks the *highest* encoder quality that fits (sweep 92 → 50) before resorting to downscaling (×0.85, floor 640px).
  - **Prefers WebP** when the platform accepts it (X, Bluesky) — smaller at equal quality and preserves alpha — and falls back to **JPEG** for LinkedIn (no WebP support) or when `imagewebp` is unavailable.
  - Within-limit / GIF / undecodable / over-pixel-ceiling images are returned untouched.
- Wired into the image-upload paths of the X, Bluesky, and LinkedIn publish connectors using each platform's existing `Platform::maxMediaBytes()` + `Platform::allowedMime()`. Video upload paths untouched.
- **Decompression-bomb hardening** (this is the first server-side decode of user images, in the queue worker):
  - Worker: pre-decode header-only pixel-count guard (50 MP ceiling, no canvas allocation) → over-ceiling images returned untouched.
  - Upload gate: `StorePostMediaRequest` rejects over-ceiling resolutions with a clear `422` (header-only read; ceiling = `config('media.max_image_pixels')`, default 50 MP).
- **Dockerfile:** runtime stage installs `gd` + `exif` (base `serversideup/php:8.5-frankenphp-trixie` ships only `mbstring`).

No DB / schema / frontend changes.

## Testing

- Unit: `ImageCompressor` — within-limit untouched, JPEG vs WebP output by platform, highest-quality-that-fits, tiny-limit fallback, GIF/undecodable skip, pixel-guard skip.
- Connector wiring: X / Bluesky / LinkedIn assert the correct per-platform limit + mime are passed and the compressed bytes/content-type reach the platform API.
- Upload gate: rejects an over-ceiling resolution.
- Full suite: **784 passing**, Pint clean, Larastan (level 7) 0 errors.

## Deploy note

The Dockerfile `gd`+`exif` change only takes effect on the **next image build/deploy** — compression is a no-op (images sent as-is) until the image is rebuilt with the GD extension.