### PR TITLE
fix: default QUEUE_WORKER_COUNT to 1 so supervisord starts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,9 @@ ARG AUTORUN_LARAVEL_VIEW_CACHE=true
 ARG AUTORUN_LARAVEL_STORAGE_LINK=true
 ARG PHP_OPCACHE_ENABLE=1
 ARG SSL_MODE=off
+# Number of queue worker processes supervisord runs (numprocs in laravel.conf).
+# Must be a non-empty integer or supervisord fails to start.
+ARG QUEUE_WORKER_COUNT=1
 
 ENV PHP_OPCACHE_ENABLE=${PHP_OPCACHE_ENABLE} \
     AUTORUN_ENABLED=${AUTORUN_ENABLED} \

--- a/docker-compose.development.yaml
+++ b/docker-compose.development.yaml
@@ -35,6 +35,7 @@ x-environment: &app-env
     REDIS_PORT: "${REDIS_PORT:-6379}"
     # In-container supervised processes — set to false to run them separately.
     QUEUE_WORKER_ENABLED: "${QUEUE_WORKER_ENABLED:-true}"
+    QUEUE_WORKER_COUNT: "${QUEUE_WORKER_COUNT:-1}"
     SCHEDULER_ENABLED: "${SCHEDULER_ENABLED:-true}"
     # In-container SSR uses localhost; off by default.
     INERTIA_SSR_ENABLED: "${INERTIA_SSR_ENABLED:-false}"

--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -36,6 +36,7 @@ x-environment: &app-env
     REDIS_PORT: "${REDIS_PORT:-6379}"
     # In-container supervised processes — set to false to run them separately.
     QUEUE_WORKER_ENABLED: "${QUEUE_WORKER_ENABLED:-true}"
+    QUEUE_WORKER_COUNT: "${QUEUE_WORKER_COUNT:-1}"
     SCHEDULER_ENABLED: "${SCHEDULER_ENABLED:-true}"
     # In-container SSR uses localhost; off by default.
     INERTIA_SSR_ENABLED: "${INERTIA_SSR_ENABLED:-false}"


### PR DESCRIPTION
### Issue:

I was running into issue deploying this and was getting this error on every deployment I tried.

```
Error: invalid literal for int() with base 10: '' in section 'program:worker' (file: '/etc/supervisor/laravel.conf')
For help, use /usr/bin/supervisord -h
```
### Cause:

The supervisord worker block uses numprocs=%(ENV_QUEUE_WORKER_COUNT)s, but `QUEUE_WORKER_COUNT` had no default. The prebuilt image and the image-based compose files left it empty, so `supervisord` aborts on boot with
` 'invalid literal for int() with base 10: \"\" in section program:worker'. `

### Fix: 
Add ARG `QUEUE_WORKER_COUNT=1` in the Dockerfile (fixes all image consumers)
and pass it through in the production/development compose files for override
and parity with docker-compose.dev.yml."

Let me know if this isn't what is needed, but it deploys fine for me now.