### PR TITLE
Fix Tiptap mention placeholders highlighting

### DIFF
--- a/resources/js/lib/compose/tiptap/__tests__/mention-placeholders.test.ts
+++ b/resources/js/lib/compose/tiptap/__tests__/mention-placeholders.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    mentionDecorations,
+    type MentionDecoration,
+} from '@/lib/compose/tiptap/mention-placeholders';
+
+function decorationsIn(text: string, base = 0): MentionDecoration[] {
+    return [...mentionDecorations(text, base)];
+}
+
+describe('mentionDecorations', () => {
+    it('highlights a standalone handle', () => {
+        expect(decorationsIn('hi @guest there')).toEqual([
+            { start: 3, end: 9, id: 'guest' },
+        ]);
+    });
+
+    it('highlights a handle at the start of the text', () => {
+        expect(decorationsIn('@guest hi')).toEqual([
+            { start: 0, end: 6, id: 'guest' },
+        ]);
+    });
+
+    it('does not highlight the @domain part of an email', () => {
+        // Regression: "@example.com" inside an email was highlighted as a handle.
+        expect(decorationsIn('user@example.com')).toEqual([]);
+        expect(decorationsIn('email me at user@example.com please')).toEqual(
+            [],
+        );
+    });
+
+    it('highlights a real handle even when an email is also present', () => {
+        expect(decorationsIn('hi @guest at user@example.com')).toEqual([
+            { start: 3, end: 9, id: 'guest' },
+        ]);
+    });
+
+    it('highlights serialized mention tokens', () => {
+        expect(decorationsIn('hi {{mention:guest}}')).toEqual([
+            { start: 3, end: 20, id: '-mention-guest-' },
+        ]);
+    });
+
+    it('offsets ranges by the provided base position', () => {
+        expect(decorationsIn('@guest', 5)).toEqual([
+            { start: 5, end: 11, id: 'guest' },
+        ]);
+    });
+
+    it('honors trailing boundary punctuation', () => {
+        expect(decorationsIn('hey @guest!')).toEqual([
+            { start: 4, end: 10, id: 'guest' },
+        ]);
+    });
+});

--- a/resources/js/lib/compose/tiptap/mention-placeholders.ts
+++ b/resources/js/lib/compose/tiptap/mention-placeholders.ts
@@ -2,8 +2,35 @@ import { Extension } from '@tiptap/core';
 import { Plugin } from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 
+/**
+ * Matches serialized mention tokens (`{{mention:id}}`) and standalone `@handle`s.
+ * The `@handle` branch requires a leading boundary (start of text or whitespace)
+ * via the `(?<!\S)` lookbehind, so the `@domain` part of an email such as
+ * `raulp@hey.com` is not mistaken for a handle and highlighted.
+ */
 const TOKEN_PATTERN =
-    /\{\{mention:[a-zA-Z0-9_-]+\}\}|@[a-zA-Z0-9_.-]{0,50}(?=\s|$|[.,!?;:])/g;
+    /\{\{mention:[a-zA-Z0-9_-]+\}\}|(?<!\S)@[a-zA-Z0-9_.-]{0,50}(?=\s|$|[.,!?;:])/g;
+
+export type MentionDecoration = { start: number; end: number; id: string };
+
+/**
+ * Yields the mention tokens to decorate within a text run — each match's absolute
+ * range (offset by `base`) and its derived `data-mention-id`. Lazy, so callers
+ * decorate in a single pass with no intermediate array.
+ */
+export function* mentionDecorations(
+    text: string,
+    base = 0,
+): Generator<MentionDecoration> {
+    for (const match of text.matchAll(TOKEN_PATTERN)) {
+        const start = base + (match.index ?? 0);
+        yield {
+            start,
+            end: start + match[0].length,
+            id: match[0].replace(/^@/, '').replace(/[^a-zA-Z0-9_-]+/g, '-'),
+        };
+    }
+}
 
 export const MentionPlaceholders = Extension.create({
     name: 'mentionPlaceholders',
@@ -41,18 +68,14 @@ export const MentionPlaceholders = Extension.create({
                                 return;
                             }
 
-                            for (const match of node.text.matchAll(
-                                TOKEN_PATTERN,
+                            for (const { start, end, id } of mentionDecorations(
+                                node.text,
+                                position,
                             )) {
-                                const start = position + (match.index ?? 0);
-                                const end = start + match[0].length;
                                 decorations.push(
                                     Decoration.inline(start, end, {
                                         class: 'cursor-pointer rounded-md bg-primary/10 px-1 py-0.5 font-medium text-primary ring-1 ring-primary/20',
-                                        'data-mention-id': (
-                                            match[1] ??
-                                            match[0].replace(/^@/, '')
-                                        ).replace(/[^a-zA-Z0-9_-]+/g, '-'),
+                                        'data-mention-id': id,
                                     }),
                                 );
                             }


### PR DESCRIPTION
### What

- [x] do not highlight emails as handles inside the Tiptap composer

### Why

Fixes the Tiptap mention placeholder extension to exclude email addresses from highlighting.

| Before | After |
| --- | --- |
| <img width="818" height="682" alt="image" src="https://github.com/user-attachments/assets/b10c2fd0-221e-42f5-93df-eb11c906a96e" /> | <img width="930" height="682" alt="image" src="https://github.com/user-attachments/assets/391c0a45-45a1-406b-80b3-05f5a1505b1e" /> |