### PR TITLE
fix: Pass env file through compose files for missing configurations

### DIFF
--- a/app/Enums/Platform.php
+++ b/app/Enums/Platform.php
@@ -72,9 +72,10 @@ enum Platform: string
 
         $key = $this->configKey();
 
+        // filled() so a blank value in .env isn't treated as configured.
         return $key !== null
-            && config($key.'.client_id') !== null
-            && config($key.'.client_secret') !== null;
+            && filled(config($key.'.client_id'))
+            && filled(config($key.'.client_secret'));
     }
 
     /**

--- a/docker-compose.development.yaml
+++ b/docker-compose.development.yaml
@@ -51,6 +51,11 @@ services:
                 POSTGRES_VERSION: "${POSTGRES_VERSION:-17}"
         image: "shoutrrr:dev"
         restart: unless-stopped
+        # Put any extra config in your .env (X_*, LINKEDIN_*, AWS_*,
+        # OCTANE_HTTPS, ...) and it's passed straight through to the app.
+        env_file:
+            - path: .env
+              required: false
         environment:
             <<: *app-env
         ports:

--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -47,6 +47,11 @@ services:
         image: "ghcr.io/coollabsio/shoutrrr:latest"
         pull_policy: always
         restart: unless-stopped
+        # Put any extra config in your .env (X_*, LINKEDIN_*, AWS_*,
+        # OCTANE_HTTPS, ...) and it's passed straight through to the app.
+        env_file:
+            - path: .env
+              required: false
         environment:
             <<: *app-env
         ports:

--- a/tests/Unit/ConnectedAccounts/PlatformTest.php
+++ b/tests/Unit/ConnectedAccounts/PlatformTest.php
@@ -38,6 +38,18 @@ test('oauth platform is configured only when client id and secret are present', 
     expect(Platform::X->isConfigured())->toBeTrue();
 });
 
+test('oauth platform with blank credentials is not configured', function () {
+    // env_file passthrough turns an unset var into an empty string, which must
+    // not count as configured.
+    config()->set('services.x.client_id', '');
+    config()->set('services.x.client_secret', '');
+    expect(Platform::X->isConfigured())->toBeFalse();
+
+    config()->set('services.x.client_id', 'cid');
+    config()->set('services.x.client_secret', '');
+    expect(Platform::X->isConfigured())->toBeFalse();
+});
+
 test('app-password platform is always configured', function () {
     expect(Platform::Bluesky->isConfigured())->toBeTrue();
 });


### PR DESCRIPTION
## Problem

The compose `environment:` block is an explicit allowlist, so any env var not listed there never reaches the container even when set in `.env`. That blocks self-hosters from configuring via the env file.

## Fix

Add `env_file: .env` (`required: false`) to both compose files so anything in `.env` is passed through. The `environment:` block still wins, so the core vars keep their `${VAR:-default}` fallbacks.

Since `env_file` turns an unset var into an empty string, also harden `Platform::isConfigured()` to use `filled()` instead of a null check, so a blank credential isn't treated as configured. Adds a test for that.

## Environment variable priority

Everything is driven by your `.env`. Order of precedence (highest first):

1. **Core settings** (`APP_*`, `DB_*`, `CACHE_STORE`, `OCTANE_*`, etc.) are defined in the compose `environment:` block as `${VAR:-default}`. Your `.env` value is used if set; otherwise the built-in default applies. An empty value falls back to the default too.

2. **Everything else you set in `.env`** (OAuth `X_*`/`LINKEDIN_*`, `AWS_*`, `OCTANE_HTTPS`, etc.) is passed straight through via `env_file`.

If the same variable appears in both places, the `environment:` block wins, but it reads from your `.env` anyway, so your value is what takes effect. Net: set it in `.env` and it applies; leave a core var unset and it falls back to a safe default.

