### PR TITLE
Adjust top margin on notification bell

### DIFF
--- a/resources/js/components/notifications/notification-bell.tsx
+++ b/resources/js/components/notifications/notification-bell.tsx
@@ -292,7 +292,7 @@ function NotificationRow({
             <span
                 aria-hidden
                 className={cn(
-                    'mt-1.5 size-1.5 shrink-0 rounded-full',
+                    'mt-4 size-1.5 shrink-0 rounded-full',
                     notification.read ? 'bg-transparent' : 'bg-primary',
                 )}
             />

--- a/resources/js/components/notifications/notification-bell.tsx
+++ b/resources/js/components/notifications/notification-bell.tsx
@@ -288,18 +288,20 @@ function NotificationRow({
         notification.actions !== undefined && notification.actions.length > 0;
 
     const content = (
-        <div className="flex min-w-0 flex-1 gap-2.5 text-left">
-            <span
-                aria-hidden
-                className={cn(
-                    'mt-4 size-1.5 shrink-0 rounded-full',
-                    notification.read ? 'bg-transparent' : 'bg-primary',
-                )}
-            />
-            <div className="min-w-0 flex-1 py-2.5">
-                <p className="truncate text-[13px] font-medium text-foreground">
+        <div className="min-w-0 flex-1 py-2.5 text-left">
+            <div className="flex items-center gap-2.5">
+                <span
+                    aria-hidden
+                    className={cn(
+                        'size-1.5 shrink-0 rounded-full',
+                        notification.read ? 'bg-transparent' : 'bg-primary',
+                    )}
+                />
+                <p className="min-w-0 flex-1 truncate text-[13px] font-medium text-foreground">
                     {notification.title}
                 </p>
+            </div>
+            <div className="pl-4">
                 {notification.body && (
                     <p className="mt-0.5 line-clamp-2 text-[12px] text-muted-foreground">
                         {notification.body}


### PR DESCRIPTION
Sorry this was annoying me enough to make a pull request. 😅

## Before
<img width="333" height="149" alt="Screenshot 2026-06-30 at 8 32 38 PM" src="https://github.com/user-attachments/assets/7be78639-f6c5-4398-b16d-bf2c14a1dc2d" />

## After
<img width="330" height="134" alt="Screenshot 2026-06-30 at 8 40 12 PM" src="https://github.com/user-attachments/assets/2b533854-09e8-46cf-98fd-11e16bbc9a53" />
