### PR TITLE
fix: trust reverse-proxy headers via TRUSTED_PROXIES

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ SELF_HOSTED=false
 # ----------------------------------------------------------------------
 # APP_URL=https://your-app.example
 # SESSION_SECURE_COOKIE=true
+# Trust reverse-proxy headers (X-Forwarded-Proto/-Host/-Port) so HTTPS redirects
+# and OAuth callback URLs are generated correctly behind Coolify/Traefik. Set to
+# `*` when the container is only reachable through the proxy, or a comma-separated
+# list of proxy IPs/CIDRs. Leave unset to trust no proxies.
+# TRUSTED_PROXIES=*
 
 # Disk used for all media (images + video). Use `public` for local/public
 # storage, or `s3` with the AWS_* values below for object storage.

--- a/.env.example.prod
+++ b/.env.example.prod
@@ -9,6 +9,14 @@ SESSION_SECURE_COOKIE=true
 # http:// and the browser blocks them. Requires APP_URL to be your https address.
 OCTANE_HTTPS=true
 
+# Trust your reverse proxy's forwarding headers (X-Forwarded-Proto/-Host/-Port).
+# This is the precise complement to OCTANE_HTTPS: it lets the app detect the real
+# scheme/host/client-IP per request (so redirects, OAuth callback URLs, and
+# per-IP rate limits are correct) instead of forcing https unconditionally. Set
+# `*` when the container is only reachable through the proxy, or a comma-separated
+# IP/CIDR list to trust specific proxies. Leave unset to trust no proxies.
+TRUSTED_PROXIES=*
+
 # Disable social login unless OAuth credentials are configured.
 SOCIALITE_ENABLED=false
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
@@ -44,6 +45,7 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->configureDefaults();
         $this->configureErrorPages();
+        $this->configureTrustedProxies();
 
         // OAuth tokens issued for the MCP/API integration. Without explicit
         // lifetimes Passport defaults to ~1 year, so a leaked bearer is
@@ -86,6 +88,23 @@ class AppServiceProvider extends ServiceProvider
             }
         );
 
