### PR TITLE
Fix global search filtering

### DIFF
--- a/resources/js/components/layout/command-palette.tsx
+++ b/resources/js/components/layout/command-palette.tsx
@@ -371,6 +371,11 @@ export function CommandPalette() {
                                             <CommandItem
                                                 key={account.id}
                                                 value={`account ${account.handle}`}
+                                                keywords={[
+                                                    trimmed,
+                                                    account.display_name ?? '',
+                                                    account.platform,
+                                                ]}
                                                 onSelect={run(() =>
                                                     router.visit(
                                                         accountsRoute().url,

--- a/resources/js/components/layout/command-palette.tsx
+++ b/resources/js/components/layout/command-palette.tsx
@@ -159,7 +159,6 @@ export function CommandPalette() {
     return (
         <CommandDialog open={open} onOpenChange={onOpenChange}>
             <Command
-                shouldFilter={false}
                 onKeyDown={(e) => {
                     if (
                         e.key === 'Backspace' &&
@@ -331,6 +330,11 @@ export function CommandPalette() {
                                     <CommandGroup heading="Jump to date">
                                         <CommandItem
                                             value={`calendar ${dateJump.yyyymm}`}
+                                            keywords={[
+                                                trimmed,
+                                                dateJump.label,
+                                                dateJump.yyyymm,
+                                            ]}
                                             onSelect={run(() =>
                                                 router.visit(
                                                     calendarMonth({
@@ -354,6 +358,7 @@ export function CommandPalette() {
                                     posts={posts}
                                     loading={loading}
                                     error={error}
+                                    query={trimmed}
                                     go={go}
                                 />
                             )}

--- a/resources/js/components/layout/command-palette/posts-group.tsx
+++ b/resources/js/components/layout/command-palette/posts-group.tsx
@@ -17,26 +17,47 @@ interface PostsGroupProps {
     posts: Post[];
     loading: boolean;
     error: boolean;
+    query: string;
     go: (item: RecentItem) => () => void;
 }
 
-export function PostsGroup({ posts, loading, error, go }: PostsGroupProps) {
+export function PostsGroup({
+    posts,
+    loading,
+    error,
+    query,
+    go,
+}: PostsGroupProps) {
+    const keywords = [query];
+
     return (
         <>
             <CommandSeparator alwaysRender />
             <CommandGroup heading="Posts">
                 {loading && posts.length === 0 && (
-                    <CommandItem disabled value="posts-loading">
+                    <CommandItem
+                        disabled
+                        value="posts-loading"
+                        keywords={keywords}
+                    >
                         Searching…
                     </CommandItem>
                 )}
                 {error && (
-                    <CommandItem disabled value="posts-error">
+                    <CommandItem
+                        disabled
+                        value="posts-error"
+                        keywords={keywords}
+                    >
                         Couldn't load posts
                     </CommandItem>
                 )}
                 {!loading && !error && posts.length === 0 && (
-                    <CommandItem disabled value="posts-empty">
+                    <CommandItem
+                        disabled
+                        value="posts-empty"
+                        keywords={keywords}
+                    >
                         No posts found
                     </CommandItem>
                 )}
@@ -44,6 +65,7 @@ export function PostsGroup({ posts, loading, error, go }: PostsGroupProps) {
                     <CommandItem
                         key={post.id}
                         value={`post ${post.id} ${post.excerpt}`}
+                        keywords={keywords}
                         onSelect={go({
                             id: post.id,
                             kind: 'post',

--- a/resources/js/lib/command/__tests__/command-palette-filtering.test.ts
+++ b/resources/js/lib/command/__tests__/command-palette-filtering.test.ts
@@ -1,33 +1,56 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest';
 
-describe("command palette filtering", () => {
-    const palette = readFileSync(
-        resolve(
-            process.cwd(),
-            "resources/js/components/layout/command-palette.tsx",
+/** Collapse runs of whitespace so assertions don't depend on formatter indentation. */
+function normalize(source: string): string {
+    return source.replace(/\s+/g, ' ');
+}
+
+describe('command palette filtering', () => {
+    const palette = normalize(
+        readFileSync(
+            resolve(
+                process.cwd(),
+                'resources/js/components/layout/command-palette.tsx',
+            ),
+            'utf8',
         ),
-        "utf8",
     );
-    const postsGroup = readFileSync(
-        resolve(
-            process.cwd(),
-            "resources/js/components/layout/command-palette/posts-group.tsx",
+    const postsGroup = normalize(
+        readFileSync(
+            resolve(
+                process.cwd(),
+                'resources/js/components/layout/command-palette/posts-group.tsx',
+            ),
+            'utf8',
         ),
-        "utf8",
     );
 
-    it("uses cmdk filtering and keeps dynamic results searchable", () => {
-        expect(palette).not.toContain("shouldFilter={false}");
-        expect(palette).not.toContain("filter={");
+    it('relies on cmdk built-in filtering rather than a custom filter', () => {
+        expect(palette).not.toContain('shouldFilter={false}');
+        expect(palette).not.toContain('filter={');
+    });
+
+    it('keeps async date jumps searchable via the live query keyword', () => {
         expect(palette).toContain(
-            "keywords={[\n                                                trimmed,",
+            'keywords={[ trimmed, dateJump.label, dateJump.yyyymm, ]}',
         );
-        expect(palette).toContain("value={`account ${account.handle}`}");
-        expect(postsGroup).toContain("const keywords = [query];");
-        expect(postsGroup).toContain("keywords={keywords}");
-        expect(postsGroup).not.toContain("forceMount");
+    });
+
+    it('keeps accounts matched by display name or platform searchable', () => {
+        // matchedAccounts filters on handle + display_name + platform, but the
+        // item value only carries the handle, so the same fields must be
+        // mirrored into keywords or cmdk would filter those matches back out.
+        expect(palette).toContain(
+            "keywords={[ trimmed, account.display_name ?? '', account.platform, ]}",
+        );
+    });
+
+    it('keeps async posts searchable and never force-mounts them', () => {
+        expect(postsGroup).toContain('const keywords = [query];');
+        expect(postsGroup).toContain('keywords={keywords}');
+        expect(postsGroup).not.toContain('forceMount');
     });
 });

--- a/resources/js/lib/command/__tests__/command-palette-filtering.test.ts
+++ b/resources/js/lib/command/__tests__/command-palette-filtering.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("command palette filtering", () => {
+    const palette = readFileSync(
+        resolve(
+            process.cwd(),
+            "resources/js/components/layout/command-palette.tsx",
+        ),
+        "utf8",
+    );
+    const postsGroup = readFileSync(
+        resolve(
+            process.cwd(),
+            "resources/js/components/layout/command-palette/posts-group.tsx",
+        ),
+        "utf8",
+    );
+
+    it("uses cmdk filtering and keeps dynamic results searchable", () => {
+        expect(palette).not.toContain("shouldFilter={false}");
+        expect(palette).not.toContain("filter={");
+        expect(palette).toContain(
+            "keywords={[\n                                                trimmed,",
+        );
+        expect(palette).toContain("value={`account ${account.handle}`}");
+        expect(postsGroup).toContain("const keywords = [query];");
+        expect(postsGroup).toContain("keywords={keywords}");
+        expect(postsGroup).not.toContain("forceMount");
+    });
+});


### PR DESCRIPTION
### What

Re-enable cmdk filtering so global search narrows static commands. Keep dynamic date, post, and account results searchable through values and keywords so valid results do not fall through to the empty state.

### Why

The global search was showing up, but typing didn't do anything.

### Demo

https://github.com/user-attachments/assets/264cea9c-6037-4090-a1fb-bf193ab7db41


Fixes #46.