### PR TITLE
fix(accounts): normalize Bluesky handle prefixes

### DIFF
--- a/app/Services/ConnectedAccounts/BlueskyConnector.php
+++ b/app/Services/ConnectedAccounts/BlueskyConnector.php
@@ -18,6 +18,7 @@ class BlueskyConnector
 
     public function connect(string $identifier, string $appPassword, ?string $pdsUrl = null): ConnectedAccountData
     {
+        $identifier = $this->normalizeIdentifier($identifier);
         $pds = $this->resolvePds($identifier, $pdsUrl);
 
         // Guard the resolved endpoint too (not just a user override) before sending
@@ -74,6 +75,8 @@ class BlueskyConnector
 
     public function resolvePds(string $identifier, ?string $override): string
     {
+        $identifier = $this->normalizeIdentifier($identifier);
+
         if ($override !== null && trim($override) !== '') {
             $pds = rtrim(trim($override), '/');
             $this->assertSafePds($pds);
@@ -136,6 +139,11 @@ class BlueskyConnector
             ->get(self::DEFAULT_PDS.'/xrpc/com.atproto.identity.resolveHandle', ['handle' => $handle]);
 
         return $response->successful() ? $response->json('did') : null;
+    }
+
+    private function normalizeIdentifier(string $identifier): string
+    {
+        return ltrim(trim($identifier), '@');
     }
 
     private function resolveDidToPds(string $did): ?string

--- a/resources/js/components/accounts/__tests__/account-card-layout.test.ts
+++ b/resources/js/components/accounts/__tests__/account-card-layout.test.ts
@@ -22,4 +22,18 @@ describe('account card layout', () => {
         expect(source).toContain('https://bsky.app/settings/app-passwords');
         expect(source).toContain('app password');
     });
+
+    it('shows the at sign as a non-submitted Bluesky reconnect handle prefix', () => {
+        const source = readFileSync(
+            resolve(
+                process.cwd(),
+                'resources/js/components/accounts/account-card.tsx',
+            ),
+            'utf8',
+        );
+
+        expect(source).toContain('InputGroupAddon');
+        expect(source).toContain('<InputGroupAddon>@</InputGroupAddon>');
+        expect(source).toContain('InputGroupInput');
+    });
 });

--- a/resources/js/components/accounts/__tests__/connect-buttons-layout.test.ts
+++ b/resources/js/components/accounts/__tests__/connect-buttons-layout.test.ts
@@ -32,4 +32,18 @@ describe('Bluesky connect dialog layout', () => {
         expect(source).not.toContain('BriefcaseBusiness');
         expect(source).not.toContain('X as XIcon');
     });
+
+    it('shows the at sign as a non-submitted Bluesky handle prefix', () => {
+        const source = readFileSync(
+            resolve(
+                process.cwd(),
+                'resources/js/components/accounts/connect-buttons.tsx',
+            ),
+            'utf8',
+        );
+
+        expect(source).toContain('InputGroupAddon');
+        expect(source).toContain('<InputGroupAddon>@</InputGroupAddon>');
+        expect(source).toContain('InputGroupInput');
+    });
 });

--- a/resources/js/components/accounts/account-card.tsx
+++ b/resources/js/components/accounts/account-card.tsx
@@ -18,6 +18,11 @@ import {
     DialogTrigger,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import {
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+} from '@/components/ui/input-group';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
 import type { PlatformName } from '@/types/compose';
@@ -76,15 +81,23 @@ function ReconnectBlueskyDialog({ account }: { account: Account }) {
                                     <Label htmlFor={`identifier-${account.id}`}>
                                         Handle or email
                                     </Label>
-                                    <Input
-                                        id={`identifier-${account.id}`}
-                                        name="identifier"
-                                        defaultValue={account.handle.replace(
-                                            /^@/,
-                                            '',
-                                        )}
-                                        required
-                                    />
+                                    <InputGroup>
+                                        <InputGroupAddon>@</InputGroupAddon>
+                                        <InputGroupInput
+                                            id={`identifier-${account.id}`}
+                                            name="identifier"
+                                            defaultValue={account.handle.replace(
+                                                /^@/,
+                                                '',
+                                            )}
+                                            aria-invalid={
+                                                errors.identifier
+                                                    ? true
+                                                    : undefined
+                                            }
+                                            required
+                                        />
+                                    </InputGroup>
                                     <InputError message={errors.identifier} />
                                 </div>
                                 <div className="grid gap-2">

--- a/resources/js/components/accounts/connect-buttons.tsx
+++ b/resources/js/components/accounts/connect-buttons.tsx
@@ -22,6 +22,11 @@ import {
     DialogTrigger,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import {
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+} from '@/components/ui/input-group';
 import { Label } from '@/components/ui/label';
 import type { PlatformName } from '@/types/compose';
 
@@ -90,12 +95,20 @@ function BlueskyConnectDialog() {
                                     <Label htmlFor="identifier">
                                         Handle or email
                                     </Label>
-                                    <Input
-                                        id="identifier"
-                                        name="identifier"
-                                        placeholder="you.bsky.social"
-                                        required
-                                    />
+                                    <InputGroup>
+                                        <InputGroupAddon>@</InputGroupAddon>
+                                        <InputGroupInput
+                                            id="identifier"
+                                            name="identifier"
+                                            placeholder="you.bsky.social"
+                                            aria-invalid={
+                                                errors.identifier
+                                                    ? true
+                                                    : undefined
+                                            }
+                                            required
+                                        />
+                                    </InputGroup>
                                     <InputError message={errors.identifier} />
                                 </div>
                                 <div className="grid gap-2">

--- a/tests/Feature/ConnectedAccounts/ConnectBlueskyTest.php
+++ b/tests/Feature/ConnectedAccounts/ConnectBlueskyTest.php
@@ -61,6 +61,20 @@ test('an owner connects a bluesky account with a sealed app password and session
         ->and($account->secret->session)->toMatchArray(['accessJwt' => 'access-jwt']);
 });
 
+test('a leading at sign is removed from the submitted bluesky handle', function () {
+    blueskyOwner();
+    fakeBlueskySession();
+
+    test()->post('/accounts/connect/bluesky', [
+        'identifier' => '@ada.bsky.social',
+        'app_password' => 'app-pass-1234',
+        'pds_url' => 'https://bsky.social',
+    ])->assertRedirect(route('accounts.index'));
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'com.atproto.server.createSession')
+        && $request['identifier'] === 'ada.bsky.social');
+});
+
 test('a member cannot connect a bluesky account', function () {
     $user = User::factory()->create();
     $workspace = Workspace::factory()->create(['owner_id' => $user->id]);


### PR DESCRIPTION
## Summary
- Show the `@` prefix as static UI text for Bluesky connect and reconnect handle fields.
- Normalize submitted Bluesky identifiers by trimming whitespace and removing leading `@` before PDS resolution and session creation.
- Add coverage for prefixed handle submission and the non-submitted UI prefix.