### PR TITLE
Fix: Self-Hosted - Handle TLS mixed content issues

### DIFF
--- a/.env.example.prod
+++ b/.env.example.prod
@@ -3,6 +3,12 @@ APP_KEY=
 APP_URL=https://your-app.example
 SESSION_SECURE_COOKIE=true
 
+# Running behind a TLS-terminating reverse proxy or tunnel (Cloudflare Tunnel,
+# Traefik, nginx, a load balancer)? Set this so Octane forces https on generated
+# URLs (redirects, route()). Without it, post-login redirects can come out
+# http:// and the browser blocks them. Requires APP_URL to be your https address.
+OCTANE_HTTPS=true
+
 # Disable social login unless OAuth credentials are configured.
 SOCIALITE_ENABLED=false
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,7 +10,6 @@ use App\Http\Middleware\WorkspaceMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
-use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 use Illuminate\Http\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
@@ -38,7 +37,15 @@ return Application::configure(basePath: dirname(__DIR__))
             // must be set first or scoped queries leak across workspaces.
             WorkspaceMiddleware::class,
             HandleInertiaRequests::class,
-            AddLinkHeadersForPreloadedAssets::class,
+            // NOTE: AddLinkHeadersForPreloadedAssets is intentionally not
+            // registered. It emits a `Link: rel=preload` HTTP header for each
+            // Vite asset, but under Octane the underlying preloadedAssets list
+            // persists across requests, so behind a TLS-terminating proxy the
+            // header gets frozen with http:// URLs from an earlier request and
+            // never reflects the per-request https scheme. The browser then
+            // blocks those preloads as mixed content. The header is redundant
+            // with the <link rel="modulepreload"> tags already rendered into the
+            // document (which are generated per request and resolve to https).
             CaptureMcpWorkspaceSelection::class,
         ]);
     })

--- a/docker-compose.development.yaml
+++ b/docker-compose.development.yaml
@@ -20,6 +20,9 @@ x-environment: &app-env
     APP_DEBUG: "${APP_DEBUG:-true}"
     APP_URL: "${APP_URL:-http://localhost:8080}"
     OCTANE_SERVER: "frankenphp"
+    # Force https on generated URLs (redirects, route()) when behind a
+    # TLS-terminating proxy/tunnel. Set OCTANE_HTTPS=true in that case.
+    OCTANE_HTTPS: "${OCTANE_HTTPS:-false}"
     DB_CONNECTION: "${DB_CONNECTION:-sqlite}"
     # NOTE: for Postgres set DB_CONNECTION=pgsql AND override DB_DATABASE=laravel (the
     # sqlite-path default below is invalid for pgsql).

--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -21,6 +21,9 @@ x-environment: &app-env
     APP_DEBUG: "${APP_DEBUG:-false}"
     APP_URL: "${APP_URL:-http://localhost:8080}"
     OCTANE_SERVER: "frankenphp"
+    # Force https on generated URLs (redirects, route()) when behind a
+    # TLS-terminating proxy/tunnel. Set OCTANE_HTTPS=true in that case.
+    OCTANE_HTTPS: "${OCTANE_HTTPS:-false}"
     DB_CONNECTION: "${DB_CONNECTION:-sqlite}"
     # NOTE: for Postgres set DB_CONNECTION=pgsql AND override DB_DATABASE=laravel (the
     # sqlite-path default below is invalid for pgsql).

--- a/tests/Feature/PreloadLinkHeaderTest.php
+++ b/tests/Feature/PreloadLinkHeaderTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+
+test('the Vite preload Link header middleware is not registered on the web group', function () {
+    // Under Octane behind a TLS-terminating proxy this middleware emits a
+    // frozen http:// `Link: rel=preload` header that the browser blocks as mixed
+    // content. It is redundant with the in-document <link rel="modulepreload">
+    // tags, so it must stay unregistered.
+    $webGroup = app('router')->getMiddlewareGroups()['web'] ?? [];
+
+    expect($webGroup)->not->toContain(AddLinkHeadersForPreloadedAssets::class);
+});


### PR DESCRIPTION
Edit: Assets and http paths now fixed for self-hosting behind a reverse-proxy or cloudflare tunnel. 

# 1st Problem

## What

Removes Laravel's `AddLinkHeadersForPreloadedAssets` middleware from the web group.

## Problem

Behind a TLS-terminating proxy or tunnel (Cloudflare Tunnel, Traefik, etc.), the login page and other pages throw browser mixed-content errors: the CSS, JS, and fonts get requested over `http://` even though the page is served over `https`, so the browser blocks them.

## Root cause

The problem is the `Link: rel=preload` HTTP response header added by `AddLinkHeadersForPreloadedAssets`. Under Octane, Vite's `preloadedAssets` list persists across requests on the worker, so the header gets frozen with `http://` URLs from an earlier request and never reflects the per-request `https` scheme. Because it is computed once and cached, `OCTANE_HTTPS`, `ASSET_URL`, and trusted-proxy settings do not fix it.

## Fix

Do not register the middleware. The header is redundant with the `<link rel="modulepreload">` tags already in the rendered HTML, which are generated per request and resolve to `https`, so preloading still works.

## Verification

Deployed behind Cloudflare Tunnel + Traefik on FrankenPHP/Octane. Before: the page's `Link` header carried 35 `http://` asset preloads (blocked as mixed content). After: no `Link` header, 0 `http://` references on the page, clean console. No env vars required.

## Notes

During my testing I had some issues because AddLinkHeadersForPreloadedAssets was baked into the image. So the image will need to be regenerated with this fix included in order to work for everyone.

- Adds a feature test asserting the middleware stays unregistered.
- Self-hosters on the prebuilt GHCR image will get this once a new release republishes the image.

# 2nd Problem

## What
Passes OCTANE_HTTPS through to the container in both compose files (docker-compose.production.yaml and docker-compose.development.yaml) and documents it in .env.example.prod.

## Problem
After the assets were fixed, logging in (and registering) still failed behind the proxy. The post-login redirect pointed at http://.../dashboard even though the page was served over https, so the browser blocked it with the connect-src 'self' CSP directive and the Inertia visit errored with a network error. Refreshing the page showed you were actually logged in, so the session was created and only the redirect was broken.

## Root cause

Two layers:

Behind a proxy, Octane generates http:// links by default. The intended fix is OCTANE_HTTPS=true, and config/octane.php already reads it ('https' => env('OCTANE_HTTPS', false)).
But the compose files only pass an explicit allowlist of env vars into the container (the &app-env anchor), and OCTANE_HTTPS was not on that list. So setting OCTANE_HTTPS=true in the deployment never reached the app, and config('octane.https') stayed false no matter what. TRUST_PROXIES and ASSET_URL have the same gap.
So the redirect was generated with the request's perceived scheme (http behind the tunnel) and there was no way to force https.

## Fix
Add OCTANE_HTTPS to the &app-env passthrough in both compose files and document it in .env.example.prod. Self-hosters behind a proxy set OCTANE_HTTPS=true, which makes Octane force https on generated URLs (redirects, route()).

## Verification
Confirmed on the same Cloudflare Tunnel + Traefik deployment. Before: config('octane.https') was false in the container (the env var never arrived), and the post-login redirect was http://.../dashboard. After the passthrough with OCTANE_HTTPS=true: config('octane.https') reads true, and login and register land on the dashboard over https with no connect-src error.

## Notes
Unlike the 1st fix, this one is a compose/env change rather than application code, so it takes effect on redeploy without regenerating the image (config/octane.php already supports OCTANE_HTTPS).
