### PR TITLE
feat(compose): client-side video compression to platform caps

### DIFF
--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -68,9 +68,13 @@ export function ComposerToolbar({
 
     const hasVideo = media.some((m) => m.kind === 'video');
     // Count confirmed media plus uploads still in flight so the badge bumps the
-    // instant a file is picked, and settles back if an upload fails.
+    // instant a file is picked, and settles back if an upload fails. "processing"
+    // (client-side compression) is in flight too, so it counts.
     const mediaCount =
-        media.length + pending.filter((p) => p.status === 'uploading').length;
+        media.length +
+        pending.filter(
+            (p) => p.status === 'uploading' || p.status === 'processing',
+        ).length;
 
     return (
         <div

--- a/resources/js/components/compose/media-chips.tsx
+++ b/resources/js/components/compose/media-chips.tsx
@@ -311,15 +311,28 @@ export function MediaChips({
                                     )}
                                 >
                                     {p.previewUrl ? (
-                                        <img
-                                            src={p.previewUrl}
-                                            alt=""
-                                            draggable={false}
-                                            className={cn(
-                                                'size-full object-cover',
-                                                inFlight && 'opacity-50',
-                                            )}
-                                        />
+                                        p.kind === 'video' ? (
+                                            <video
+                                                src={p.previewUrl}
+                                                muted
+                                                playsInline
+                                                preload="metadata"
+                                                className={cn(
+                                                    'size-full object-cover',
+                                                    inFlight && 'opacity-50',
+                                                )}
+                                            />
+                                        ) : (
+                                            <img
+                                                src={p.previewUrl}
+                                                alt=""
+                                                draggable={false}
+                                                className={cn(
+                                                    'size-full object-cover',
+                                                    inFlight && 'opacity-50',
+                                                )}
+                                            />
+                                        )
                                     ) : (
                                         <div className="size-full bg-muted" />
                                     )}

--- a/resources/js/components/compose/media-chips.tsx
+++ b/resources/js/components/compose/media-chips.tsx
@@ -286,71 +286,81 @@ export function MediaChips({
                 );
             })}
 
-            {pending.map((p) => (
-                <Tooltip key={p.tempId}>
-                    <TooltipTrigger asChild>
-                        <div
-                            className="group/chip relative"
-                            aria-label={
-                                p.status === 'uploading'
-                                    ? 'Uploading media'
-                                    : 'Failed upload'
-                            }
-                        >
+            {pending.map((p) => {
+                const inFlight =
+                    p.status === 'uploading' || p.status === 'processing';
+
+                return (
+                    <Tooltip key={p.tempId}>
+                        <TooltipTrigger asChild>
                             <div
-                                className={cn(
-                                    'relative size-7 overflow-hidden rounded-md border border-border',
-                                    p.status === 'error' &&
-                                        'ring-1 ring-destructive/60',
-                                )}
+                                className="group/chip relative"
+                                aria-label={
+                                    p.status === 'processing'
+                                        ? 'Compressing media'
+                                        : p.status === 'uploading'
+                                          ? 'Uploading media'
+                                          : 'Failed upload'
+                                }
                             >
-                                {p.previewUrl ? (
-                                    <img
-                                        src={p.previewUrl}
-                                        alt=""
-                                        draggable={false}
-                                        className={cn(
-                                            'size-full object-cover',
-                                            p.status === 'uploading' &&
-                                                'opacity-50',
-                                        )}
-                                    />
-                                ) : (
-                                    <div className="size-full bg-muted" />
-                                )}
-                                {p.status === 'uploading' && (
-                                    <div className="absolute inset-0 grid place-items-center bg-background/30">
-                                        {p.progress !== undefined ? (
-                                            <span className="font-mono text-[7px] leading-none font-semibold text-foreground">
-                                                {p.progress}%
-                                            </span>
-                                        ) : (
-                                            <span className="size-3 animate-spin rounded-full border-2 border-foreground/70 border-t-transparent" />
-                                        )}
-                                    </div>
+                                <div
+                                    className={cn(
+                                        'relative size-7 overflow-hidden rounded-md border border-border',
+                                        p.status === 'error' &&
+                                            'ring-1 ring-destructive/60',
+                                    )}
+                                >
+                                    {p.previewUrl ? (
+                                        <img
+                                            src={p.previewUrl}
+                                            alt=""
+                                            draggable={false}
+                                            className={cn(
+                                                'size-full object-cover',
+                                                inFlight && 'opacity-50',
+                                            )}
+                                        />
+                                    ) : (
+                                        <div className="size-full bg-muted" />
+                                    )}
+                                    {inFlight && (
+                                        <div className="absolute inset-0 grid place-items-center bg-background/30">
+                                            {p.progress !== undefined ? (
+                                                <span className="font-mono text-[7px] leading-none font-semibold text-foreground">
+                                                    {p.progress}%
+                                                </span>
+                                            ) : (
+                                                <span className="size-3 animate-spin rounded-full border-2 border-foreground/70 border-t-transparent" />
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
+                                {p.status === 'error' && (
+                                    <CornerButton
+                                        label="Dismiss failed upload"
+                                        onClick={() =>
+                                            onDismissPending(p.tempId)
+                                        }
+                                        always
+                                    >
+                                        <X
+                                            className="size-2.5 text-black"
+                                            aria-hidden="true"
+                                        />
+                                    </CornerButton>
                                 )}
                             </div>
-                            {p.status === 'error' && (
-                                <CornerButton
-                                    label="Dismiss failed upload"
-                                    onClick={() => onDismissPending(p.tempId)}
-                                    always
-                                >
-                                    <X
-                                        className="size-2.5 text-black"
-                                        aria-hidden="true"
-                                    />
-                                </CornerButton>
-                            )}
-                        </div>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="text-[11px]">
-                        {p.status === 'uploading'
-                            ? 'Uploading…'
-                            : 'Upload failed — dismiss and retry'}
-                    </TooltipContent>
-                </Tooltip>
-            ))}
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom" className="text-[11px]">
+                            {p.status === 'processing'
+                                ? 'Compressing…'
+                                : p.status === 'uploading'
+                                  ? 'Uploading…'
+                                  : 'Upload failed — dismiss and retry'}
+                        </TooltipContent>
+                    </Tooltip>
+                );
+            })}
         </div>
     );
 }

--- a/resources/js/components/compose/video-editor.tsx
+++ b/resources/js/components/compose/video-editor.tsx
@@ -34,7 +34,7 @@ type Props = {
     variant?: 'new' | 'existing';
     /** Called when the user chooses to upload without editing (only relevant for 'new' variant). */
     onSkip?: () => void;
-    phase: 'idle' | 'rendering' | 'uploading';
+    phase: 'idle' | 'rendering' | 'compressing' | 'uploading';
     /** 0..1 — shown as a progress bar while phase !== 'idle'. */
     progress: number;
 };
@@ -843,7 +843,9 @@ export function VideoEditor({
                         <span className="text-sm text-muted-foreground">
                             {phase === 'rendering'
                                 ? 'Rendering…'
-                                : 'Uploading…'}
+                                : phase === 'compressing'
+                                  ? 'Compressing…'
+                                  : 'Uploading…'}
                         </span>
                     )}
 

--- a/resources/js/hooks/compose/use-media-uploads.ts
+++ b/resources/js/hooks/compose/use-media-uploads.ts
@@ -86,7 +86,11 @@ export function useMediaUploads({
         [],
     );
 
-    const isUploading = pending.some((p) => p.status === 'uploading');
+    // Compression ('processing') counts as in flight too — the publish/send gates
+    // hang off this, so a post must not ship while a video is still being encoded.
+    const isUploading = pending.some(
+        (p) => p.status === 'uploading' || p.status === 'processing',
+    );
 
     function mintPreview(file: File): string | undefined {
         try {
@@ -106,12 +110,13 @@ export function useMediaUploads({
 
     function beginUpload(
         file: File,
+        kind: PendingUpload['kind'],
         status: PendingUpload['status'] = 'uploading',
     ): { tempId: string; previewUrl?: string } {
         tempSeq.current += 1;
         const tempId = `up_${tempSeq.current}`;
         const previewUrl = mintPreview(file);
-        setPending((cur) => [...cur, { tempId, previewUrl, status }]);
+        setPending((cur) => [...cur, { tempId, kind, previewUrl, status }]);
 
         return { tempId, previewUrl };
     }
@@ -160,7 +165,7 @@ export function useMediaUploads({
     // --- Upload flows -------------------------------------------------------
 
     async function uploadImage(file: File): Promise<void> {
-        const { tempId, previewUrl } = beginUpload(file);
+        const { tempId, previewUrl } = beginUpload(file, 'image');
 
         const id = await onEnsurePost();
         if (!id) {
@@ -189,64 +194,70 @@ export function useMediaUploads({
             return;
         }
 
-        // Only compress an over-cap clip whose duration is still publishable —
-        // re-encoding can't shorten a clip, so a too-long video is rejected
-        // outright rather than wasting an encode.
+        // Re-encoding can only shrink an over-cap clip's bytes — it can't fix a
+        // wrong codec or a too-long runtime. So we compress only when an
+        // oversized file is otherwise valid, detected by re-running the gate as
+        // if the file already fit (sizeBytes 0). Anything else gets the cheap
+        // up-front rejection, so a doomed file never flashes a ghost chip.
         const maxBytes = minVideoBytes(videoLimits);
-        const maxDuration = Math.min(
-            ...videoLimits.map((l) => l.maxVideoDurationSeconds),
-            Number.POSITIVE_INFINITY,
-        );
+        const verdict = validateVideo(meta, videoLimits);
         const willCompress =
+            !verdict.ok &&
             Number.isFinite(maxBytes) &&
             file.size > maxBytes &&
-            meta.durationSeconds <= maxDuration;
+            validateVideo({ ...meta, sizeBytes: 0 }, videoLimits).ok;
 
-        // Cases we won't try to compress get the cheap up-front gate, so a doomed
-        // file (wrong type, too long) never flashes a ghost chip.
-        if (!willCompress) {
-            const verdict = validateVideo(meta, videoLimits);
-            if (!verdict.ok) {
-                toast.error(verdict.reason);
+        if (!verdict.ok && !willCompress) {
+            toast.error(verdict.reason);
 
-                return;
-            }
+            return;
         }
 
         const { tempId, previewUrl } = beginUpload(
             file,
+            'video',
             willCompress ? 'processing' : 'uploading',
         );
 
         let finalFile = file;
         if (willCompress) {
+            let compressed: Blob | null = null;
             try {
                 const { compressVideoToFit } =
                     await import('@/lib/video-editor/compress');
-                const compressed = await compressVideoToFit(
+                compressed = await compressVideoToFit(
                     file,
                     maxBytes,
                     (fraction) =>
                         setProgress(tempId, Math.round(fraction * 100)),
                 );
-                if (compressed) {
-                    finalFile = new File([compressed], file.name, {
-                        type: 'video/mp4',
-                    });
+            } catch {
+                // Encode threw outright; fall through to the gate, which rejects
+                // the still-over-cap original.
+            }
+
+            if (compressed) {
+                finalFile = new File([compressed], file.name, {
+                    type: 'video/mp4',
+                });
+                try {
                     // Downscaling changes width/height/size — re-read so the
                     // final gate and confirm payload reflect the real output.
                     meta = await readVideoMetadata(finalFile);
+                } catch {
+                    // compressVideoToFit already guarantees the blob fits; if the
+                    // re-read fails, trust that size over the stale original
+                    // rather than dropping an otherwise-valid upload.
+                    meta = { ...meta, sizeBytes: finalFile.size };
                 }
-            } catch {
-                // Fall through: the gate below rejects if it's still over cap.
             }
 
             setStatus(tempId, 'uploading');
             setProgress(tempId, 0);
 
-            const verdict = validateVideo(meta, videoLimits);
-            if (!verdict.ok) {
-                toast.error(verdict.reason);
+            const finalVerdict = validateVideo(meta, videoLimits);
+            if (!finalVerdict.ok) {
+                toast.error(finalVerdict.reason);
                 dismissPending(tempId);
 
                 return;

--- a/resources/js/hooks/compose/use-media-uploads.ts
+++ b/resources/js/hooks/compose/use-media-uploads.ts
@@ -5,9 +5,11 @@ import { toast } from 'sonner';
 import PostMediaController from '@/actions/App/Http/Controllers/Posts/PostMediaController';
 import PostVideoUploadController from '@/actions/App/Http/Controllers/Posts/PostVideoUploadController';
 import {
+    minVideoBytes,
     putWithProgress,
     readVideoMetadata,
     validateVideo,
+    type VideoMeta,
 } from '@/lib/compose/video';
 import type { MediaView, PendingUpload, PlatformLimits } from '@/types/compose';
 
@@ -102,14 +104,14 @@ export function useMediaUploads({
 
     // --- Pending-chip lifecycle (shared by both upload flows) ---------------
 
-    function beginUpload(file: File): { tempId: string; previewUrl?: string } {
+    function beginUpload(
+        file: File,
+        status: PendingUpload['status'] = 'uploading',
+    ): { tempId: string; previewUrl?: string } {
         tempSeq.current += 1;
         const tempId = `up_${tempSeq.current}`;
         const previewUrl = mintPreview(file);
-        setPending((cur) => [
-            ...cur,
-            { tempId, previewUrl, status: 'uploading' },
-        ]);
+        setPending((cur) => [...cur, { tempId, previewUrl, status }]);
 
         return { tempId, previewUrl };
     }
@@ -119,6 +121,12 @@ export function useMediaUploads({
             cur.map((p) =>
                 p.tempId === tempId ? { ...p, status: 'error' } : p,
             ),
+        );
+    }
+
+    function setStatus(tempId: string, status: PendingUpload['status']): void {
+        setPending((cur) =>
+            cur.map((p) => (p.tempId === tempId ? { ...p, status } : p)),
         );
     }
 
@@ -172,7 +180,7 @@ export function useMediaUploads({
     }
 
     async function uploadVideo(file: File): Promise<void> {
-        let meta;
+        let meta: VideoMeta;
         try {
             meta = await readVideoMetadata(file);
         } catch {
@@ -181,23 +189,69 @@ export function useMediaUploads({
             return;
         }
 
-        const verdict = validateVideo(
-            {
-                sizeBytes: file.size,
-                mime: file.type,
-                durationSeconds: meta.durationSeconds,
-                width: meta.width,
-                height: meta.height,
-            },
-            videoLimits,
+        // Only compress an over-cap clip whose duration is still publishable —
+        // re-encoding can't shorten a clip, so a too-long video is rejected
+        // outright rather than wasting an encode.
+        const maxBytes = minVideoBytes(videoLimits);
+        const maxDuration = Math.min(
+            ...videoLimits.map((l) => l.maxVideoDurationSeconds),
+            Number.POSITIVE_INFINITY,
         );
-        if (!verdict.ok) {
-            toast.error(verdict.reason);
+        const willCompress =
+            Number.isFinite(maxBytes) &&
+            file.size > maxBytes &&
+            meta.durationSeconds <= maxDuration;
 
-            return;
+        // Cases we won't try to compress get the cheap up-front gate, so a doomed
+        // file (wrong type, too long) never flashes a ghost chip.
+        if (!willCompress) {
+            const verdict = validateVideo(meta, videoLimits);
+            if (!verdict.ok) {
+                toast.error(verdict.reason);
+
+                return;
+            }
         }
 
-        const { tempId, previewUrl } = beginUpload(file);
+        const { tempId, previewUrl } = beginUpload(
+            file,
+            willCompress ? 'processing' : 'uploading',
+        );
+
+        let finalFile = file;
+        if (willCompress) {
+            try {
+                const { compressVideoToFit } =
+                    await import('@/lib/video-editor/compress');
+                const compressed = await compressVideoToFit(
+                    file,
+                    maxBytes,
+                    (fraction) =>
+                        setProgress(tempId, Math.round(fraction * 100)),
+                );
+                if (compressed) {
+                    finalFile = new File([compressed], file.name, {
+                        type: 'video/mp4',
+                    });
+                    // Downscaling changes width/height/size — re-read so the
+                    // final gate and confirm payload reflect the real output.
+                    meta = await readVideoMetadata(finalFile);
+                }
+            } catch {
+                // Fall through: the gate below rejects if it's still over cap.
+            }
+
+            setStatus(tempId, 'uploading');
+            setProgress(tempId, 0);
+
+            const verdict = validateVideo(meta, videoLimits);
+            if (!verdict.ok) {
+                toast.error(verdict.reason);
+                dismissPending(tempId);
+
+                return;
+            }
+        }
 
         const id = await onEnsurePost();
         if (!id) {
@@ -211,8 +265,11 @@ export function useMediaUploads({
                 onNetworkError: () => undefined,
             });
 
-            await putWithProgress(signed.url, signed.headers, file, (pct) =>
-                setProgress(tempId, pct),
+            await putWithProgress(
+                signed.url,
+                signed.headers,
+                finalFile,
+                (pct) => setProgress(tempId, pct),
             );
 
             confirmHttp.setData({

--- a/resources/js/hooks/compose/use-video-editor.ts
+++ b/resources/js/hooks/compose/use-video-editor.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 
 import PostVideoUploadController from '@/actions/App/Http/Controllers/Posts/PostVideoUploadController';
 import {
+    minVideoBytes,
     putWithProgress,
     readVideoMetadata,
     validateVideo,
@@ -24,9 +25,9 @@ type Args = {
 };
 
 export function useVideoEditor({ onEnsurePost, onComplete }: Args) {
-    const [phase, setPhase] = useState<'idle' | 'rendering' | 'uploading'>(
-        'idle',
-    );
+    const [phase, setPhase] = useState<
+        'idle' | 'rendering' | 'compressing' | 'uploading'
+    >('idle');
     const [progress, setProgress] = useState(0);
 
     const signHttp = useHttp<
@@ -57,21 +58,32 @@ export function useVideoEditor({ onEnsurePost, onComplete }: Args) {
             const { renderVideo } = await import('@/lib/video-editor/render');
             const blob = await renderVideo(source, settings, setProgress);
 
-            const file = new File([blob], 'edited-video.mp4', {
+            let file = new File([blob], 'edited-video.mp4', {
                 type: 'video/mp4',
             });
-            const meta = await readVideoMetadata(file);
+            let meta = await readVideoMetadata(file);
 
-            const verdict = validateVideo(
-                {
-                    sizeBytes: file.size,
-                    mime: file.type,
-                    durationSeconds: meta.durationSeconds,
-                    width: meta.width,
-                    height: meta.height,
-                },
-                limits,
-            );
+            // Keep the edited output within the selected platforms' caps too.
+            const maxBytes = minVideoBytes(limits);
+            if (Number.isFinite(maxBytes) && file.size > maxBytes) {
+                setPhase('compressing');
+                setProgress(0);
+                const { compressVideoToFit } =
+                    await import('@/lib/video-editor/compress');
+                const compressed = await compressVideoToFit(
+                    file,
+                    maxBytes,
+                    setProgress,
+                );
+                if (compressed) {
+                    file = new File([compressed], 'edited-video.mp4', {
+                        type: 'video/mp4',
+                    });
+                    meta = await readVideoMetadata(file);
+                }
+            }
+
+            const verdict = validateVideo(meta, limits);
             if (!verdict.ok) {
                 toast.error(verdict.reason);
 

--- a/resources/js/lib/compose/__tests__/video.test.ts
+++ b/resources/js/lib/compose/__tests__/video.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { validateVideo } from '@/lib/compose/video';
+import {
+    minVideoBytes,
+    nextDownscale,
+    planVideoEncode,
+    validateVideo,
+    type VideoMeta,
+} from '@/lib/compose/video';
 import type { PlatformLimits } from '@/types/compose';
 
 function limits(
@@ -64,5 +70,79 @@ describe('validateVideo', () => {
             limits({ platform: 'bluesky', maxVideoBytes: 100_000_000 }),
         ]);
         expect(result.ok).toBe(false);
+    });
+});
+
+describe('minVideoBytes', () => {
+    it('returns Infinity when no platform is selected', () => {
+        expect(minVideoBytes([])).toBe(Number.POSITIVE_INFINITY);
+    });
+
+    it('returns the smallest cap across the selected platforms', () => {
+        expect(
+            minVideoBytes([
+                limits({ platform: 'x', maxVideoBytes: 512_000_000 }),
+                limits({ platform: 'bluesky', maxVideoBytes: 100_000_000 }),
+            ]),
+        ).toBe(100_000_000);
+    });
+});
+
+describe('planVideoEncode', () => {
+    const source: VideoMeta = {
+        sizeBytes: 0,
+        mime: 'video/mp4',
+        durationSeconds: 100,
+        width: 1280,
+        height: 720,
+    };
+
+    it('derives the video bitrate from the byte budget minus the audio cap', () => {
+        const plan = planVideoEncode(source, 100_000_000);
+        expect(plan.audioBitrate).toBe(128_000);
+        expect(plan.videoBitrate).toBe(
+            Math.floor((100_000_000 * 8 * 0.9) / 100) - 128_000,
+        );
+        // Under the resolution ceiling: dimensions pass through unchanged.
+        expect(plan).toMatchObject({ width: 1280, height: 720 });
+    });
+
+    it('caps the longest edge to the resolution ceiling, even-rounded', () => {
+        const plan = planVideoEncode(
+            { ...source, width: 3840, height: 2160 },
+            100_000_000,
+        );
+        expect(plan.width).toBe(1920);
+        expect(plan.height).toBe(1080);
+        expect(plan.width % 2).toBe(0);
+        expect(plan.height % 2).toBe(0);
+    });
+
+    it('never starves the video bitrate below the floor for a tiny cap', () => {
+        const plan = planVideoEncode(
+            { ...source, durationSeconds: 600, width: 640, height: 360 },
+            1_000_000,
+        );
+        expect(plan.videoBitrate).toBe(300_000);
+    });
+
+    it('treats a zero duration as one second rather than dividing by zero', () => {
+        const plan = planVideoEncode(
+            { ...source, durationSeconds: 0 },
+            100_000_000,
+        );
+        expect(Number.isFinite(plan.videoBitrate)).toBe(true);
+        expect(plan.videoBitrate).toBeGreaterThan(0);
+    });
+});
+
+describe('nextDownscale', () => {
+    it('shrinks the longest edge ~20%, even-rounded', () => {
+        expect(nextDownscale(1920, 1080)).toEqual({ width: 1536, height: 864 });
+    });
+
+    it('returns null once the longest edge would fall below the floor', () => {
+        // 560 * 0.8 = 448, below the 480 floor.
+        expect(nextDownscale(560, 320)).toBeNull();
     });
 });

--- a/resources/js/lib/compose/video.ts
+++ b/resources/js/lib/compose/video.ts
@@ -60,6 +60,90 @@ export function validateVideo(
     return { ok: true };
 }
 
+// --- Compression budget helpers ----------------------------------------
+// Pure math shared by the compose/edit gates and the mediabunny encoder, so the
+// "what size do we aim for" decision lives in exactly one place.
+
+/** Audio is re-encoded at a fixed cap so the bitrate budget is predictable. */
+const AUDIO_BITRATE = 128_000;
+/** Headroom for container overhead + VBR drift, so we land under the cap. */
+const SIZE_SAFETY = 0.9;
+/** Never starve the video track below this, however tight the budget. */
+const MIN_VIDEO_BITRATE = 300_000;
+/** Cap the longest edge of a compressed video before bitrate even comes in. */
+const RESOLUTION_CEILING = 1920;
+/** Stop downscaling once the longest edge would drop below this. */
+const DOWNSCALE_FLOOR = 480;
+/** Each downscale step shrinks the longest edge by this factor. */
+const DOWNSCALE_STEP = 0.8;
+
+/** Re-export for the encoder's retry clamp (keep the floor in one place). */
+export const VIDEO_MIN_BITRATE = MIN_VIDEO_BITRATE;
+
+export type EncodePlan = {
+    videoBitrate: number;
+    audioBitrate: number;
+    width: number;
+    height: number;
+};
+
+/** Even and ≥ 2 — encoders reject odd dimensions. */
+function toEven(value: number): number {
+    return Math.max(2, Math.floor(value / 2) * 2);
+}
+
+/** Smallest video byte cap across the selected platforms (∞ when none selected). */
+export function minVideoBytes(limits: PlatformLimits[]): number {
+    return Math.min(
+        ...limits.map((l) => l.maxVideoBytes),
+        Number.POSITIVE_INFINITY,
+    );
+}
+
+/**
+ * Bitrate + dimension budget to re-encode `meta` under `maxBytes`. Pure: the
+ * actual encode and its corrective retries live in the mediabunny chunk.
+ */
+export function planVideoEncode(meta: VideoMeta, maxBytes: number): EncodePlan {
+    // Guard against a zero/garbage duration blowing up the division.
+    const duration = Math.max(meta.durationSeconds, 1);
+    const targetBits = maxBytes * 8 * SIZE_SAFETY;
+    const videoBitrate = Math.max(
+        Math.floor(targetBits / duration) - AUDIO_BITRATE,
+        MIN_VIDEO_BITRATE,
+    );
+
+    const longest = Math.max(meta.width, meta.height);
+    const scale =
+        longest > RESOLUTION_CEILING ? RESOLUTION_CEILING / longest : 1;
+
+    return {
+        videoBitrate,
+        audioBitrate: AUDIO_BITRATE,
+        width: toEven(meta.width * scale),
+        height: toEven(meta.height * scale),
+    };
+}
+
+/**
+ * Next smaller even dimensions (longest edge −20%), or `null` once the longest
+ * edge would fall below the floor — the signal to stop retrying. Mirrors
+ * `ImageCompressor`'s quality-then-downscale fallback.
+ */
+export function nextDownscale(
+    width: number,
+    height: number,
+): { width: number; height: number } | null {
+    if (Math.max(width, height) * DOWNSCALE_STEP < DOWNSCALE_FLOOR) {
+        return null;
+    }
+
+    return {
+        width: toEven(width * DOWNSCALE_STEP),
+        height: toEven(height * DOWNSCALE_STEP),
+    };
+}
+
 export function readVideoMetadata(file: File): Promise<VideoMeta> {
     return new Promise((resolve, reject) => {
         const url = URL.createObjectURL(file);

--- a/resources/js/lib/video-editor/compress.ts
+++ b/resources/js/lib/video-editor/compress.ts
@@ -1,0 +1,142 @@
+import {
+    ALL_FORMATS,
+    BlobSource,
+    BufferTarget,
+    Conversion,
+    Input,
+    Mp4OutputFormat,
+    Output,
+    type ConversionVideoOptions,
+    type VideoCodec,
+} from 'mediabunny';
+
+import {
+    nextDownscale,
+    planVideoEncode,
+    readVideoMetadata,
+    VIDEO_MIN_BITRATE,
+} from '@/lib/compose/video';
+
+import { firstEncodableVideoCodec } from './support';
+
+/** Single-pass bitrate targeting is approximate, so allow a couple of corrective passes. */
+const MAX_ATTEMPTS = 3;
+/** Aim comfortably under the cap on the corrective pass so a near-miss doesn't loop. */
+const RETRY_HEADROOM = 0.9;
+
+type EncodeParams = {
+    codec: VideoCodec;
+    width: number;
+    height: number;
+    videoBitrate: number;
+    audioBitrate: number;
+};
+
+/**
+ * Re-encode `source` to fit within `maxBytes`, reusing the editor's mediabunny
+ * pipeline and encoder-capability probe. Returns the fitting `Blob`, or `null`
+ * when the browser can't encode or no resolution/bitrate combination fits (the
+ * caller then rejects with the same "too large" message as before).
+ *
+ * Lazy-imported (this pulls in mediabunny's chunk) the same way `render.ts` is.
+ */
+export async function compressVideoToFit(
+    source: Blob,
+    maxBytes: number,
+    onProgress: (fraction: number) => void,
+): Promise<Blob | null> {
+    const probe =
+        source instanceof File
+            ? source
+            : new File([source], 'video.mp4', { type: 'video/mp4' });
+    const meta = await readVideoMetadata(probe);
+    const plan = planVideoEncode(meta, maxBytes);
+
+    let { width, height, videoBitrate } = plan;
+    const audioBitrate = plan.audioBitrate;
+
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+        // Confirm an encoder that actually works at this exact output size —
+        // the same probe gating the crop UI, so they can't disagree.
+        const codec = await firstEncodableVideoCodec(width, height);
+        if (!codec) {
+            return null;
+        }
+
+        const blob = await encodeOnce(
+            source,
+            { codec, width, height, videoBitrate, audioBitrate },
+            onProgress,
+        );
+        if (blob === null) {
+            return null;
+        }
+        if (blob.size <= maxBytes) {
+            return blob;
+        }
+
+        // Overshot the cap: scale the bitrate by the observed ratio and drop a
+        // resolution step. Give up once we hit the dimension floor.
+        videoBitrate = Math.max(
+            Math.floor(videoBitrate * (maxBytes / blob.size) * RETRY_HEADROOM),
+            VIDEO_MIN_BITRATE,
+        );
+        const smaller = nextDownscale(width, height);
+        if (!smaller) {
+            return null;
+        }
+        width = smaller.width;
+        height = smaller.height;
+    }
+
+    return null;
+}
+
+async function encodeOnce(
+    source: Blob,
+    params: EncodeParams,
+    onProgress: (fraction: number) => void,
+): Promise<Blob | null> {
+    const input = new Input({
+        formats: ALL_FORMATS,
+        source: new BlobSource(source),
+    });
+
+    try {
+        const output = new Output({
+            format: new Mp4OutputFormat(),
+            target: new BufferTarget(),
+        });
+
+        const video: ConversionVideoOptions = {
+            codec: params.codec,
+            bitrate: params.videoBitrate,
+            width: params.width,
+            height: params.height,
+            fit: 'contain',
+            forceTranscode: true,
+        };
+
+        const conversion = await Conversion.init({
+            input,
+            output,
+            video,
+            // No-op when the source has no audio track.
+            audio: { bitrate: params.audioBitrate, forceTranscode: true },
+        });
+
+        if (!conversion.isValid) {
+            return null;
+        }
+
+        conversion.onProgress = (progress) => onProgress(progress);
+        await conversion.execute();
+
+        const buffer = output.target.buffer;
+        return buffer === null
+            ? null
+            : new Blob([buffer], { type: 'video/mp4' });
+    } finally {
+        input.dispose();
+    }
+}

--- a/resources/js/lib/video-editor/compress.ts
+++ b/resources/js/lib/video-editor/compress.ts
@@ -23,6 +23,8 @@ import { firstEncodableVideoCodec } from './support';
 const MAX_ATTEMPTS = 3;
 /** Aim comfortably under the cap on the corrective pass so a near-miss doesn't loop. */
 const RETRY_HEADROOM = 0.9;
+/** Fraction of the remaining progress bar each encode pass fills (keeps it monotonic). */
+const PROGRESS_BAND = 0.9;
 
 type EncodeParams = {
     codec: VideoCodec;
@@ -55,6 +57,11 @@ export async function compressVideoToFit(
     let { width, height, videoBitrate } = plan;
     const audioBitrate = plan.audioBitrate;
 
+    // mediabunny reports 0..1 per pass, so each corrective retry would restart at
+    // 0. Map every pass into a shrinking band above the previous one (0→.9,
+    // .9→.99, …) so the chip's percentage only ever climbs.
+    let progressFloor = 0;
+
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
         // Confirm an encoder that actually works at this exact output size —
         // the same probe gating the crop UI, so they can't disagree.
@@ -63,10 +70,13 @@ export async function compressVideoToFit(
             return null;
         }
 
+        const base = progressFloor;
+        const span = (1 - base) * PROGRESS_BAND;
+        progressFloor = base + span;
         const blob = await encodeOnce(
             source,
             { codec, width, height, videoBitrate, audioBitrate },
-            onProgress,
+            (fraction) => onProgress(base + fraction * span),
         );
         if (blob === null) {
             return null;

--- a/resources/js/types/compose.ts
+++ b/resources/js/types/compose.ts
@@ -67,6 +67,8 @@ export type MediaView = {
 /** An upload still in flight (or just failed) — rendered as a ghost chip. */
 export type PendingUpload = {
     tempId: string;
+    /** Image vs video — drives whether the preview chip renders <img> or <video>. */
+    kind: 'image' | 'video';
     /** Local object-URL preview shown immediately; absent where unsupported. */
     previewUrl?: string;
     status: 'processing' | 'uploading' | 'error';

--- a/resources/js/types/compose.ts
+++ b/resources/js/types/compose.ts
@@ -69,8 +69,8 @@ export type PendingUpload = {
     tempId: string;
     /** Local object-URL preview shown immediately; absent where unsupported. */
     previewUrl?: string;
-    status: 'uploading' | 'error';
-    /** Upload progress 0–100; only set during direct-to-storage PUT. */
+    status: 'processing' | 'uploading' | 'error';
+    /** Progress 0–100; set during client-side compression and the storage PUT. */
     progress?: number;
 };
 


### PR DESCRIPTION
## Summary

Over-cap videos are currently rejected at the validation gate. This re-encodes them in the browser before upload, so a clip exceeding the smallest selected platform's byte limit still publishes.

- **`compressVideoToFit`** (`lib/video-editor/compress.ts`) — re-encodes a clip to fit a byte budget, reusing the editor's mediabunny/WebCodecs pipeline and encoder-capability probe. Lazy-imported like `render.ts`. Corrective passes scale bitrate by the observed overshoot and drop a resolution step, giving up at the dimension floor.
- **Pure budget math** extracted into `lib/compose/video.ts` (`minVideoBytes`, `planVideoEncode`, `nextDownscale`) so the compose gate, editor gate, and encoder share one "target size" decision. Mirrors the existing image-compressor's quality-then-downscale fallback.
- **Wired into both flows**: direct upload (`use-media-uploads`) and post-edit (`use-video-editor`).
- **UI**: new `processing`/`compressing` pending state with progress in the media chips and video editor.
- Too-long clips are still rejected up front (re-encoding can't shorten them), so no doomed file flashes a ghost chip.

## Testing

- `vitest` — 12 tests pass, including new coverage for the budget helpers (bitrate floor, resolution ceiling, zero-duration guard, downscale floor).
- `tsc --noEmit`, `oxlint`, `oxfmt --check` all clean.
- ⚠️ Not yet verified in a real browser — compression runs on WebCodecs, which can't be exercised in the sandbox.