### PR TITLE
Improve mention picker

### DIFF
--- a/resources/js/components/compose/__tests__/editor-body.test.ts
+++ b/resources/js/components/compose/__tests__/editor-body.test.ts
@@ -11,7 +11,6 @@ import {
 import {
     hasPasteableMedia,
     isPasteableMediaFile,
-    shouldSelectMentionNameInput,
     shouldFocusEditorOnMount,
 } from '../editor-body';
 
@@ -38,15 +37,6 @@ describe('shouldFocusEditorOnMount', () => {
         expect(shouldFocusEditorOnMount(true, true)).toBe(true);
         expect(shouldFocusEditorOnMount(false, true)).toBe(false);
         expect(shouldFocusEditorOnMount(true, false)).toBe(false);
-    });
-});
-
-describe('shouldSelectMentionNameInput', () => {
-    it('does not reselect the mention name while the user is typing in it', () => {
-        const input = {} as HTMLInputElement;
-
-        expect(shouldSelectMentionNameInput(input, input)).toBe(false);
-        expect(shouldSelectMentionNameInput(input, null)).toBe(true);
     });
 });
 

--- a/resources/js/components/compose/__tests__/mention-picker.test.ts
+++ b/resources/js/components/compose/__tests__/mention-picker.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    mentionFilter,
+    savedMentionSearchKeywords,
+    shouldFocusMentionPickerSearch,
+} from '@/components/compose/mention-picker';
+
+describe('savedMentionSearchKeywords', () => {
+    it('includes platform handles without @ prefix', () => {
+        expect(
+            savedMentionSearchKeywords(
+                {
+                    id: '1',
+                    name: '@saved',
+                    handles: {
+                        x: '@saved_x',
+                        linkedin: 'Saved Name',
+                    },
+                },
+                ['x', 'linkedin'],
+            ),
+        ).toEqual(['saved_x', 'Saved Name']);
+    });
+});
+
+describe('mentionFilter', () => {
+    it('shows all items when search is empty', () => {
+        expect(mentionFilter('@saved', '', ['saved_x'])).toBe(1);
+    });
+
+    it('matches mention name and platform handle keywords', () => {
+        expect(mentionFilter('@saved', 'saved', ['saved_x'])).toBe(1);
+        expect(mentionFilter('@saved', 'saved_x', ['saved_x'])).toBe(1);
+        expect(mentionFilter('@saved', 'missing', ['saved_x'])).toBe(0);
+    });
+});
+
+describe('mention picker focus helpers', () => {
+    it('does not select the input while the user is already typing in it', () => {
+        const input = {} as HTMLInputElement;
+
+        expect(shouldFocusMentionPickerSearch(input, input)).toBe(false);
+        expect(shouldFocusMentionPickerSearch(input, null)).toBe(true);
+    });
+});

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -19,6 +19,7 @@ import {
     type ComposerState,
 } from '@/lib/compose/composer-state';
 import {
+    replaceMentionLabel,
     replaceMentionTokens,
     savedMentionToPlaceholder,
     syncMentionsFromText,
@@ -545,7 +546,9 @@ export default function Composer({
         next: MentionPlaceholder,
     ) {
         const replaceSeg = (segments: string[]): string[] =>
-            segments.map((s) => s.split(mention.label).join(next.label));
+            segments.map((s) =>
+                replaceMentionLabel(s, mention.label, next.label),
+            );
         const overrideByAccount = Object.fromEntries(
             Object.entries(state.overrideByAccount).map(([accountId, segs]) => [
                 accountId,

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/lib/compose/composer-state';
 import {
     replaceMentionTokens,
+    savedMentionToPlaceholder,
     syncMentionsFromText,
 } from '@/lib/compose/mentions';
 import { buildPlatformPreview } from '@/lib/compose/platform-preview';
@@ -577,14 +578,7 @@ export default function Composer({
         mention: MentionPlaceholder,
         saved: WorkspaceMention,
     ) {
-        renameMention(mention, {
-            id: saved.name
-                .replace(/^@/, '')
-                .toLowerCase()
-                .replace(/[^a-z0-9_-]+/g, '-'),
-            label: saved.name,
-            handles: saved.handles,
-        });
+        renameMention(mention, savedMentionToPlaceholder(saved));
     }
 
     async function saveMention(mention: MentionPlaceholder): Promise<void> {

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -2,12 +2,11 @@ import { EditorContent, useEditor } from '@tiptap/react';
 import { Split } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
-import { PlatformGlyph } from '@/components/common/platform-glyph';
 import MentionPicker from '@/components/compose/mention-picker';
 import {
     Popover,
+    PopoverAnchor,
     PopoverContent,
-    PopoverTrigger,
 } from '@/components/ui/popover';
 import { mentionInputValue, updateMentionName } from '@/lib/compose/mentions';
 import {
@@ -17,7 +16,9 @@ import {
 } from '@/lib/compose/tiptap-doc';
 import {
     editorContainsMentionLabel,
+    findMentionLabelStart,
     focusEditorAfterMentionLabel,
+    removeMentionLabel,
 } from '@/lib/compose/tiptap/mention-focus';
 import { composerExtensions } from '@/lib/compose/tiptap/setup';
 import { cn } from '@/lib/utils';
@@ -114,6 +115,14 @@ export default function EditorBody({
     const [activeMentionId, setActiveMentionId] = useState<string | null>(null);
     const previousMentionCount = useRef(mentions.length);
     const pendingFocusLabel = useRef<string | null>(null);
+    // A zero-size element pinned to the active `@`; the picker popover anchors to
+    // it so it floats beside the mention instead of inserting an in-flow bar that
+    // would shove the editor down. `ready` gates the popover open until the anchor
+    // has been positioned, so it never flashes at a stale spot on first open.
+    const containerRef = useRef<HTMLDivElement>(null);
+    const mentionAnchorRef = useRef<HTMLDivElement>(null);
+    const mentionWasActive = useRef(false);
+    const [mentionAnchorReady, setMentionAnchorReady] = useState(false);
     // editorProps is captured once at editor creation, but onPasteFiles is a
     // fresh closure each render (it reads the current media/limits). Route through
     // a ref so handlePaste always enforces the latest one-video / no-mixing rule.
@@ -271,6 +280,40 @@ export default function EditorBody({
             ? mentionPlatforms
             : ([markerPlatform ?? 'x'] as PlatformName[]);
 
+    // Place the floating anchor at the active `@` only on the open transition.
+    // The `@` does not move as the name is typed into the picker, so positioning
+    // once keeps the popover put; re-running on every keystroke would needlessly
+    // churn (and Radix would not re-measure an already-open popover anyway).
+    function positionMentionAnchor(label: string) {
+        const container = containerRef.current;
+        const anchor = mentionAnchorRef.current;
+        if (!editor || !container || !anchor) {
+            return;
+        }
+        const pos =
+            findMentionLabelStart(editor, label) ?? editor.state.selection.from;
+        const caret = editor.view.coordsAtPos(pos);
+        const rect = container.getBoundingClientRect();
+        anchor.style.left = `${caret.left - rect.left}px`;
+        anchor.style.top = `${caret.top - rect.top}px`;
+        anchor.style.height = `${caret.bottom - caret.top}px`;
+    }
+
+    useEffect(() => {
+        if (activeMention) {
+            if (!mentionWasActive.current) {
+                positionMentionAnchor(activeMention.label);
+                setMentionAnchorReady(true);
+            }
+            mentionWasActive.current = true;
+
+            return;
+        }
+        mentionWasActive.current = false;
+        setMentionAnchorReady(false);
+        // oxlint-disable-next-line react-hooks/exhaustive-deps
+    }, [editor, activeMentionId]);
+
     function updateMention(
         previous: MentionPlaceholder,
         next: MentionPlaceholder,
@@ -294,10 +337,19 @@ export default function EditorBody({
         tryFocusMentionLabel(mention.label);
     }
 
+    // Discard an empty mention: drop the bare `@` from the editor and close the
+    // picker. Triggered by Backspace in an empty search field or by Escape once
+    // the typed name has been cleared.
+    function removeActiveMention() {
+        if (!activeMention || !editor) {
+            return;
+        }
+        setActiveMentionId(null);
+        removeMentionLabel(editor, activeMention.label);
+    }
+
     // Escape in the picker is two-step: the first press clears the typed name
-    // (back to a bare `@`), the second closes the picker. The `@` itself stays
-    // in the editor so a literal `@` can still be typed, and focus returns to
-    // the editor so typing can continue right after it.
+    // (back to a bare `@`), the second discards the now-empty mention entirely.
     function handleMentionEscape() {
         if (!activeMention) {
             return;
@@ -307,12 +359,11 @@ export default function EditorBody({
 
             return;
         }
-        setActiveMentionId(null);
-        requestAnimationFrame(() => editor?.commands.focus());
+        removeActiveMention();
     }
 
     return (
-        <div className="relative">
+        <div ref={containerRef} className="relative">
             {overrideBanner && (
                 <output
                     className={cn(
@@ -350,54 +401,52 @@ export default function EditorBody({
                     )}
                 </output>
             )}
-            {editable && onMentionsChange && activeMention && (
-                <div className="flex items-center border-b border-border/70 px-4 py-2 sm:px-[26px]">
-                    <Popover
-                        open
-                        onOpenChange={(open) => {
-                            if (!open) {
-                                setActiveMentionId(null);
-                            }
+            <Popover
+                open={
+                    !!(editable && onMentionsChange && activeMention) &&
+                    mentionAnchorReady
+                }
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setActiveMentionId(null);
+                    }
+                }}
+            >
+                <PopoverAnchor asChild>
+                    <div
+                        ref={mentionAnchorRef}
+                        aria-hidden
+                        className="pointer-events-none absolute w-0"
+                    />
+                </PopoverAnchor>
+                {activeMention && (
+                    <PopoverContent
+                        align="start"
+                        side="bottom"
+                        sideOffset={8}
+                        className="w-80 gap-0 rounded-2xl p-2"
+                        onOpenAutoFocus={(event) => event.preventDefault()}
+                        onEscapeKeyDown={(event) => {
+                            event.preventDefault();
+                            handleMentionEscape();
                         }}
                     >
-                        <PopoverTrigger asChild>
-                            <button
-                                type="button"
-                                className="inline-flex items-center gap-1.5 rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary shadow-sm"
-                            >
-                                <PlatformGlyph
-                                    platform={activePlatforms[0] ?? 'x'}
-                                    size={12}
-                                    className="shrink-0"
-                                />
-                                {activeMention.label}
-                            </button>
-                        </PopoverTrigger>
-                        <PopoverContent
-                            align="start"
-                            className="w-80 gap-0 rounded-2xl p-2"
-                            onOpenAutoFocus={(event) => event.preventDefault()}
-                            onEscapeKeyDown={(event) => {
-                                event.preventDefault();
-                                handleMentionEscape();
+                        <MentionPicker
+                            activeMention={activeMention}
+                            savedMentions={savedMentions}
+                            activePlatforms={activePlatforms}
+                            onApplySavedMention={(saved) => {
+                                onApplySavedMention?.(activeMention, saved);
                             }}
-                        >
-                            <MentionPicker
-                                activeMention={activeMention}
-                                savedMentions={savedMentions}
-                                activePlatforms={activePlatforms}
-                                onApplySavedMention={(saved) => {
-                                    onApplySavedMention?.(activeMention, saved);
-                                }}
-                                onUpdateMention={updateMention}
-                                onSaveMention={onSaveMention}
-                                saveMentionProcessing={saveMentionProcessing}
-                                onMentionComplete={completeMention}
-                            />
-                        </PopoverContent>
-                    </Popover>
-                </div>
-            )}
+                            onUpdateMention={updateMention}
+                            onSaveMention={onSaveMention}
+                            saveMentionProcessing={saveMentionProcessing}
+                            onMentionComplete={completeMention}
+                            onRemoveMention={removeActiveMention}
+                        />
+                    </PopoverContent>
+                )}
+            </Popover>
             <div className="px-4 pt-[22px] pb-[18px] sm:px-[26px]">
                 <EditorContent
                     editor={editor}

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -3,28 +3,21 @@ import { Split } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { PlatformGlyph } from '@/components/common/platform-glyph';
-import {
-    InputGroup,
-    InputGroupAddon,
-    InputGroupInput,
-} from '@/components/ui/input-group';
+import MentionPicker from '@/components/compose/mention-picker';
 import {
     Popover,
     PopoverContent,
     PopoverTrigger,
 } from '@/components/ui/popover';
 import {
-    mentionInputValue,
-    setPlatformMentionMode,
-    updateMentionHandle,
-    updateMentionName,
-    usesPlatformMention,
-} from '@/lib/compose/mentions';
-import {
     docToSegments,
     segmentsToDoc,
     type DocNode,
 } from '@/lib/compose/tiptap-doc';
+import {
+    editorContainsMentionLabel,
+    focusEditorAfterMentionLabel,
+} from '@/lib/compose/tiptap/mention-focus';
 import { composerExtensions } from '@/lib/compose/tiptap/setup';
 import { cn } from '@/lib/utils';
 import type {
@@ -96,13 +89,6 @@ export function hasPasteableMedia(files: FileList | null | undefined): boolean {
     return !!files && Array.from(files).some(isPasteableMediaFile);
 }
 
-export function shouldSelectMentionNameInput(
-    input: HTMLInputElement | null,
-    activeElement: Element | null,
-): boolean {
-    return !!input && input !== activeElement;
-}
-
 export default function EditorBody({
     value,
     onChange,
@@ -126,7 +112,7 @@ export default function EditorBody({
 }: EditorBodyProps) {
     const [activeMentionId, setActiveMentionId] = useState<string | null>(null);
     const previousMentionCount = useRef(mentions.length);
-    const mentionNameInput = useRef<HTMLInputElement>(null);
+    const pendingFocusLabel = useRef<string | null>(null);
     // editorProps is captured once at editor creation, but onPasteFiles is a
     // fresh closure each render (it reads the current media/limits). Route through
     // a ref so handlePaste always enforces the latest one-video / no-mixing rule.
@@ -182,6 +168,37 @@ export default function EditorBody({
                 emitUpdate: false,
             });
         }
+        // oxlint-disable-next-line react-hooks/exhaustive-deps
+    }, [value, editor]);
+
+    // Focus the editor after `label` once it actually lands in the document.
+    // Completing a mention updates `value` first, so the label may not be present
+    // yet — in that case defer to the value-change effect below. Membership is
+    // boundary-aware so a stale request can't be satisfied by an unrelated token
+    // that merely contains the label as a substring.
+    function tryFocusMentionLabel(label: string) {
+        if (!editor) {
+            return;
+        }
+
+        if (!editorContainsMentionLabel(editor, label)) {
+            pendingFocusLabel.current = label;
+
+            return;
+        }
+
+        pendingFocusLabel.current = null;
+        requestAnimationFrame(() => {
+            focusEditorAfterMentionLabel(editor, label);
+        });
+    }
+
+    useEffect(() => {
+        if (!editor || pendingFocusLabel.current === null) {
+            return;
+        }
+
+        tryFocusMentionLabel(pendingFocusLabel.current);
         // oxlint-disable-next-line react-hooks/exhaustive-deps
     }, [value, editor]);
 
@@ -253,26 +270,6 @@ export default function EditorBody({
             ? mentionPlatforms
             : ([markerPlatform ?? 'x'] as PlatformName[]);
 
-    useEffect(() => {
-        if (!activeMentionId) {
-            return;
-        }
-
-        const frame = window.requestAnimationFrame(() => {
-            mentionNameInput.current?.focus();
-            if (
-                shouldSelectMentionNameInput(
-                    mentionNameInput.current,
-                    document.activeElement,
-                )
-            ) {
-                mentionNameInput.current?.select();
-            }
-        });
-
-        return () => window.cancelAnimationFrame(frame);
-    }, [activeMentionId]);
-
     function updateMention(
         previous: MentionPlaceholder,
         next: MentionPlaceholder,
@@ -289,6 +286,11 @@ export default function EditorBody({
                 mention.id === next.id ? next : mention,
             ),
         );
+    }
+
+    function completeMention(mention: MentionPlaceholder) {
+        setActiveMentionId(null);
+        tryFocusMentionLabel(mention.label);
     }
 
     return (
@@ -355,193 +357,21 @@ export default function EditorBody({
                         </PopoverTrigger>
                         <PopoverContent
                             align="start"
-                            className="w-80 gap-3 rounded-2xl p-3"
+                            className="w-80 gap-0 rounded-2xl p-2"
+                            onOpenAutoFocus={(event) => event.preventDefault()}
                         >
-                            <div>
-                                <div className="text-xs font-medium text-muted-foreground">
-                                    Mention Name
-                                </div>
-                                <InputGroup className="mt-1.5 h-9 rounded-lg border-border bg-background">
-                                    <InputGroupAddon>@</InputGroupAddon>
-                                    <InputGroupInput
-                                        ref={mentionNameInput}
-                                        value={mentionInputValue(
-                                            activeMention.label,
-                                        )}
-                                        placeholder="name"
-                                        aria-label="Mention name shown in the post"
-                                        onChange={(event) =>
-                                            updateMention(
-                                                activeMention,
-                                                updateMentionName(
-                                                    activeMention,
-                                                    event.target.value,
-                                                ),
-                                            )
-                                        }
-                                    />
-                                </InputGroup>
-                            </div>
-                            <div className="text-xs font-medium text-muted-foreground">
-                                Platform handles
-                            </div>
-                            <div className="flex flex-col gap-2">
-                                {activePlatforms.map((platform, index) => {
-                                    const canUseMention =
-                                        platform !== 'linkedin';
-                                    const useMention =
-                                        canUseMention &&
-                                        usesPlatformMention(
-                                            activeMention,
-                                            platform,
-                                        );
-                                    const value =
-                                        activeMention.handles[platform] ??
-                                        activeMention.label;
-
-                                    return (
-                                        <label
-                                            key={platform}
-                                            className="flex flex-col gap-1.5 text-xs"
-                                        >
-                                            <span className="inline-flex items-center gap-1.5 text-muted-foreground">
-                                                <PlatformGlyph
-                                                    platform={platform}
-                                                    size={14}
-                                                    className="text-foreground"
-                                                />
-                                                <span className="capitalize">
-                                                    {platform}
-                                                </span>
-                                            </span>
-                                            <div className="flex gap-2">
-                                                <InputGroup className="h-9 min-w-0 flex-1 rounded-lg border-border bg-background">
-                                                    {useMention && (
-                                                        <InputGroupAddon>
-                                                            @
-                                                        </InputGroupAddon>
-                                                    )}
-                                                    <InputGroupInput
-                                                        value={mentionInputValue(
-                                                            value,
-                                                        )}
-                                                        placeholder={
-                                                            useMention
-                                                                ? 'handle'
-                                                                : 'display name'
-                                                        }
-                                                        aria-label={`${platform} ${
-                                                            useMention
-                                                                ? 'handle'
-                                                                : 'display text'
-                                                        } for ${activeMention.label}`}
-                                                        onChange={(event) =>
-                                                            updateMention(
-                                                                activeMention,
-                                                                updateMentionHandle(
-                                                                    activeMention,
-                                                                    platform,
-                                                                    event.target
-                                                                        .value,
-                                                                    useMention,
-                                                                ),
-                                                            )
-                                                        }
-                                                        autoFocus={index === 0}
-                                                    />
-                                                </InputGroup>
-                                                {canUseMention && (
-                                                    <button
-                                                        type="button"
-                                                        className="h-9 shrink-0 rounded-lg border border-border px-2.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
-                                                        onClick={() =>
-                                                            updateMention(
-                                                                activeMention,
-                                                                setPlatformMentionMode(
-                                                                    activeMention,
-                                                                    platform,
-                                                                    !useMention,
-                                                                ),
-                                                            )
-                                                        }
-                                                    >
-                                                        {useMention
-                                                            ? 'Use text only'
-                                                            : 'Use @ mention'}
-                                                    </button>
-                                                )}
-                                            </div>
-                                        </label>
-                                    );
-                                })}
-                            </div>
-                            {onSaveMention && (
-                                <button
-                                    type="button"
-                                    disabled={saveMentionProcessing}
-                                    onClick={() =>
-                                        void onSaveMention(activeMention)
-                                    }
-                                    className="rounded-lg bg-primary px-3 py-2 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
-                                >
-                                    {saveMentionProcessing
-                                        ? 'Saving…'
-                                        : 'Save to workspace'}
-                                </button>
-                            )}
-                            {savedMentions.length > 0 && (
-                                <div className="flex flex-col gap-2 border-t border-border/70 pt-3">
-                                    <div className="text-xs font-medium text-muted-foreground">
-                                        Saved mentions
-                                    </div>
-                                    <div className="flex flex-col gap-1">
-                                        {savedMentions.map((saved) => (
-                                            <button
-                                                key={saved.id}
-                                                type="button"
-                                                onClick={() => {
-                                                    onApplySavedMention?.(
-                                                        activeMention,
-                                                        saved,
-                                                    );
-                                                    setActiveMentionId(
-                                                        saved.name
-                                                            .replace(/^@/, '')
-                                                            .toLowerCase()
-                                                            .replace(
-                                                                /[^a-z0-9_-]+/g,
-                                                                '-',
-                                                            ),
-                                                    );
-                                                }}
-                                                className="flex items-center justify-between gap-3 rounded-lg px-2.5 py-2 text-left text-sm transition-colors hover:bg-muted"
-                                            >
-                                                <span className="font-medium text-foreground">
-                                                    {saved.name}
-                                                </span>
-                                                <span className="flex items-center gap-1 text-muted-foreground">
-                                                    {activePlatforms
-                                                        .filter(
-                                                            (platform) =>
-                                                                saved.handles[
-                                                                    platform
-                                                                ],
-                                                        )
-                                                        .map((platform) => (
-                                                            <PlatformGlyph
-                                                                key={platform}
-                                                                platform={
-                                                                    platform
-                                                                }
-                                                                size={13}
-                                                            />
-                                                        ))}
-                                                </span>
-                                            </button>
-                                        ))}
-                                    </div>
-                                </div>
-                            )}
+                            <MentionPicker
+                                activeMention={activeMention}
+                                savedMentions={savedMentions}
+                                activePlatforms={activePlatforms}
+                                onApplySavedMention={(saved) => {
+                                    onApplySavedMention?.(activeMention, saved);
+                                }}
+                                onUpdateMention={updateMention}
+                                onSaveMention={onSaveMention}
+                                saveMentionProcessing={saveMentionProcessing}
+                                onMentionComplete={completeMention}
+                            />
                         </PopoverContent>
                     </Popover>
                 </div>

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -9,6 +9,7 @@ import {
     PopoverContent,
     PopoverTrigger,
 } from '@/components/ui/popover';
+import { mentionInputValue, updateMentionName } from '@/lib/compose/mentions';
 import {
     docToSegments,
     segmentsToDoc,
@@ -293,6 +294,23 @@ export default function EditorBody({
         tryFocusMentionLabel(mention.label);
     }
 
+    // Escape in the picker is two-step: the first press clears the typed name
+    // (back to a bare `@`), the second closes the picker. The `@` itself stays
+    // in the editor so a literal `@` can still be typed, and focus returns to
+    // the editor so typing can continue right after it.
+    function handleMentionEscape() {
+        if (!activeMention) {
+            return;
+        }
+        if (mentionInputValue(activeMention.label) !== '') {
+            updateMention(activeMention, updateMentionName(activeMention, ''));
+
+            return;
+        }
+        setActiveMentionId(null);
+        requestAnimationFrame(() => editor?.commands.focus());
+    }
+
     return (
         <div className="relative">
             {overrideBanner && (
@@ -359,6 +377,10 @@ export default function EditorBody({
                             align="start"
                             className="w-80 gap-0 rounded-2xl p-2"
                             onOpenAutoFocus={(event) => event.preventDefault()}
+                            onEscapeKeyDown={(event) => {
+                                event.preventDefault();
+                                handleMentionEscape();
+                            }}
                         >
                             <MentionPicker
                                 activeMention={activeMention}

--- a/resources/js/components/compose/mention-picker.tsx
+++ b/resources/js/components/compose/mention-picker.tsx
@@ -1,0 +1,436 @@
+import { ArrowLeft, Plus } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState, type RefObject } from 'react';
+
+import { PlatformGlyph } from '@/components/common/platform-glyph';
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+    CommandSeparator,
+} from '@/components/ui/command';
+import {
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+} from '@/components/ui/input-group';
+import {
+    mentionInputValue,
+    normalizeMentionName,
+    savedMentionToPlaceholder,
+    setPlatformMentionMode,
+    updateMentionHandle,
+    updateMentionName,
+    usesPlatformMention,
+} from '@/lib/compose/mentions';
+import { cn } from '@/lib/utils';
+import type {
+    MentionPlaceholder,
+    PlatformName,
+    WorkspaceMention,
+} from '@/types/compose';
+
+export type MentionPickerMode = 'search' | 'edit';
+
+type MentionPickerProps = {
+    activeMention: MentionPlaceholder;
+    savedMentions: WorkspaceMention[];
+    activePlatforms: PlatformName[];
+    onApplySavedMention: (saved: WorkspaceMention) => void;
+    onUpdateMention: (
+        previous: MentionPlaceholder,
+        next: MentionPlaceholder,
+    ) => void;
+    onSaveMention?: (mention: MentionPlaceholder) => Promise<void>;
+    saveMentionProcessing?: boolean;
+    onMentionComplete?: (mention: MentionPlaceholder) => void;
+};
+
+export function savedMentionSearchKeywords(
+    saved: WorkspaceMention,
+    platforms: PlatformName[],
+): string[] {
+    const keywords: string[] = [];
+
+    for (const platform of platforms) {
+        const handle = saved.handles[platform];
+        if (handle) {
+            keywords.push(mentionInputValue(handle));
+        }
+    }
+
+    return keywords;
+}
+
+export function shouldFocusMentionPickerSearch(
+    input: HTMLInputElement | null,
+    activeElement: Element | null,
+): boolean {
+    return !!input && input !== activeElement;
+}
+
+export function mentionFilter(
+    value: string,
+    search: string,
+    keywords?: string[],
+): number {
+    const needle = search.trim().toLowerCase();
+
+    if (needle === '') {
+        return 1;
+    }
+
+    const tokens = [value, ...(keywords ?? [])].map((token) =>
+        mentionInputValue(token).toLowerCase(),
+    );
+    if (tokens.some((token) => token.startsWith(needle))) {
+        return 1;
+    }
+    if (tokens.some((token) => token.includes(needle))) {
+        return 0.5;
+    }
+
+    return 0;
+}
+
+export default function MentionPicker({
+    activeMention,
+    savedMentions,
+    activePlatforms,
+    onApplySavedMention,
+    onUpdateMention,
+    onSaveMention,
+    saveMentionProcessing = false,
+    onMentionComplete,
+}: MentionPickerProps) {
+    const [mode, setMode] = useState<MentionPickerMode>('search');
+    const searchInputRef = useRef<HTMLInputElement>(null);
+    const mentionNameInputRef = useRef<HTMLInputElement>(null);
+    const search = mentionInputValue(activeMention.label);
+    const createLabel = normalizeMentionName(search);
+
+    // Focus (and select) whichever field the current mode exposes. Both modes
+    // share the same defer-a-frame-then-focus dance, so they live in one effect.
+    // It also re-runs when the active mention changes — a different chip clicked
+    // or a brand-new @mention — so focus follows it. The shouldFocus guard skips
+    // select() while the field is already focused, so renaming the current
+    // mention (whose id changes on every keystroke) leaves typing untouched.
+    useEffect(() => {
+        const ref = mode === 'edit' ? mentionNameInputRef : searchInputRef;
+
+        const frame = window.requestAnimationFrame(() => {
+            const input = ref.current;
+            if (!input) {
+                return;
+            }
+            const shouldSelect = shouldFocusMentionPickerSearch(
+                input,
+                document.activeElement,
+            );
+            input.focus();
+            if (shouldSelect) {
+                input.select();
+            }
+        });
+
+        return () => window.cancelAnimationFrame(frame);
+    }, [mode, activeMention.id]);
+
+    const savedMentionKeywords = useMemo(
+        () =>
+            new Map(
+                savedMentions.map((saved) => [
+                    saved.id,
+                    savedMentionSearchKeywords(saved, activePlatforms),
+                ]),
+            ),
+        // Keyed on the platform set by value: activePlatforms is a fresh array
+        // each render, so depending on its identity would defeat the memo.
+        // oxlint-disable-next-line react-hooks/exhaustive-deps
+        [savedMentions, activePlatforms.join(',')],
+    );
+
+    function selectSaved(saved: WorkspaceMention) {
+        onApplySavedMention(saved);
+        onMentionComplete?.(savedMentionToPlaceholder(saved));
+    }
+
+    async function saveAndComplete(mention: MentionPlaceholder) {
+        if (!onSaveMention) {
+            return;
+        }
+
+        await onSaveMention(mention);
+        onMentionComplete?.(mention);
+    }
+
+    function openCreateMode() {
+        // `search` is derived from activeMention.label, so the typed name is
+        // already applied live via the input's onValueChange — no rename needed.
+        setMode('edit');
+    }
+
+    if (mode === 'edit') {
+        return (
+            <div className="flex flex-col gap-3">
+                <button
+                    type="button"
+                    onClick={() => setMode('search')}
+                    className="inline-flex items-center gap-1.5 self-start rounded-md px-1 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                    <ArrowLeft className="size-3.5" aria-hidden />
+                    Back to search
+                </button>
+                <MentionHandleEditor
+                    activeMention={activeMention}
+                    activePlatforms={activePlatforms}
+                    mentionNameInputRef={mentionNameInputRef}
+                    onUpdateMention={onUpdateMention}
+                    onSave={
+                        onSaveMention
+                            ? () => void saveAndComplete(activeMention)
+                            : undefined
+                    }
+                    saveMentionProcessing={saveMentionProcessing}
+                />
+            </div>
+        );
+    }
+
+    return (
+        <Command
+            filter={mentionFilter}
+            className="rounded-xl bg-transparent p-0"
+        >
+            <CommandInput
+                ref={searchInputRef}
+                value={search}
+                placeholder="Search saved mentions…"
+                aria-label="Mention name shown in the post"
+                onValueChange={(value) =>
+                    onUpdateMention(
+                        activeMention,
+                        updateMentionName(activeMention, value),
+                    )
+                }
+            />
+            <CommandList className="max-h-56">
+                <CommandEmpty className="py-4">
+                    <button
+                        type="button"
+                        onClick={openCreateMode}
+                        className="inline-flex w-full items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                    >
+                        <Plus className="size-3.5" aria-hidden />
+                        {search.trim() === ''
+                            ? 'Create new mention'
+                            : `Create ${createLabel}`}
+                    </button>
+                </CommandEmpty>
+                {savedMentions.length > 0 && (
+                    <CommandGroup heading="Saved mentions">
+                        {savedMentions.map((saved) => (
+                            <CommandItem
+                                key={saved.id}
+                                value={saved.name}
+                                keywords={savedMentionKeywords.get(saved.id)}
+                                onSelect={() => selectSaved(saved)}
+                                className="flex items-center justify-between gap-3"
+                            >
+                                <span className="font-medium">
+                                    {saved.name}
+                                </span>
+                                <span className="flex items-center gap-1 text-muted-foreground">
+                                    {activePlatforms
+                                        .filter(
+                                            (platform) =>
+                                                saved.handles[platform],
+                                        )
+                                        .map((platform) => (
+                                            <PlatformGlyph
+                                                key={platform}
+                                                platform={platform}
+                                                size={13}
+                                            />
+                                        ))}
+                                </span>
+                            </CommandItem>
+                        ))}
+                    </CommandGroup>
+                )}
+                {savedMentions.length > 0 && search.trim() !== '' && (
+                    <>
+                        <CommandSeparator />
+                        <CommandGroup>
+                            <CommandItem
+                                value={`__create__${createLabel}`}
+                                onSelect={openCreateMode}
+                                className="text-primary"
+                            >
+                                <Plus className="size-3.5" aria-hidden />
+                                Create {createLabel} as new mention
+                            </CommandItem>
+                        </CommandGroup>
+                    </>
+                )}
+            </CommandList>
+            <div className="border-t border-border/70 pt-2">
+                <button
+                    type="button"
+                    onClick={() => setMode('edit')}
+                    className="w-full rounded-lg px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                    Edit platform handles for {activeMention.label}
+                </button>
+            </div>
+        </Command>
+    );
+}
+
+type MentionHandleEditorProps = {
+    activeMention: MentionPlaceholder;
+    activePlatforms: PlatformName[];
+    mentionNameInputRef: RefObject<HTMLInputElement | null>;
+    onUpdateMention: (
+        previous: MentionPlaceholder,
+        next: MentionPlaceholder,
+    ) => void;
+    /** Omitted when workspace saving is unsupported, which hides the Save button. */
+    onSave?: () => void;
+    saveMentionProcessing?: boolean;
+};
+
+function MentionHandleEditor({
+    activeMention,
+    activePlatforms,
+    mentionNameInputRef,
+    onUpdateMention,
+    onSave,
+    saveMentionProcessing = false,
+}: MentionHandleEditorProps) {
+    return (
+        <>
+            <div>
+                <div className="text-xs font-medium text-muted-foreground">
+                    Mention name
+                </div>
+                <InputGroup className="mt-1.5 h-9 rounded-lg border-border bg-background">
+                    <InputGroupAddon>@</InputGroupAddon>
+                    <InputGroupInput
+                        ref={mentionNameInputRef}
+                        value={mentionInputValue(activeMention.label)}
+                        placeholder="name"
+                        aria-label="Mention name shown in the post"
+                        onChange={(event) =>
+                            onUpdateMention(
+                                activeMention,
+                                updateMentionName(
+                                    activeMention,
+                                    event.target.value,
+                                ),
+                            )
+                        }
+                    />
+                </InputGroup>
+            </div>
+            <div className="text-xs font-medium text-muted-foreground">
+                Platform handles
+            </div>
+            <div className="flex flex-col gap-2">
+                {activePlatforms.map((platform) => {
+                    const canUseMention = platform !== 'linkedin';
+                    const useMention =
+                        canUseMention &&
+                        usesPlatformMention(activeMention, platform);
+                    const handleValue =
+                        activeMention.handles[platform] ?? activeMention.label;
+
+                    return (
+                        <label
+                            key={platform}
+                            className="flex flex-col gap-1.5 text-xs"
+                        >
+                            <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                                <PlatformGlyph
+                                    platform={platform}
+                                    size={14}
+                                    className="text-foreground"
+                                />
+                                <span className="capitalize">{platform}</span>
+                            </span>
+                            <div className="flex gap-2">
+                                <InputGroup className="h-9 min-w-0 flex-1 rounded-lg border-border bg-background">
+                                    {useMention && (
+                                        <InputGroupAddon>@</InputGroupAddon>
+                                    )}
+                                    <InputGroupInput
+                                        value={mentionInputValue(handleValue)}
+                                        placeholder={
+                                            useMention
+                                                ? 'handle'
+                                                : 'display name'
+                                        }
+                                        aria-label={`${platform} ${
+                                            useMention
+                                                ? 'handle'
+                                                : 'display text'
+                                        } for ${activeMention.label}`}
+                                        onChange={(event) =>
+                                            onUpdateMention(
+                                                activeMention,
+                                                updateMentionHandle(
+                                                    activeMention,
+                                                    platform,
+                                                    event.target.value,
+                                                    useMention,
+                                                ),
+                                            )
+                                        }
+                                    />
+                                </InputGroup>
+                                {canUseMention && (
+                                    <button
+                                        type="button"
+                                        className="h-9 shrink-0 rounded-lg border border-border px-2.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+                                        onClick={() =>
+                                            onUpdateMention(
+                                                activeMention,
+                                                setPlatformMentionMode(
+                                                    activeMention,
+                                                    platform,
+                                                    !useMention,
+                                                ),
+                                            )
+                                        }
+                                    >
+                                        {useMention
+                                            ? 'Use text only'
+                                            : 'Use @ mention'}
+                                    </button>
+                                )}
+                            </div>
+                        </label>
+                    );
+                })}
+            </div>
+            {onSave && (
+                <button
+                    type="button"
+                    disabled={
+                        saveMentionProcessing ||
+                        mentionInputValue(activeMention.label).trim() === ''
+                    }
+                    onClick={onSave}
+                    className={cn(
+                        'rounded-lg bg-primary px-3 py-2 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90',
+                        'disabled:cursor-not-allowed disabled:opacity-60',
+                    )}
+                >
+                    {saveMentionProcessing ? 'Saving…' : 'Save to workspace'}
+                </button>
+            )}
+        </>
+    );
+}

--- a/resources/js/components/compose/mention-picker.tsx
+++ b/resources/js/components/compose/mention-picker.tsx
@@ -46,6 +46,8 @@ type MentionPickerProps = {
     onSaveMention?: (mention: MentionPlaceholder) => Promise<void>;
     saveMentionProcessing?: boolean;
     onMentionComplete?: (mention: MentionPlaceholder) => void;
+    /** Discard the in-progress mention (Backspace on an empty search field). */
+    onRemoveMention?: () => void;
 };
 
 export function savedMentionSearchKeywords(
@@ -104,6 +106,7 @@ export default function MentionPicker({
     onSaveMention,
     saveMentionProcessing = false,
     onMentionComplete,
+    onRemoveMention,
 }: MentionPickerProps) {
     const [mode, setMode] = useState<MentionPickerMode>('search');
     const searchInputRef = useRef<HTMLInputElement>(null);
@@ -114,11 +117,15 @@ export default function MentionPicker({
     // Focus (and select) whichever field the current mode exposes. Both modes
     // share the same defer-a-frame-then-focus dance, so they live in one effect.
     // It also re-runs when the active mention changes — a different chip clicked
-    // or a brand-new @mention — so focus follows it. The shouldFocus guard skips
-    // select() while the field is already focused, so renaming the current
-    // mention (whose id changes on every keystroke) leaves typing untouched.
+    // or a brand-new @mention — so focus follows it. Renaming the current mention
+    // re-runs this too (its id changes on every keystroke), but the field is
+    // already focused then, so the early return leaves the caret untouched.
     useEffect(() => {
         const ref = mode === 'edit' ? mentionNameInputRef : searchInputRef;
+
+        if (ref.current && ref.current === document.activeElement) {
+            return;
+        }
 
         const frame = window.requestAnimationFrame(() => {
             const input = ref.current;
@@ -215,19 +222,16 @@ export default function MentionPicker({
                         updateMentionName(activeMention, value),
                     )
                 }
+                onKeyDown={(event) => {
+                    if (event.key === 'Backspace' && search === '') {
+                        event.preventDefault();
+                        onRemoveMention?.();
+                    }
+                }}
             />
             <CommandList className="max-h-56">
-                <CommandEmpty className="py-4">
-                    <button
-                        type="button"
-                        onClick={openCreateMode}
-                        className="inline-flex w-full items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-                    >
-                        <Plus className="size-3.5" aria-hidden />
-                        {search.trim() === ''
-                            ? 'Create new mention'
-                            : `Create ${createLabel}`}
-                    </button>
+                <CommandEmpty className="py-6 text-center text-xs text-muted-foreground">
+                    Type a name to create a mention
                 </CommandEmpty>
                 {savedMentions.length > 0 && (
                     <CommandGroup heading="Saved mentions">
@@ -260,9 +264,9 @@ export default function MentionPicker({
                         ))}
                     </CommandGroup>
                 )}
-                {savedMentions.length > 0 && search.trim() !== '' && (
+                {search.trim() !== '' && (
                     <>
-                        <CommandSeparator />
+                        {savedMentions.length > 0 && <CommandSeparator />}
                         <CommandGroup>
                             <CommandItem
                                 value={`__create__${createLabel}`}
@@ -276,15 +280,6 @@ export default function MentionPicker({
                     </>
                 )}
             </CommandList>
-            <div className="border-t border-border/70 pt-2">
-                <button
-                    type="button"
-                    onClick={() => setMode('edit')}
-                    className="w-full rounded-lg px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                >
-                    Edit platform handles for {activeMention.label}
-                </button>
-            </div>
         </Command>
     );
 }

--- a/resources/js/components/ui/command.tsx
+++ b/resources/js/components/ui/command.tsx
@@ -63,10 +63,11 @@ function CommandDialog({
   )
 }
 
-const CommandInput = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Input>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(function CommandInput({ className, ...props }, ref) {
+function CommandInput({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
   return (
     <div data-slot="command-input-wrapper" className="p-1 pb-0">
       <InputGroup className="h-8! bg-input/50">
@@ -85,7 +86,7 @@ const CommandInput = React.forwardRef<
       </InputGroup>
     </div>
   )
-})
+}
 
 function CommandList({
   className,

--- a/resources/js/components/ui/command.tsx
+++ b/resources/js/components/ui/command.tsx
@@ -63,14 +63,15 @@ function CommandDialog({
   )
 }
 
-function CommandInput({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(function CommandInput({ className, ...props }, ref) {
   return (
     <div data-slot="command-input-wrapper" className="p-1 pb-0">
       <InputGroup className="h-8! bg-input/50">
         <CommandPrimitive.Input
+          ref={ref}
           data-slot="command-input"
           className={cn(
             "w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
@@ -84,7 +85,7 @@ function CommandInput({
       </InputGroup>
     </div>
   )
-}
+})
 
 function CommandList({
   className,

--- a/resources/js/lib/compose/__tests__/mentions.test.ts
+++ b/resources/js/lib/compose/__tests__/mentions.test.ts
@@ -4,6 +4,7 @@ import {
     createMention,
     mentionInputValue,
     mentionToken,
+    replaceMentionLabel,
     replaceMentionTokens,
     setPlatformMentionMode,
     updateMentionHandle,
@@ -12,6 +13,44 @@ import {
     usesPlatformMention,
     type MentionPlaceholder,
 } from '../mentions';
+
+describe('replaceMentionLabel', () => {
+    it('renames a whole mention token', () => {
+        expect(
+            replaceMentionLabel('hi @guest there', '@guest', '@guest2'),
+        ).toBe('hi @guest2 there');
+        expect(
+            replaceMentionLabel('@guest and @guest', '@guest', '@member'),
+        ).toBe('@member and @member');
+    });
+
+    it('renames the in-progress "@" without rewriting other handles', () => {
+        // Regression: a naive replaceAll("@", "@member") corrupted "@guest".
+        expect(replaceMentionLabel('@guest @', '@', '@member')).toBe(
+            '@guest @member',
+        );
+    });
+
+    it('leaves the label alone when it is only part of a longer token', () => {
+        expect(replaceMentionLabel('@guest', '@', '@member')).toBe('@guest');
+        expect(replaceMentionLabel('email@guest', '@guest', '@member')).toBe(
+            'email@guest',
+        );
+    });
+
+    it('honors trailing boundary punctuation', () => {
+        expect(replaceMentionLabel('hey @guest!', '@guest', '@member')).toBe(
+            'hey @member!',
+        );
+    });
+
+    it('is a no-op for an empty or unchanged label', () => {
+        expect(replaceMentionLabel('@guest', '', '@member')).toBe('@guest');
+        expect(replaceMentionLabel('@guest', '@guest', '@guest')).toBe(
+            '@guest',
+        );
+    });
+});
 
 describe('mention helpers', () => {
     it('creates mention metadata from a typed handle', () => {

--- a/resources/js/lib/compose/mentions.ts
+++ b/resources/js/lib/compose/mentions.ts
@@ -196,6 +196,48 @@ export function mentionInputValue(name: string): string {
     return name.replace(/^@/, '');
 }
 
+/**
+ * Replace whole-token occurrences of `fromLabel` with `toLabel`. A label that is
+ * only a substring of a longer handle is left alone — so renaming the in-progress
+ * `@` mention does not rewrite the `@` inside an existing `@handle`.
+ */
+export function replaceMentionLabel(
+    text: string,
+    fromLabel: string,
+    toLabel: string,
+): string {
+    if (fromLabel === '' || fromLabel === toLabel) {
+        return text;
+    }
+
+    let result = '';
+    let cursor = 0;
+    for (
+        let index = text.indexOf(fromLabel);
+        index !== -1;
+        index = text.indexOf(fromLabel, cursor)
+    ) {
+        const before = index === 0 ? '' : text[index - 1];
+        const after = text[index + fromLabel.length] ?? '';
+        result += text.slice(cursor, index);
+        result += isMentionTokenBoundary(before, after) ? toLabel : fromLabel;
+        cursor = index + fromLabel.length;
+    }
+
+    return result + text.slice(cursor);
+}
+
+/**
+ * A mention spans a whole token when it is preceded by the start or whitespace
+ * and followed by the end, whitespace, or the punctuation HANDLE_PATTERN allows.
+ */
+function isMentionTokenBoundary(before: string, after: string): boolean {
+    const startsOk = before === '' || /\s/.test(before);
+    const endsOk = after === '' || /\s/.test(after) || '.,!?;:'.includes(after);
+
+    return startsOk && endsOk;
+}
+
 /** Stable mention id from a workspace library name or label. */
 export function mentionIdFromLabel(label: string): string {
     const id = label

--- a/resources/js/lib/compose/mentions.ts
+++ b/resources/js/lib/compose/mentions.ts
@@ -227,19 +227,36 @@ export function replaceMentionLabel(
     return result + text.slice(cursor);
 }
 
+/** Punctuation HANDLE_PATTERN permits immediately after a mention handle. */
+export const MENTION_BOUNDARY_PUNCTUATION = '.,!?;:';
+
+/** A char that can precede a mention token: the token start ('') or whitespace. */
+export function startsMentionBoundary(char: string): boolean {
+    return char === '' || /\s/.test(char);
+}
+
+/**
+ * A char that can close a mention token: the token end (''), whitespace, or the
+ * punctuation HANDLE_PATTERN permits after a handle.
+ */
+export function endsMentionBoundary(char: string): boolean {
+    return (
+        char === '' ||
+        /\s/.test(char) ||
+        MENTION_BOUNDARY_PUNCTUATION.includes(char)
+    );
+}
+
 /**
  * A mention spans a whole token when it is preceded by the start or whitespace
  * and followed by the end, whitespace, or the punctuation HANDLE_PATTERN allows.
  */
 function isMentionTokenBoundary(before: string, after: string): boolean {
-    const startsOk = before === '' || /\s/.test(before);
-    const endsOk = after === '' || /\s/.test(after) || '.,!?;:'.includes(after);
-
-    return startsOk && endsOk;
+    return startsMentionBoundary(before) && endsMentionBoundary(after);
 }
 
 /** Stable mention id from a workspace library name or label. */
-export function mentionIdFromLabel(label: string): string {
+function mentionIdFromLabel(label: string): string {
     const id = label
         .replace(/^@/, '')
         .toLowerCase()

--- a/resources/js/lib/compose/mentions.ts
+++ b/resources/js/lib/compose/mentions.ts
@@ -132,11 +132,7 @@ export function syncMentionsFromText(
 
         const savedMention = saved.get(label);
         if (savedMention) {
-            return {
-                id: mentionIdFromLabel(savedMention.name),
-                label: savedMention.name,
-                handles: savedMention.handles,
-            };
+            return savedMentionToPlaceholder(savedMention);
         }
 
         return createMention(label);
@@ -200,11 +196,22 @@ export function mentionInputValue(name: string): string {
     return name.replace(/^@/, '');
 }
 
-function mentionIdFromLabel(label: string): string {
+/** Stable mention id from a workspace library name or label. */
+export function mentionIdFromLabel(label: string): string {
     const id = label
         .replace(/^@/, '')
         .toLowerCase()
         .replace(/[^a-z0-9_-]+/g, '-');
 
     return id || crypto.randomUUID();
+}
+
+export function savedMentionToPlaceholder(
+    saved: WorkspaceMention,
+): MentionPlaceholder {
+    return {
+        id: mentionIdFromLabel(saved.name),
+        label: saved.name,
+        handles: saved.handles,
+    };
 }

--- a/resources/js/lib/compose/tiptap/__tests__/mention-focus.test.ts
+++ b/resources/js/lib/compose/tiptap/__tests__/mention-focus.test.ts
@@ -1,9 +1,26 @@
+import { getSchema } from '@tiptap/core';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { describe, expect, it } from 'vitest';
 
 import {
     endsMention,
     findMentionLabelEndInText,
+    mentionRemovalRange,
 } from '@/lib/compose/tiptap/mention-focus';
+import { composerExtensions } from '@/lib/compose/tiptap/setup';
+
+const schema = getSchema(composerExtensions());
+
+function docFromText(text: string): ProseMirrorNode {
+    return schema.nodeFromJSON({
+        type: 'doc',
+        content: [
+            text === ''
+                ? { type: 'paragraph' }
+                : { type: 'paragraph', content: [{ type: 'text', text }] },
+        ],
+    });
+}
 
 describe('findMentionLabelEndInText', () => {
     it('locates a boundary-delimited mention and returns the index past it', () => {
@@ -33,6 +50,38 @@ describe('findMentionLabelEndInText', () => {
     it('returns null for an absent label or empty needle', () => {
         expect(findMentionLabelEndInText('nothing here', '@john')).toBeNull();
         expect(findMentionLabelEndInText('@john', '')).toBeNull();
+    });
+});
+
+describe('mentionRemovalRange', () => {
+    it('swallows a single leading space so `hi @` deletes back to `hi`', () => {
+        // "hi @": '@' is the 4th char → doc positions 4–5; the space at 3–4 is
+        // swallowed, leaving the range 3–5.
+        expect(mentionRemovalRange(docFromText('hi @'), '@')).toEqual({
+            from: 3,
+            to: 5,
+        });
+    });
+
+    it('removes only the token when there is no leading space', () => {
+        expect(mentionRemovalRange(docFromText('@'), '@')).toEqual({
+            from: 1,
+            to: 2,
+        });
+        expect(mentionRemovalRange(docFromText('@guest'), '@guest')).toEqual({
+            from: 1,
+            to: 7,
+        });
+    });
+
+    it('targets a named mention and its leading space', () => {
+        expect(
+            mentionRemovalRange(docFromText('hey @guest'), '@guest'),
+        ).toEqual({ from: 4, to: 11 });
+    });
+
+    it('returns null when the label is absent', () => {
+        expect(mentionRemovalRange(docFromText('hello'), '@')).toBeNull();
     });
 });
 

--- a/resources/js/lib/compose/tiptap/__tests__/mention-focus.test.ts
+++ b/resources/js/lib/compose/tiptap/__tests__/mention-focus.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    endsMention,
+    findMentionLabelEndInText,
+} from '@/lib/compose/tiptap/mention-focus';
+
+describe('findMentionLabelEndInText', () => {
+    it('locates a boundary-delimited mention and returns the index past it', () => {
+        expect(findMentionLabelEndInText('hi @john', '@john')).toBe(8);
+        expect(findMentionLabelEndInText('@john here', '@john')).toBe(5);
+    });
+
+    it('treats trailing boundary punctuation as a valid mention end', () => {
+        expect(findMentionLabelEndInText('@john!', '@john')).toBe(5);
+        expect(findMentionLabelEndInText('hey @john, ok', '@john')).toBe(9);
+    });
+
+    it('ignores the label when it only appears inside a longer token', () => {
+        expect(findMentionLabelEndInText('@sammy', '@sam')).toBeNull();
+        expect(findMentionLabelEndInText('email@sam', '@sam')).toBeNull();
+    });
+
+    it('matches the real token even when a longer overlapping one follows', () => {
+        // `@sam` must resolve to the standalone mention, not the `@sam` inside `@sammy`.
+        expect(findMentionLabelEndInText('@sam and @sammy', '@sam')).toBe(4);
+    });
+
+    it('returns the last boundary-delimited occurrence', () => {
+        expect(findMentionLabelEndInText('@a then @a', '@a')).toBe(10);
+    });
+
+    it('returns null for an absent label or empty needle', () => {
+        expect(findMentionLabelEndInText('nothing here', '@john')).toBeNull();
+        expect(findMentionLabelEndInText('@john', '')).toBeNull();
+    });
+});
+
+describe('endsMention', () => {
+    it('treats whitespace and handle punctuation as terminators', () => {
+        for (const char of [' ', '\n', '.', ',', '!', '?', ';', ':']) {
+            expect(endsMention(char)).toBe(true);
+        }
+    });
+
+    it('does not treat word characters or the document end as terminators', () => {
+        expect(endsMention('a')).toBe(false);
+        expect(endsMention('@')).toBe(false);
+        expect(endsMention('')).toBe(false);
+    });
+});

--- a/resources/js/lib/compose/tiptap/mention-focus.ts
+++ b/resources/js/lib/compose/tiptap/mention-focus.ts
@@ -1,0 +1,115 @@
+import type { Editor } from '@tiptap/react';
+
+/** Characters HANDLE_PATTERN allows to immediately follow a mention handle. */
+const MENTION_BOUNDARY_PUNCTUATION = '.,!?;:';
+
+/**
+ * Move focus to the end of `label` in the editor, inserting a trailing space when
+ * the mention is not already followed by whitespace or boundary punctuation.
+ */
+export function focusEditorAfterMentionLabel(
+    editor: Editor,
+    label: string,
+): boolean {
+    if (editor.isDestroyed) {
+        return false;
+    }
+
+    if (label.trim() === '@') {
+        editor.commands.focus('end');
+
+        return false;
+    }
+
+    const end = findMentionLabelEnd(editor, label);
+    if (end === null) {
+        editor.commands.focus('end');
+
+        return false;
+    }
+
+    const after = editor.state.doc.textBetween(end, end + 1);
+    if (!endsMention(after)) {
+        editor.chain().focus().insertContentAt(end, ' ').run();
+
+        editor.commands.setTextSelection(end + 1);
+        editor.commands.focus();
+
+        return true;
+    }
+
+    editor.chain().focus().setTextSelection(end).run();
+
+    return true;
+}
+
+/** Whether `label` appears in the editor as a real, boundary-delimited token. */
+export function editorContainsMentionLabel(
+    editor: Editor,
+    label: string,
+): boolean {
+    return findMentionLabelEnd(editor, label) !== null;
+}
+
+function findMentionLabelEnd(editor: Editor, label: string): number | null {
+    let end: number | null = null;
+
+    editor.state.doc.descendants((node, pos) => {
+        if (!node.isText || !node.text) {
+            return;
+        }
+
+        const localEnd = findMentionLabelEndInText(node.text, label);
+        if (localEnd !== null) {
+            end = pos + localEnd;
+        }
+    });
+
+    return end;
+}
+
+/**
+ * Index just past the last boundary-delimited occurrence of `label` in `text`,
+ * or null when it only appears inside a longer token (e.g. `@sam` inside
+ * `@sammy`). A match at the very end of `text` counts as a valid boundary.
+ */
+export function findMentionLabelEndInText(
+    text: string,
+    label: string,
+): number | null {
+    if (label === '') {
+        return null;
+    }
+
+    let end: number | null = null;
+    let index = text.indexOf(label);
+    while (index !== -1) {
+        const before = index === 0 ? '' : text[index - 1];
+        const after = text[index + label.length] ?? '';
+        if (startsMention(before) && (after === '' || endsMention(after))) {
+            end = index + label.length;
+        }
+        index = text.indexOf(label, index + 1);
+    }
+
+    return end;
+}
+
+/** A char that can precede a mention: the token start or whitespace. */
+function startsMention(char: string): boolean {
+    return char === '' || /\s/.test(char);
+}
+
+/**
+ * A char that already terminates a mention: whitespace or the punctuation
+ * HANDLE_PATTERN permits after a handle. The empty string (end of document) is
+ * deliberately not a terminator, so a trailing space is added to seal the
+ * mention when the caller positions the caret there.
+ */
+export function endsMention(char: string): boolean {
+    return (
+        char === ' ' ||
+        char === '\n' ||
+        (char !== '' && MENTION_BOUNDARY_PUNCTUATION.includes(char))
+    );
+}

--- a/resources/js/lib/compose/tiptap/mention-focus.ts
+++ b/resources/js/lib/compose/tiptap/mention-focus.ts
@@ -1,7 +1,10 @@
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import type { Editor } from '@tiptap/react';
 
-/** Characters HANDLE_PATTERN allows to immediately follow a mention handle. */
-const MENTION_BOUNDARY_PUNCTUATION = '.,!?;:';
+import {
+    endsMentionBoundary,
+    startsMentionBoundary,
+} from '@/lib/compose/mentions';
 
 /**
  * Move focus to the end of `label` in the editor, inserting a trailing space when
@@ -21,7 +24,7 @@ export function focusEditorAfterMentionLabel(
         return false;
     }
 
-    const end = findMentionLabelEnd(editor, label);
+    const end = findMentionLabelEnd(editor.state.doc, label);
     if (end === null) {
         editor.commands.focus('end');
 
@@ -48,13 +51,72 @@ export function editorContainsMentionLabel(
     editor: Editor,
     label: string,
 ): boolean {
-    return findMentionLabelEnd(editor, label) !== null;
+    return findMentionLabelEnd(editor.state.doc, label) !== null;
 }
 
-function findMentionLabelEnd(editor: Editor, label: string): number | null {
+/**
+ * Delete the `@label` token from the editor and keep focus there — used when the
+ * user backspaces or escapes an empty mention. Returns true when a token was
+ * removed.
+ */
+export function removeMentionLabel(editor: Editor, label: string): boolean {
+    if (editor.isDestroyed) {
+        return false;
+    }
+
+    const range = mentionRemovalRange(editor.state.doc, label);
+    if (range === null) {
+        return false;
+    }
+
+    editor.chain().focus().deleteRange(range).run();
+
+    return true;
+}
+
+/**
+ * The `{ from, to }` document range to delete to remove `label`'s token,
+ * swallowing a single leading space so deleting the `@` in `hi @` leaves `hi`,
+ * not a dangling `hi `. Null when the label is not present as a real token.
+ */
+export function mentionRemovalRange(
+    doc: ProseMirrorNode,
+    label: string,
+): { from: number; to: number } | null {
+    const to = findMentionLabelEnd(doc, label);
+    if (to === null) {
+        return null;
+    }
+
+    let from = to - label.length;
+    if (from > 0 && doc.textBetween(from - 1, from) === ' ') {
+        from -= 1;
+    }
+
+    return { from, to };
+}
+
+/**
+ * Document position of the start of `label`'s boundary-delimited occurrence —
+ * the `@` itself — or null when the label isn't present as a real token. Used to
+ * pin the mention picker beside the `@` so it stays put as the name is typed.
+ */
+export function findMentionLabelStart(
+    editor: Editor,
+    label: string,
+): number | null {
+    const end = findMentionLabelEnd(editor.state.doc, label);
+
+    return end === null ? null : end - label.length;
+}
+
+function findMentionLabelEnd(
+    doc: ProseMirrorNode,
+    label: string,
+): number | null {
     let end: number | null = null;
 
-    editor.state.doc.descendants((node, pos) => {
+    doc.descendants((node, pos) => {
         if (!node.isText || !node.text) {
             return;
         }
@@ -86,18 +148,13 @@ export function findMentionLabelEndInText(
     while (index !== -1) {
         const before = index === 0 ? '' : text[index - 1];
         const after = text[index + label.length] ?? '';
-        if (startsMention(before) && (after === '' || endsMention(after))) {
+        if (startsMentionBoundary(before) && endsMentionBoundary(after)) {
             end = index + label.length;
         }
         index = text.indexOf(label, index + 1);
     }
 
     return end;
-}
-
-/** A char that can precede a mention: the token start or whitespace. */
-function startsMention(char: string): boolean {
-    return char === '' || /\s/.test(char);
 }
 
 /**
@@ -107,9 +164,5 @@ function startsMention(char: string): boolean {
  * mention when the caller positions the caret there.
  */
 export function endsMention(char: string): boolean {
-    return (
-        char === ' ' ||
-        char === '\n' ||
-        (char !== '' && MENTION_BOUNDARY_PUNCTUATION.includes(char))
-    );
+    return char !== '' && endsMentionBoundary(char);
 }


### PR DESCRIPTION
[[ref](https://x.com/heyandras/status/2071625103062769757?s=20)]

### What

- [x] typing "@" in the composer should open up a mention picker where you can search for already saved mentions
- [x] make the new mention picker keyboard friendly where hitting the `Escape` key while the mention picker search is focused, dismisses the picker
- [x] hitting `Escape` key within the mention picker search while the input has content, clears the content (double-`Escape` dismisses it too)
- [x] fix inserting multiple mentions in the composer

### Why

Improve the UX of the composer to be more intuitive and keyboard-friendly.

### Demo

https://github.com/user-attachments/assets/6d0cea8a-858b-40ca-af9b-6bb8a950983c