+    }
+
+    /**
+     * Trust reverse-proxy forwarding headers (X-Forwarded-Proto/-Host/-Port) so
+     * redirects, asset URLs, and OAuth redirect_uri values use the public HTTPS
+     * scheme when the app is served behind a TLS-terminating proxy (Coolify/
+     * Traefik). Off unless TRUSTED_PROXIES is configured. Set here rather than in
+     * bootstrap/app.php because the config repository is not yet bound while the
+     * middleware closure runs.
+     */
+    protected function configureTrustedProxies(): void
+    {
+        $trustedProxies = config('app.trusted_proxies');
+
+        if (is_string($trustedProxies) && $trustedProxies !== '') {
+            TrustProxies::at($trustedProxies);
+        }
     }
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -19,6 +19,14 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
+        // Honor reverse-proxy forwarding headers (X-Forwarded-Proto, -Host, -Port)
+        // so request-derived URLs — redirects, asset URLs, and OAuth redirect_uri —
+        // use the public HTTPS scheme when terminated at a proxy (Coolify/Traefik).
+        // Off by default; opt in by setting TRUSTED_PROXIES (e.g. `*` for a container
+        // only reachable through the internal proxy, or a comma-separated CIDR list).
+        // env() here reads the real process environment, so it survives config caching.
+        $middleware->trustProxies(at: env('TRUSTED_PROXIES'));
+
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
 
         $middleware->alias([

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -19,14 +19,6 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        // Honor reverse-proxy forwarding headers (X-Forwarded-Proto, -Host, -Port)
-        // so request-derived URLs — redirects, asset URLs, and OAuth redirect_uri —
-        // use the public HTTPS scheme when terminated at a proxy (Coolify/Traefik).
-        // Off by default; opt in by setting TRUSTED_PROXIES (e.g. `*` for a container
-        // only reachable through the internal proxy, or a comma-separated CIDR list).
-        // env() here reads the real process environment, so it survives config caching.
-        $middleware->trustProxies(at: env('TRUSTED_PROXIES'));
-
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
 
         $middleware->alias([

--- a/config/app.php
+++ b/config/app.php
@@ -56,6 +56,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Trusted Proxies
+    |--------------------------------------------------------------------------
+    |
+    | Reverse proxies (Coolify/Traefik, load balancers) whose forwarding
+    | headers (X-Forwarded-Proto/-Host/-Port) the application should trust, so
+    | redirects, asset URLs, and OAuth redirect_uri values use the public HTTPS
+    | scheme. Set `*` when the container is only reachable through the internal
+    | proxy, a comma-separated IP/CIDR list to trust specific proxies, or leave
+    | unset to trust none.
+    |
+    */
+
+    'trusted_proxies' => env('TRUSTED_PROXIES'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Timezone
     |--------------------------------------------------------------------------
     |

--- a/docker-compose.development.yaml
+++ b/docker-compose.development.yaml
@@ -23,6 +23,13 @@ x-environment: &app-env
     # Force https on generated URLs (redirects, route()) when behind a
     # TLS-terminating proxy/tunnel. Set OCTANE_HTTPS=true in that case.
     OCTANE_HTTPS: "${OCTANE_HTTPS:-false}"
+    # Trust reverse-proxy forwarding headers (X-Forwarded-Proto/-Host/-Port) so
+    # redirects and OAuth callback URLs use the public https scheme and rate
+    # limits see the real client IP. Set `*` when only reachable via the proxy,
+    # or a comma-separated IP/CIDR list. Unset trusts no proxies.
+    TRUSTED_PROXIES: "${TRUSTED_PROXIES:-}"
+    # Optional CDN/base URL for built assets. Leave unset to serve from APP_URL.
+    ASSET_URL: "${ASSET_URL:-}"
     DB_CONNECTION: "${DB_CONNECTION:-sqlite}"
     # NOTE: for Postgres set DB_CONNECTION=pgsql AND override DB_DATABASE=laravel (the
     # sqlite-path default below is invalid for pgsql).

--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -24,6 +24,13 @@ x-environment: &app-env
     # Force https on generated URLs (redirects, route()) when behind a
     # TLS-terminating proxy/tunnel. Set OCTANE_HTTPS=true in that case.
     OCTANE_HTTPS: "${OCTANE_HTTPS:-false}"
+    # Trust reverse-proxy forwarding headers (X-Forwarded-Proto/-Host/-Port) so
+    # redirects and OAuth callback URLs use the public https scheme and rate
+    # limits see the real client IP. Set `*` when only reachable via the proxy,
+    # or a comma-separated IP/CIDR list. Unset trusts no proxies.
+    TRUSTED_PROXIES: "${TRUSTED_PROXIES:-}"
+    # Optional CDN/base URL for built assets. Leave unset to serve from APP_URL.
+    ASSET_URL: "${ASSET_URL:-}"
     DB_CONNECTION: "${DB_CONNECTION:-sqlite}"
     # NOTE: for Postgres set DB_CONNECTION=pgsql AND override DB_DATABASE=laravel (the
     # sqlite-path default below is invalid for pgsql).

--- a/tests/Feature/TrustedProxyTest.php
+++ b/tests/Feature/TrustedProxyTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Http\Middleware\TrustProxies;
+
+afterEach(function (): void {
+    TrustProxies::flushState();
+});
+
+test('honors X-Forwarded-Proto from a trusted proxy, generating https redirects', function (): void {
+    TrustProxies::at('*');
+
+    $response = $this->get('/', ['X-Forwarded-Proto' => 'https']);
+
+    $response->assertRedirect();
+    expect($response->headers->get('Location'))->toStartWith('https://');
+});
+
+test('ignores X-Forwarded-Proto when no proxy is trusted', function (): void {
+    $response = $this->get('/', ['X-Forwarded-Proto' => 'https']);
+
+    $response->assertRedirect();
+    expect($response->headers->get('Location'))->toStartWith('http://');
+});

--- a/tests/Feature/TrustedProxyTest.php
+++ b/tests/Feature/TrustedProxyTest.php
@@ -1,9 +1,29 @@
 <?php
 
+use App\Providers\AppServiceProvider;
 use Illuminate\Http\Middleware\TrustProxies;
+use Illuminate\Http\Request;
 
 afterEach(function (): void {
     TrustProxies::flushState();
+});
+
+test('app.trusted_proxies config wires the trusted proxy via the provider', function (): void {
+    config(['app.trusted_proxies' => '198.51.100.4']);
+
+    Closure::bind(
+        fn () => $this->configureTrustedProxies(),
+        new AppServiceProvider($this->app),
+        AppServiceProvider::class,
+    )();
+
+    $request = Request::create('http://app.test/', 'GET');
+    $request->server->set('REMOTE_ADDR', '198.51.100.4');
+    $request->headers->set('X-Forwarded-Proto', 'https');
+
+    (new TrustProxies)->handle($request, fn (): null => null);
+
+    expect($request->isSecure())->toBeTrue();
 });
 
 test('honors X-Forwarded-Proto from a trusted proxy, generating https redirects', function (): void {


### PR DESCRIPTION
Behind a TLS-terminating proxy (Coolify/Traefik) the app generated http:// redirects and OAuth redirect_uri values even when served over HTTPS, because the global TrustProxies middleware had no proxies configured and so ignored X-Forwarded-Proto.

Wire trustProxies(at: env('TRUSTED_PROXIES')) in bootstrap/app.php (off by default; opt in with TRUSTED_PROXIES=* or a CIDR list), document the env, and cover the redirect scheme behavior with a test.

Fixes #50