### PR TITLE
feat(compose): add post submit keyboard shortcut

### DIFF
--- a/resources/js/components/compose/__tests__/submit-bar.test.ts
+++ b/resources/js/components/compose/__tests__/submit-bar.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSubmitShortcut, shouldAllowSubmit } from '../submit-bar';
+
+const baseEvent = {
+    altKey: false,
+    ctrlKey: false,
+    key: 'Enter',
+    metaKey: false,
+    shiftKey: false,
+};
+
+describe('isSubmitShortcut', () => {
+    it('matches plain command or control enter only', () => {
+        expect(isSubmitShortcut({ ...baseEvent, metaKey: true })).toBe(true);
+        expect(isSubmitShortcut({ ...baseEvent, ctrlKey: true })).toBe(true);
+        expect(
+            isSubmitShortcut({ ...baseEvent, metaKey: true, key: 'N' }),
+        ).toBe(false);
+        expect(
+            isSubmitShortcut({ ...baseEvent, metaKey: true, shiftKey: true }),
+        ).toBe(false);
+        expect(
+            isSubmitShortcut({ ...baseEvent, metaKey: true, altKey: true }),
+        ).toBe(false);
+    });
+});
+
+describe('shouldAllowSubmit', () => {
+    it('uses the same guard as the publish button', () => {
+        expect(
+            shouldAllowSubmit({
+                disabled: false,
+                processing: false,
+                queueDisabled: false,
+                trayMode: 'now',
+                uploading: false,
+            }),
+        ).toBe(true);
+        expect(
+            shouldAllowSubmit({
+                disabled: true,
+                processing: false,
+                queueDisabled: false,
+                trayMode: 'now',
+                uploading: false,
+            }),
+        ).toBe(false);
+        expect(
+            shouldAllowSubmit({
+                disabled: false,
+                processing: false,
+                queueDisabled: true,
+                trayMode: 'queue',
+                uploading: false,
+            }),
+        ).toBe(false);
+        expect(
+            shouldAllowSubmit({
+                disabled: false,
+                processing: false,
+                queueDisabled: true,
+                trayMode: 'pick',
+                uploading: false,
+            }),
+        ).toBe(true);
+    });
+});

--- a/resources/js/components/compose/submit-bar.tsx
+++ b/resources/js/components/compose/submit-bar.tsx
@@ -1,6 +1,6 @@
 import { Link, router, useHttp } from '@inertiajs/react';
 import { Send } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 
 import ComposerController from '@/actions/App/Http/Controllers/Posts/ComposerController';
@@ -47,6 +47,43 @@ type Props = {
     onServerPost: (post: PostView) => void;
 };
 
+type ShortcutEvent = Pick<
+    KeyboardEvent,
+    'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'
+>;
+
+type SubmitGuard = {
+    disabled?: boolean;
+    uploading: boolean;
+    processing: boolean;
+    trayMode: ScheduleTray['mode'];
+    queueDisabled?: boolean;
+};
+
+export function isSubmitShortcut(event: ShortcutEvent): boolean {
+    return (
+        (event.metaKey || event.ctrlKey) &&
+        !event.altKey &&
+        !event.shiftKey &&
+        event.key === 'Enter'
+    );
+}
+
+export function shouldAllowSubmit({
+    disabled,
+    uploading,
+    processing,
+    trayMode,
+    queueDisabled,
+}: SubmitGuard): boolean {
+    return !(
+        disabled ||
+        uploading ||
+        processing ||
+        (trayMode === 'queue' && Boolean(queueDisabled))
+    );
+}
+
 export function SubmitBar({
     tray,
     postId,
@@ -74,6 +111,18 @@ export function SubmitBar({
               : 'Schedule';
 
     async function handleSubmit() {
+        if (
+            !shouldAllowSubmit({
+                disabled,
+                uploading,
+                processing: http.processing,
+                trayMode: tray.mode,
+                queueDisabled,
+            })
+        ) {
+            return;
+        }
+
         setNoSlot(false);
         setPastTime(false);
         // Flush pending edits AND wait for them to persist before publishing —
@@ -143,15 +192,42 @@ export function SubmitBar({
         });
     }
 
+    useEffect(() => {
+        function onKeyDown(event: KeyboardEvent) {
+            if (
+                !isSubmitShortcut(event) ||
+                !shouldAllowSubmit({
+                    disabled,
+                    uploading,
+                    processing: http.processing,
+                    trayMode: tray.mode,
+                    queueDisabled,
+                })
+            ) {
+                return;
+            }
+
+            event.preventDefault();
+            void handleSubmit();
+        }
+
+        document.addEventListener('keydown', onKeyDown);
+
+        return () => document.removeEventListener('keydown', onKeyDown);
+    });
+
+    const canSubmit = shouldAllowSubmit({
+        disabled,
+        uploading,
+        processing: http.processing,
+        trayMode: tray.mode,
+        queueDisabled,
+    });
+
     const submitButton = (
         <TrayButton
             variant="primary"
-            disabled={
-                disabled ||
-                uploading ||
-                http.processing ||
-                (tray.mode === 'queue' && Boolean(queueDisabled))
-            }
+            disabled={!canSubmit}
             onClick={() => void handleSubmit()}
             className="flex-1 sm:flex-none"
         >


### PR DESCRIPTION
## Summary
- Adds Cmd/Ctrl+Enter support for submitting posts from the composer.
- Keeps shortcut submissions aligned with the publish button guard for disabled, uploading, processing, and queue-disabled states.
- Adds unit coverage for shortcut detection and submit eligibility.