### PR TITLE
feat(accounts): add Bluesky OAuth connections

### DIFF
--- a/app/Console/Commands/RefreshExpiringTokens.php
+++ b/app/Console/Commands/RefreshExpiringTokens.php
@@ -22,7 +22,13 @@ class RefreshExpiringTokens extends Command
     {
         ConnectedAccount::query()
             ->withoutGlobalScopes()
-            ->where('platform', '!=', Platform::Bluesky->value)
+            ->where(function ($query): void {
+                $query->where('platform', '!=', Platform::Bluesky->value)
+                    ->orWhere(function ($query): void {
+                        $query->where('platform', Platform::Bluesky->value)
+                            ->where('auth_method', 'oauth');
+                    });
+            })
             ->where('status', ConnectedAccountStatus::Active->value)
             ->whereNotNull('token_expires_at')
             ->where('token_expires_at', '<=', Date::now()->addHours(6))

--- a/app/Http/Controllers/ConnectedAccounts/BlueskyOAuthController.php
+++ b/app/Http/Controllers/ConnectedAccounts/BlueskyOAuthController.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\ConnectedAccounts;
+
+use App\Http\Controllers\Controller;
+use App\Models\ConnectedAccount;
+use App\Services\ConnectedAccounts\AccountConnectionService;
+use App\Services\ConnectedAccounts\BlueskyOAuthConnector;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+
+class BlueskyOAuthController extends Controller
+{
+    private const string SESSION_KEY = 'accounts.bluesky.oauth';
+
+    public function __construct(
+        private readonly BlueskyOAuthConnector $connector,
+        private readonly AccountConnectionService $connections,
+    ) {}
+
+    public function redirect(Request $request): RedirectResponse
+    {
+        $request->user()->can('create', ConnectedAccount::class) ?: abort(403);
+
+        $validated = $request->validate([
+            'pds_url' => ['nullable', 'url', 'max:255'],
+        ]);
+
+        try {
+            $authorization = $this->connector->authorizationRedirect(
+                null,
+                $this->clientId(),
+                route('accounts.bluesky.oauth.callback'),
+                $validated['pds_url'] ?? null,
+            );
+        } catch (RuntimeException $exception) {
+            return redirect()->route('accounts.index')->with('error', $exception->getMessage());
+        }
+
+        $request->session()->put(self::SESSION_KEY.'.'.$authorization['state'], $authorization['context']);
+
+        return redirect()->away($authorization['url']);
+    }
+
+    private function clientId(): string
+    {
+        $callback = route('accounts.bluesky.oauth.callback');
+        $host = parse_url($callback, PHP_URL_HOST);
+
+        if (app()->isLocal() && in_array($host, ['127.0.0.1', '::1', 'localhost'], true)) {
+            return 'http://localhost/?'.http_build_query([
+                'redirect_uri' => $callback,
+                'scope' => 'atproto transition:generic',
+            ]);
+        }
+
+        return route('oauth.bluesky.metadata');
+    }
+
+    public function callback(Request $request): RedirectResponse
+    {
+        $request->user()->can('create', ConnectedAccount::class) ?: abort(403);
+
+        if ($request->filled('error')) {
+            return redirect()->route('accounts.index')->with('error', 'Bluesky did not authorize the connection.');
+        }
+
+        $state = (string) $request->query('state');
+        $context = $request->session()->pull(self::SESSION_KEY.'.'.$state);
+
+        if (! is_array($context)) {
+            return redirect()->route('accounts.index')->with('error', 'Bluesky OAuth state expired. Please try again.');
+        }
+
+        try {
+            $data = $this->connector->callback(
+                (string) $request->query('code'),
+                (string) $request->query('iss'),
+                $context,
+            );
+        } catch (RuntimeException $exception) {
+            Log::warning('Bluesky OAuth callback failed.', ['message' => $exception->getMessage()]);
+
+            return redirect()->route('accounts.index')->with('error', $exception->getMessage());
+        }
+
+        $this->connections->store($data, $request->user());
+
+        return redirect()->route('accounts.index')->with('success', 'Bluesky account connected.');
+    }
+}

--- a/app/Http/Controllers/ConnectedAccounts/ConnectedAccountController.php
+++ b/app/Http/Controllers/ConnectedAccounts/ConnectedAccountController.php
@@ -28,7 +28,7 @@ class ConnectedAccountController extends Controller
         $defaultAccountId = $request->user()->currentWorkspace()->value('default_connected_account_id');
 
         $accounts = ConnectedAccount::query()
-            ->with('connectedBy:id,name')
+            ->with(['connectedBy:id,name', 'secret:connected_account_id,session'])
             ->latest()
             ->get()
             ->sortByDesc(fn (ConnectedAccount $account): bool => $account->id === $defaultAccountId)
@@ -47,6 +47,7 @@ class ConnectedAccountController extends Controller
                 'max_text_length' => $account->maxTextLength(),
                 'x_premium' => $account->hasXPremium(),
                 'is_default' => $account->id === $defaultAccountId,
+                'pds_url' => $this->customPdsUrl($account),
             ])
             ->values()
             ->all();
@@ -56,6 +57,26 @@ class ConnectedAccountController extends Controller
             'capabilities' => Platform::capabilities(),
             'canManage' => $request->user()->can('create', ConnectedAccount::class),
         ]);
+    }
+
+    /**
+     * The saved PDS for a Bluesky account, but only when it differs from the
+     * default discovery target — so reconnect can re-run OAuth against a custom
+     * service URL instead of silently falling back to bsky.social.
+     */
+    private function customPdsUrl(ConnectedAccount $account): ?string
+    {
+        if ($account->platform !== Platform::Bluesky) {
+            return null;
+        }
+
+        $pds = $account->secret?->session['pds'] ?? null;
+
+        if (! is_string($pds) || $pds === '' || rtrim($pds, '/') === 'https://bsky.social') {
+            return null;
+        }
+
+        return $pds;
     }
 
     public function reconnect(Request $request, ConnectedAccount $account): RedirectResponse

--- a/app/Http/Controllers/OAuth/BlueskyClientMetadataController.php
+++ b/app/Http/Controllers/OAuth/BlueskyClientMetadataController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\OAuth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+
+class BlueskyClientMetadataController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        $clientId = route('oauth.bluesky.metadata');
+
+        return response()->json([
+            'client_id' => $clientId,
+            'application_type' => 'web',
+            'client_name' => config('app.name', 'Shoutrrr'),
+            'client_uri' => url('/'),
+            'grant_types' => ['authorization_code', 'refresh_token'],
+            'scope' => 'atproto transition:generic',
+            'response_types' => ['code'],
+            'redirect_uris' => [route('accounts.bluesky.oauth.callback')],
+            'dpop_bound_access_tokens' => true,
+            'token_endpoint_auth_method' => 'none',
+        ], 200, ['Content-Type' => 'application/json']);
+    }
+}

--- a/app/Services/Atproto/DPoP.php
+++ b/app/Services/Atproto/DPoP.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Atproto;
+
+use Firebase\JWT\JWT;
+use Illuminate\Support\Str;
+use phpseclib3\Crypt\EC;
+use phpseclib3\Crypt\EC\PrivateKey;
+use phpseclib3\Crypt\PublicKeyLoader;
+use RuntimeException;
+
+class DPoP
+{
+    /**
+     * @return array{kty: string, crv: string, x: string, y: string, d: string}
+     */
+    public function generateKey(): array
+    {
+        $jwkSet = json_decode(EC::createKey('secp256r1')->toString('JWK'), true, flags: JSON_THROW_ON_ERROR);
+        $jwk = $jwkSet['keys'][0] ?? null;
+
+        if (! is_array($jwk) || ! isset($jwk['x'], $jwk['y'], $jwk['d'])) {
+            throw new RuntimeException('Could not generate a DPoP key.');
+        }
+
+        return [
+            'kty' => 'EC',
+            'crv' => 'P-256',
+            'x' => (string) $jwk['x'],
+            'y' => (string) $jwk['y'],
+            'd' => (string) $jwk['d'],
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $jwk
+     */
+    public function proof(string $method, string $url, array $jwk, ?string $accessToken = null, ?string $nonce = null): string
+    {
+        $publicJwk = [
+            'kty' => 'EC',
+            'crv' => 'P-256',
+            'x' => $jwk['x'],
+            'y' => $jwk['y'],
+        ];
+
+        $payload = [
+            'jti' => (string) Str::uuid(),
+            'htm' => strtoupper($method),
+            'htu' => strtok($url, '?') ?: $url,
+            'iat' => time(),
+        ];
+
+        if ($accessToken !== null && $accessToken !== '') {
+            $payload['ath'] = $this->base64Url(hash('sha256', $accessToken, true));
+        }
+
+        if ($nonce !== null && $nonce !== '') {
+            $payload['nonce'] = $nonce;
+        }
+
+        return $this->jwt(['typ' => 'dpop+jwt', 'alg' => 'ES256', 'jwk' => $publicJwk], $payload, $jwk);
+    }
+
+    /**
+     * @param  array<string, mixed>  $header
+     * @param  array<string, mixed>  $payload
+     * @param  array<string, string>  $jwk
+     */
+    private function jwt(array $header, array $payload, array $jwk): string
+    {
+        $privateKey = PublicKeyLoader::loadPrivateKey(json_encode(['keys' => [$jwk]], JSON_THROW_ON_ERROR));
+
+        if (! $privateKey instanceof PrivateKey) {
+            throw new RuntimeException('Could not load the DPoP key.');
+        }
+
+        return JWT::encode(
+            $payload,
+            $privateKey->toString('PKCS8'),
+            'ES256',
+            null,
+            $header,
+        );
+    }
+
+    private function base64Url(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+}

--- a/app/Services/ConnectedAccounts/BlueskyOAuthConnector.php
+++ b/app/Services/ConnectedAccounts/BlueskyOAuthConnector.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\ConnectedAccounts;
+
+use App\Dto\ConnectedAccount\ConnectedAccountData;
+use App\Enums\Platform;
+use App\Services\Atproto\DPoP;
+use Illuminate\Http\Client\Factory as HttpFactory;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class BlueskyOAuthConnector
+{
+    public function __construct(
+        private readonly HttpFactory $http,
+        private readonly BlueskyConnector $bluesky,
+        private readonly DPoP $dpop,
+    ) {}
+
+    /**
+     * @return array{url: string, state: string, context: array<string, mixed>}
+     */
+    public function authorizationRedirect(?string $identifier, string $clientId, string $redirectUri, ?string $pdsUrl = null): array
+    {
+        $identifier = $identifier === null ? null : ltrim(trim($identifier), '@');
+        $pds = match (true) {
+            $identifier !== null && $identifier !== '' => $this->bluesky->resolvePds($identifier, null),
+            $pdsUrl !== null && trim($pdsUrl) !== '' => $this->bluesky->resolvePds('bsky.social', $pdsUrl),
+            default => 'https://bsky.social',
+        };
+        $did = $identifier ? $this->resolveDid($identifier) : null;
+        $issuer = $this->authorizationServer($pds);
+        $metadata = $this->authorizationMetadata($issuer);
+
+        $state = Str::random(64);
+        $verifier = $this->base64Url(random_bytes(64));
+        $key = $this->dpop->generateKey();
+        $scope = 'atproto transition:generic';
+
+        $parEndpoint = (string) $metadata['pushed_authorization_request_endpoint'];
+        $par = $this->postWithDpopNonce($parEndpoint, $key, [
+            'client_id' => $clientId,
+            'response_type' => 'code',
+            'redirect_uri' => $redirectUri,
+            'scope' => $scope,
+            'state' => $state,
+            'code_challenge' => $this->base64Url(hash('sha256', $verifier, true)),
+            'code_challenge_method' => 'S256',
+        ]);
+
+        if ($par->failed() || ! is_string($par->json('request_uri'))) {
+            throw new RuntimeException('Bluesky OAuth could not start. Please try the app-password option for now.');
+        }
+
+        $authorizationEndpoint = (string) $metadata['authorization_endpoint'];
+        $url = $authorizationEndpoint.'?'.http_build_query([
+            'client_id' => $clientId,
+            'request_uri' => $par->json('request_uri'),
+        ]);
+
+        return [
+            'url' => $url,
+            'state' => $state,
+            'context' => [
+                'identifier' => $identifier,
+                'expected_did' => $did,
+                'pds' => $pds,
+                'issuer' => $issuer,
+                'token_endpoint' => (string) $metadata['token_endpoint'],
+                'code_verifier' => $verifier,
+                'dpop_private_jwk' => $key,
+                'client_id' => $clientId,
+                'redirect_uri' => $redirectUri,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function callback(string $code, string $issuer, array $context): ConnectedAccountData
+    {
+        if ($issuer !== ($context['issuer'] ?? null)) {
+            throw new RuntimeException('Bluesky returned from an unexpected authorization server.');
+        }
+
+        /** @var array<string, string> $key */
+        $key = $context['dpop_private_jwk'];
+        $tokenEndpoint = (string) $context['token_endpoint'];
+        $response = $this->postWithDpopNonce($tokenEndpoint, $key, [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'client_id' => (string) $context['client_id'],
+            'redirect_uri' => (string) $context['redirect_uri'],
+            'code_verifier' => (string) $context['code_verifier'],
+        ]);
+
+        if ($response->failed()) {
+            throw new RuntimeException('Bluesky OAuth token exchange failed. Please try again. (HTTP '.$response->status().')');
+        }
+
+        $did = (string) $response->json('sub');
+        if ($did === '' || ($context['expected_did'] && $did !== $context['expected_did'])) {
+            throw new RuntimeException('Bluesky returned a different account than the one requested.');
+        }
+
+        $pds = (string) ($context['pds'] ?? 'https://bsky.social');
+        if (! ($context['expected_did'] ?? null)) {
+            $pds = $this->resolveDidToPds($did) ?? $pds;
+        }
+
+        $profile = $this->profile($did);
+        $handle = (string) ($profile['handle'] ?? $context['identifier'] ?? $did);
+        $expiresIn = (int) ($response->json('expires_in') ?? 0);
+
+        return new ConnectedAccountData(
+            platform: Platform::Bluesky,
+            remoteAccountId: $did,
+            handle: '@'.ltrim($handle, '@'),
+            displayName: isset($profile['displayName']) ? (string) $profile['displayName'] : null,
+            avatarUrl: isset($profile['avatar']) ? (string) $profile['avatar'] : null,
+            authMethod: 'oauth',
+            accessToken: (string) $response->json('access_token'),
+            refreshToken: $response->json('refresh_token'),
+            session: [
+                'pds' => $pds,
+                'auth_server' => (string) $context['issuer'],
+                'token_endpoint' => $tokenEndpoint,
+                'client_id' => (string) $context['client_id'],
+                'dpop_private_jwk' => $key,
+                'dpop_nonce' => $response->header('DPoP-Nonce'),
+            ],
+            tokenExpiresAt: $expiresIn > 0 ? Date::now()->addSeconds($expiresIn)->toImmutable() : null,
+        );
+    }
+
+    private function resolveDid(string $identifier): ?string
+    {
+        if (str_starts_with($identifier, 'did:')) {
+            return $identifier;
+        }
+
+        $response = $this->http->timeout(10)->connectTimeout(5)->acceptJson()
+            ->get('https://bsky.social/xrpc/com.atproto.identity.resolveHandle', ['handle' => $identifier]);
+
+        return $response->successful() ? $response->json('did') : null;
+    }
+
+    private function resolveDidToPds(string $did): ?string
+    {
+        $response = $this->http->timeout(10)->connectTimeout(5)->acceptJson()
+            ->get('https://plc.directory/'.$did);
+
+        if ($response->failed()) {
+            return null;
+        }
+
+        /** @var array<int, array{type?: string, serviceEndpoint?: string}> $services */
+        $services = $response->json('service', []);
+
+        foreach ($services as $service) {
+            if (($service['type'] ?? null) === 'AtprotoPersonalDataServer' && isset($service['serviceEndpoint'])) {
+                return rtrim((string) $service['serviceEndpoint'], '/');
+            }
+        }
+
+        return null;
+    }
+
+    private function authorizationServer(string $pds): string
+    {
+        $response = $this->http->timeout(10)->connectTimeout(5)->acceptJson()
+            ->get($pds.'/.well-known/oauth-protected-resource');
+
+        $server = $response->json('authorization_servers.0');
+
+        if (is_string($server) && $server !== '') {
+            return rtrim($server, '/');
+        }
+
+        $origin = parse_url($pds, PHP_URL_SCHEME).'://'.parse_url($pds, PHP_URL_HOST);
+        $metadata = $this->http->timeout(10)->connectTimeout(5)->acceptJson()
+            ->get($origin.'/.well-known/oauth-authorization-server');
+
+        if ($metadata->successful() && $metadata->json('issuer') === $origin) {
+            return $origin;
+        }
+
+        throw new RuntimeException('Could not discover the Bluesky authorization server.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function authorizationMetadata(string $issuer): array
+    {
+        $response = $this->http->timeout(10)->connectTimeout(5)->acceptJson()
+            ->get($issuer.'/.well-known/oauth-authorization-server');
+
+        if ($response->failed()) {
+            throw new RuntimeException('Could not read Bluesky OAuth metadata.');
+        }
+
+        /** @var array<string, mixed> $metadata */
+        $metadata = (array) $response->json();
+
+        foreach (['authorization_endpoint', 'token_endpoint', 'pushed_authorization_request_endpoint'] as $key) {
+            if (! is_string($metadata[$key] ?? null) || $metadata[$key] === '') {
+                throw new RuntimeException('Bluesky OAuth metadata is incomplete.');
+            }
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * @param  array<string, string>  $key
+     * @param  array<string, string>  $form
+     */
+    private function postWithDpopNonce(string $url, array $key, array $form, ?string $nonce = null): Response
+    {
+        $response = $this->http->asForm()
+            ->withHeader('DPoP', $this->dpop->proof('POST', $url, $key, nonce: $nonce))
+            ->post($url, $form);
+
+        if ($response->status() === 400 && $nonce === null) {
+            return $this->postWithDpopNonce($url, $key, $form, $response->header('DPoP-Nonce'));
+        }
+
+        return $response;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function profile(string $did): array
+    {
+        $response = $this->http->timeout(10)->connectTimeout(5)->acceptJson()
+            ->get('https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile', ['actor' => $did]);
+
+        return $response->successful() ? (array) $response->json() : [];
+    }
+
+    private function base64Url(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+}

--- a/app/Services/Publishing/Connectors/BlueskyPublishConnector.php
+++ b/app/Services/Publishing/Connectors/BlueskyPublishConnector.php
@@ -11,12 +11,14 @@ use App\Enums\ErrorKind;
 use App\Enums\Platform;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
+use App\Services\Atproto\DPoP;
 use App\Services\Media\ImageCompressor;
 use App\Services\Publishing\Connectors\Concerns\MapsHttpErrors;
 use App\Services\Publishing\Contracts\PublishConnector;
 use GuzzleHttp\Psr7\Utils;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Factory as HttpFactory;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Storage;
@@ -32,6 +34,7 @@ class BlueskyPublishConnector implements PublishConnector
     public function __construct(
         private readonly HttpFactory $http,
         private readonly ImageCompressor $imageCompressor,
+        private readonly DPoP $dpop,
     ) {}
 
     public function publish(PublishContext $context): PublishResult
@@ -52,22 +55,22 @@ class BlueskyPublishConnector implements PublishConnector
             $videoMedia = array_values(array_filter($context->media, fn (PostMedia $m): bool => $m->isVideo()));
 
             if ($rootUri === null && $videoMedia !== []) {
-                $ready = $this->ensureVideoReady($context, $videoMedia[0], $pds, $jwt, $did);
+                $ready = $this->ensureVideoReady($context, $videoMedia[0], $pds, $jwt, $did, $session);
                 if (! $ready->isSuccessful()) {
                     return $ready;
                 }
                 $embed = $this->videoEmbed($context, $videoMedia[0]);
             } else {
                 // Media rides on the root post only; uploaded once, then embedded below.
-                $embed = $rootUri === null ? $this->uploadImages($context->media, $pds, $jwt) : null;
+                $embed = $rootUri === null ? $this->uploadImages($context->media, $pds, $jwt, $session) : null;
             }
 
             // Resume: remote_ids stores only AT-URIs, so recover the root and parent CIDs
             // (needed for threading) from the already-posted records before continuing.
             if ($rootUri !== null) {
-                $rootCid = $this->recordCid($pds, $jwt, $did, $rootUri);
+                $rootCid = $this->recordCid($pds, $jwt, $did, $rootUri, $session);
                 $parentUri = (string) end($remoteIds);
-                $parentCid = $this->recordCid($pds, $jwt, $did, $parentUri);
+                $parentCid = $this->recordCid($pds, $jwt, $did, $parentUri, $session);
             }
 
             foreach ($context->segments as $index => $text) {
@@ -93,14 +96,11 @@ class BlueskyPublishConnector implements PublishConnector
                     ];
                 }
 
-                $response = $this->http
-                    ->withToken($jwt)
-                    ->acceptJson()
-                    ->post($pds.'/xrpc/com.atproto.repo.createRecord', [
-                        'repo' => $did,
-                        'collection' => 'app.bsky.feed.post',
-                        'record' => $record,
-                    ]);
+                $response = $this->postJsonAuthorized($pds.'/xrpc/com.atproto.repo.createRecord', $jwt, $session, [
+                    'repo' => $did,
+                    'collection' => 'app.bsky.feed.post',
+                    'record' => $record,
+                ]);
 
                 if ($response->failed()) {
                     return $this->mapFailure($response);
@@ -144,7 +144,7 @@ class BlueskyPublishConnector implements PublishConnector
         foreach ($target->remote_ids ?? array_filter([$target->remote_id]) as $uri) {
             $rkey = (string) (explode('/', (string) $uri)[4] ?? '');
 
-            $response = $this->http->withToken($jwt)->post($pds.'/xrpc/com.atproto.repo.deleteRecord', [
+            $response = $this->postJsonAuthorized($pds.'/xrpc/com.atproto.repo.deleteRecord', $jwt, $session, [
                 'repo' => $did,
                 'collection' => 'app.bsky.feed.post',
                 'rkey' => $rkey,
@@ -157,19 +157,18 @@ class BlueskyPublishConnector implements PublishConnector
     /**
      * Fetch the CID of an already-posted record so a resumed thread can reference it.
      * The rkey is the 5th `/`-split segment of the at-uri (same extraction as delete()).
+     *
+     * @param  array<string, mixed>  $session
      */
-    private function recordCid(string $pds, string $jwt, string $did, string $uri): string
+    private function recordCid(string $pds, string $jwt, string $did, string $uri, array $session): string
     {
         $rkey = (string) (explode('/', $uri)[4] ?? '');
 
-        $response = $this->http
-            ->withToken($jwt)
-            ->acceptJson()
-            ->get($pds.'/xrpc/com.atproto.repo.getRecord', [
-                'repo' => $did,
-                'collection' => 'app.bsky.feed.post',
-                'rkey' => $rkey,
-            ]);
+        $response = $this->getAuthorized($pds.'/xrpc/com.atproto.repo.getRecord', $jwt, $session, [
+            'repo' => $did,
+            'collection' => 'app.bsky.feed.post',
+            'rkey' => $rkey,
+        ]);
 
         if ($response->failed()) {
             throw new BlueskyRequestFailed($response);
@@ -182,15 +181,17 @@ class BlueskyPublishConnector implements PublishConnector
      * Ensure the video job is running or completed. On first call, mints a service-auth token
      * and uploads the video, persisting the jobId. On subsequent calls, polls getJobStatus.
      * Returns a successful PublishResult only when the job has completed.
+     *
+     * @param  array<string, mixed>  $session
      */
-    private function ensureVideoReady(PublishContext $context, PostMedia $media, string $pds, string $jwt, string $did): PublishResult
+    private function ensureVideoReady(PublishContext $context, PostMedia $media, string $pds, string $jwt, string $did, array $session): PublishResult
     {
         $state = new MediaUploadState($context->target->media_upload_state);
         $jobId = $state->remoteRef($media->id);
 
         try {
             if ($jobId === null) {
-                $jobId = $this->uploadVideo($media, $pds, $jwt, $did);
+                $jobId = $this->uploadVideo($media, $pds, $jwt, $did, $session);
                 $state->markUploaded($media->id, $jobId);
                 $context->target->forceFill(['media_upload_state' => $state->toArray()])->save();
             }
@@ -238,17 +239,18 @@ class BlueskyPublishConnector implements PublishConnector
     /**
      * Mint a service-auth token scoped to the user's PDS for blob upload, then push raw
      * bytes to the video service (which cannot be PDS-proxied).
+     *
+     * @param  array<string, mixed>  $session
      */
-    private function uploadVideo(PostMedia $media, string $pds, string $jwt, string $did): string
+    private function uploadVideo(PostMedia $media, string $pds, string $jwt, string $did, array $session): string
     {
         $pdsHost = (string) parse_url($pds, PHP_URL_HOST);
 
-        $auth = $this->http->withToken($jwt)->acceptJson()
-            ->get($pds.'/xrpc/com.atproto.server.getServiceAuth', [
-                'aud' => 'did:web:'.$pdsHost,
-                'lxm' => 'com.atproto.repo.uploadBlob',
-                'exp' => time() + 1800,
-            ]);
+        $auth = $this->getAuthorized($pds.'/xrpc/com.atproto.server.getServiceAuth', $jwt, $session, [
+            'aud' => 'did:web:'.$pdsHost,
+            'lxm' => 'com.atproto.repo.uploadBlob',
+            'exp' => time() + 1800,
+        ]);
 
         if ($auth->failed()) {
             throw new BlueskyRequestFailed($auth);
@@ -293,9 +295,10 @@ class BlueskyPublishConnector implements PublishConnector
      * Upload each media item as a blob and build an `app.bsky.embed.images` embed.
      *
      * @param  list<PostMedia>  $media
+     * @param  array<string, mixed>  $session
      * @return array{'$type': string, images: list<array{alt: string, image: array<string, mixed>}>}|null
      */
-    private function uploadImages(array $media, string $pds, string $jwt): ?array
+    private function uploadImages(array $media, string $pds, string $jwt, array $session): ?array
     {
         $media = array_slice($media, 0, Platform::Bluesky->maxMedia());
 
@@ -309,10 +312,7 @@ class BlueskyPublishConnector implements PublishConnector
             $bytes = (string) Storage::disk($item->disk)->get($item->path);
             $compressed = $this->imageCompressor->compressToFit($bytes, Platform::Bluesky->maxMediaBytes(), $item->mime, Platform::Bluesky->allowedMime());
 
-            $response = $this->http
-                ->withToken($jwt)
-                ->withBody($compressed->bytes, $compressed->mime)
-                ->post($pds.'/xrpc/com.atproto.repo.uploadBlob');
+            $response = $this->postBodyAuthorized($pds.'/xrpc/com.atproto.repo.uploadBlob', $jwt, $session, $compressed->bytes, $compressed->mime);
 
             if ($response->failed()) {
                 throw new BlueskyRequestFailed($response);
@@ -325,6 +325,71 @@ class BlueskyPublishConnector implements PublishConnector
         }
 
         return ['$type' => 'app.bsky.embed.images', 'images' => $images];
+    }
+
+    /**
+     * @param  array<string, mixed>  $session
+     * @param  array<string, mixed>  $payload
+     */
+    private function postJsonAuthorized(string $url, string $jwt, array $session, array $payload): Response
+    {
+        $response = $this->authorized('POST', $url, $jwt, $session)->acceptJson()->post($url, $payload);
+        $nonce = $this->responseNonce($response);
+
+        return $response->failed() && $nonce !== null
+            ? $this->authorized('POST', $url, $jwt, $session, $nonce)->acceptJson()->post($url, $payload)
+            : $response;
+    }
+
+    /**
+     * @param  array<string, mixed>  $session
+     * @param  array<string, mixed>  $query
+     */
+    private function getAuthorized(string $url, string $jwt, array $session, array $query): Response
+    {
+        $response = $this->authorized('GET', $url, $jwt, $session)->acceptJson()->get($url, $query);
+        $nonce = $this->responseNonce($response);
+
+        return $response->failed() && $nonce !== null
+            ? $this->authorized('GET', $url, $jwt, $session, $nonce)->acceptJson()->get($url, $query)
+            : $response;
+    }
+
+    /**
+     * @param  array<string, mixed>  $session
+     */
+    private function postBodyAuthorized(string $url, string $jwt, array $session, string $body, string $mime): Response
+    {
+        $response = $this->authorized('POST', $url, $jwt, $session)->withBody($body, $mime)->post($url);
+        $nonce = $this->responseNonce($response);
+
+        return $response->failed() && $nonce !== null
+            ? $this->authorized('POST', $url, $jwt, $session, $nonce)->withBody($body, $mime)->post($url)
+            : $response;
+    }
+
+    private function responseNonce(Response $response): ?string
+    {
+        $nonce = $response->header('DPoP-Nonce');
+
+        return $nonce !== '' ? $nonce : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $session
+     */
+    private function authorized(string $method, string $url, string $jwt, array $session, ?string $nonce = null): PendingRequest
+    {
+        $key = $session['dpop_private_jwk'] ?? null;
+
+        if (is_array($key)) {
+            return $this->http->withHeaders([
+                'Authorization' => 'DPoP '.$jwt,
+                'DPoP' => $this->dpop->proof($method, $url, $key, $jwt, $nonce ?? $session['dpop_nonce'] ?? null),
+            ]);
+        }
+
+        return $this->http->withToken($jwt);
     }
 
     /**

--- a/app/Services/Publishing/TokenManager.php
+++ b/app/Services/Publishing/TokenManager.php
@@ -9,6 +9,7 @@ use App\Enums\Platform;
 use App\Exceptions\TokenRefreshException;
 use App\Models\ConnectedAccount;
 use App\Models\ConnectedAccountSecret;
+use App\Services\Atproto\DPoP;
 use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Cache;
@@ -20,7 +21,10 @@ class TokenManager
 
     private const string BLUESKY_DEFAULT_PDS = 'https://bsky.social';
 
-    public function __construct(private readonly HttpFactory $http) {}
+    public function __construct(
+        private readonly HttpFactory $http,
+        private readonly DPoP $dpop,
+    ) {}
 
     /**
      * Resolve usable credentials for an account, refreshing the OAuth token when it
@@ -33,8 +37,12 @@ class TokenManager
     {
         $secret = $account->secret()->firstOrFail();
 
-        if ($account->platform === Platform::Bluesky) {
+        if ($account->platform === Platform::Bluesky && $account->auth_method === 'app_password') {
             return $this->blueskyCredentials($account, $secret);
+        }
+
+        if ($account->platform === Platform::Bluesky && $account->auth_method === 'oauth') {
+            return $this->blueskyOAuthCredentials($account, $secret, $force);
         }
 
         if (! $force && ! $this->needsRefresh($account)) {
@@ -61,6 +69,18 @@ class TokenManager
         }
 
         return $account->token_expires_at->lte(Date::now()->addSeconds(self::SKEW_SECONDS));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function blueskyOAuthCredentials(ConnectedAccount $account, ConnectedAccountSecret $secret, bool $force): array
+    {
+        if (! $force && ! $this->needsRefresh($account)) {
+            return $this->blueskyOAuthPayload($secret);
+        }
+
+        return $this->refreshOAuth($account, $secret);
     }
 
     /**
@@ -167,14 +187,18 @@ class TokenManager
      */
     private function refreshOAuth(ConnectedAccount $account, ConnectedAccountSecret $secret): array
     {
-        $endpoint = match ($account->platform) {
-            Platform::X => 'https://api.twitter.com/2/oauth2/token',
-            Platform::LinkedIn => 'https://www.linkedin.com/oauth/v2/accessToken',
-            default => null,
-        };
+        if ($account->platform === Platform::Bluesky) {
+            $endpoint = (string) ($secret->session['token_endpoint'] ?? '');
+        } elseif ($account->platform === Platform::X) {
+            $endpoint = 'https://api.twitter.com/2/oauth2/token';
+        } else {
+            $endpoint = 'https://www.linkedin.com/oauth/v2/accessToken';
+        }
 
         $configKey = $account->platform->configKey();
-        $clientId = (string) config($configKey.'.client_id');
+        $clientId = $account->platform === Platform::Bluesky
+            ? (string) ($secret->session['client_id'] ?? route('oauth.bluesky.metadata'))
+            : (string) config($configKey.'.client_id');
         $clientSecret = (string) config($configKey.'.client_secret');
 
         $request = $this->http->asForm();
@@ -190,6 +214,13 @@ class TokenManager
         // with "Missing valid authorization header". LinkedIn expects them in the body.
         if ($account->platform === Platform::X) {
             $request = $request->withBasicAuth($clientId, $clientSecret);
+        } elseif ($account->platform === Platform::Bluesky) {
+            /** @var array<string, string>|null $key */
+            $key = $secret->session['dpop_private_jwk'] ?? null;
+            if (! is_array($key) || $endpoint === '') {
+                throw new TokenRefreshException("Token refresh failed for account {$account->id}.");
+            }
+            $request = $request->withHeader('DPoP', $this->dpop->proof('POST', $endpoint, $key, nonce: $secret->session['dpop_nonce'] ?? null));
         } else {
             $body['client_secret'] = $clientSecret;
         }
@@ -213,6 +244,9 @@ class TokenManager
         $secret->forceFill([
             'access_token' => $accessToken,
             'refresh_token' => $refreshToken,
+            'session' => $account->platform === Platform::Bluesky
+                ? [...($secret->session ?? []), 'dpop_nonce' => $response->header('DPoP-Nonce')]
+                : $secret->session,
         ])->save();
 
         $account->forceFill([
@@ -223,7 +257,25 @@ class TokenManager
             'refresh_failure_reason' => null,
         ])->save();
 
-        return ['access_token' => $accessToken];
+        return $account->platform === Platform::Bluesky
+            ? $this->blueskyOAuthPayload($secret->refresh())
+            : ['access_token' => $accessToken];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function blueskyOAuthPayload(ConnectedAccountSecret $secret): array
+    {
+        $session = $secret->session ?? [];
+
+        return [
+            'access_token' => $secret->access_token,
+            'session' => [
+                ...$session,
+                'accessJwt' => $secret->access_token,
+            ],
+        ];
     }
 
     private function refreshFailureReason(Response $response): string

--- a/resources/js/components/accounts/connect-buttons.tsx
+++ b/resources/js/components/accounts/connect-buttons.tsx
@@ -3,6 +3,7 @@ import { AtSign, ChevronDown } from 'lucide-react';
 import { useState } from 'react';
 
 import BlueskyConnectionController from '@/actions/App/Http/Controllers/ConnectedAccounts/BlueskyConnectionController';
+import BlueskyOAuthController from '@/actions/App/Http/Controllers/ConnectedAccounts/BlueskyOAuthController';
 import OAuthConnectionController from '@/actions/App/Http/Controllers/ConnectedAccounts/OAuthConnectionController';
 import InputError from '@/components/common/input-error';
 import { PlatformGlyph } from '@/components/common/platform-glyph';
@@ -69,7 +70,7 @@ function BlueskyConnectDialog() {
                 <DialogHeader>
                     <DialogTitle>Connect a Bluesky account</DialogTitle>
                     <DialogDescription>
-                        Use an{' '}
+                        Use OAuth for the easiest setup, or connect with an{' '}
                         <a
                             href="https://bsky.app/settings/app-passwords"
                             target="_blank"
@@ -78,10 +79,48 @@ function BlueskyConnectDialog() {
                         >
                             app password
                         </a>{' '}
-                        instead of your main password. App passwords bypass 2FA,
-                        and disconnecting here does not revoke them on Bluesky.
+                        if you prefer. App passwords bypass 2FA, and
+                        disconnecting here does not revoke them on Bluesky.
                     </DialogDescription>
                 </DialogHeader>
+                <form
+                    {...BlueskyOAuthController.redirect.form()}
+                    className="space-y-4 py-2"
+                >
+                    <Button type="submit" className="w-full">
+                        Continue with Bluesky OAuth
+                    </Button>
+                    <Collapsible>
+                        <CollapsibleTrigger asChild>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className={ADVANCED_SERVICE_URL_TRIGGER_CLASS}
+                            >
+                                Advanced: service URL
+                                <ChevronDown
+                                    aria-hidden="true"
+                                    data-icon="inline-end"
+                                    className="size-4 text-muted-foreground transition-transform"
+                                />
+                            </Button>
+                        </CollapsibleTrigger>
+                        <CollapsibleContent className="grid gap-2 pt-2">
+                            <Label htmlFor="oauth_pds_url">Service URL</Label>
+                            <Input
+                                id="oauth_pds_url"
+                                name="pds_url"
+                                placeholder="https://bsky.social"
+                            />
+                        </CollapsibleContent>
+                    </Collapsible>
+                </form>
+                <div className="flex items-center gap-3 py-1 text-[11px] tracking-wide text-muted-foreground uppercase">
+                    <span className="h-px flex-1 bg-border" />
+                    App password
+                    <span className="h-px flex-1 bg-border" />
+                </div>
                 <Form
                     {...BlueskyConnectionController.store.form()}
                     options={{ preserveScroll: true }}

--- a/resources/js/components/accounts/types.ts
+++ b/resources/js/components/accounts/types.ts
@@ -13,6 +13,7 @@ export type Account = {
     max_text_length: number;
     x_premium: boolean;
     is_default: boolean;
+    pds_url: string | null;
 };
 
 export type Capability = {

--- a/resources/js/pages/accounts/__tests__/reconnect-oauth-route.test.ts
+++ b/resources/js/pages/accounts/__tests__/reconnect-oauth-route.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+describe('OAuth account reconnect route selection', () => {
+    it('uses the dedicated Bluesky OAuth route for Bluesky accounts', () => {
+        const source = readFileSync(
+            resolve(process.cwd(), 'resources/js/pages/accounts/index.tsx'),
+            'utf8',
+        );
+
+        expect(source).toContain('BlueskyOAuthController');
+        expect(source).toContain("account.platform === 'bluesky'");
+        expect(source).toContain('BlueskyOAuthController.redirect.url()');
+    });
+});

--- a/resources/js/pages/accounts/__tests__/reconnect-oauth-route.test.ts
+++ b/resources/js/pages/accounts/__tests__/reconnect-oauth-route.test.ts
@@ -1,17 +1,56 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-
 import { describe, expect, it } from 'vitest';
 
-describe('OAuth account reconnect route selection', () => {
-    it('uses the dedicated Bluesky OAuth route for Bluesky accounts', () => {
-        const source = readFileSync(
-            resolve(process.cwd(), 'resources/js/pages/accounts/index.tsx'),
-            'utf8',
-        );
+import BlueskyOAuthController from '@/actions/App/Http/Controllers/ConnectedAccounts/BlueskyOAuthController';
+import OAuthConnectionController from '@/actions/App/Http/Controllers/ConnectedAccounts/OAuthConnectionController';
+import type { Account } from '@/components/accounts/types';
+import { reconnectOAuthUrl } from '@/pages/accounts/index';
 
-        expect(source).toContain('BlueskyOAuthController');
-        expect(source).toContain("account.platform === 'bluesky'");
-        expect(source).toContain('BlueskyOAuthController.redirect.url()');
+function account(overrides: Partial<Account>): Account {
+    return {
+        id: '1',
+        platform: 'bluesky',
+        platform_label: 'Bluesky',
+        handle: '@me.bsky.social',
+        display_name: null,
+        avatar_url: null,
+        status: 'needs_attention',
+        status_label: 'Needs attention',
+        auth_method: 'oauth',
+        connected_by: null,
+        token_expires_at: null,
+        max_text_length: 300,
+        x_premium: false,
+        is_default: false,
+        pds_url: null,
+        ...overrides,
+    };
+}
+
+describe('reconnectOAuthUrl', () => {
+    it('uses the dedicated Bluesky OAuth route for Bluesky accounts', () => {
+        expect(reconnectOAuthUrl(account({ platform: 'bluesky' }))).toBe(
+            BlueskyOAuthController.redirect.url(),
+        );
+    });
+
+    it('replays a saved custom PDS as pds_url for Bluesky accounts', () => {
+        expect(
+            reconnectOAuthUrl(
+                account({
+                    platform: 'bluesky',
+                    pds_url: 'https://pds.example',
+                }),
+            ),
+        ).toBe(
+            BlueskyOAuthController.redirect.url({
+                query: { pds_url: 'https://pds.example' },
+            }),
+        );
+    });
+
+    it('uses the generic OAuth route for other platforms', () => {
+        expect(reconnectOAuthUrl(account({ platform: 'x' }))).toBe(
+            OAuthConnectionController.redirect.url({ platform: 'x' }),
+        );
     });
 });

--- a/resources/js/pages/accounts/index.tsx
+++ b/resources/js/pages/accounts/index.tsx
@@ -2,6 +2,7 @@ import { Head, router, usePage } from '@inertiajs/react';
 import { CircleAlert, Plug, X as XIcon } from 'lucide-react';
 import { useState } from 'react';
 
+import BlueskyOAuthController from '@/actions/App/Http/Controllers/ConnectedAccounts/BlueskyOAuthController';
 import ConnectedAccountController from '@/actions/App/Http/Controllers/ConnectedAccounts/ConnectedAccountController';
 import OAuthConnectionController from '@/actions/App/Http/Controllers/ConnectedAccounts/OAuthConnectionController';
 import { AccountCard } from '@/components/accounts/account-card';
@@ -46,9 +47,12 @@ export default function ConnectedAccounts({
     };
 
     const reconnectOAuth = (account: Account) => {
-        window.location.href = OAuthConnectionController.redirect.url({
-            platform: account.platform,
-        });
+        window.location.href =
+            account.platform === 'bluesky'
+                ? BlueskyOAuthController.redirect.url()
+                : OAuthConnectionController.redirect.url({
+                      platform: account.platform,
+                  });
     };
 
     const { flash } = usePage().props;

--- a/resources/js/pages/accounts/index.tsx
+++ b/resources/js/pages/accounts/index.tsx
@@ -21,6 +21,24 @@ import { removeById } from '@/lib/optimistic';
 
 export const ACCOUNT_GRID_CLASS = 'grid grid-cols-1 gap-4 lg:grid-cols-2';
 
+/**
+ * Resolve the OAuth redirect URL used to (re)connect an account. Bluesky has a
+ * dedicated controller; every other platform shares the generic OAuth route.
+ * A saved custom PDS is replayed as `pds_url` so reconnect targets the original
+ * authorization server instead of falling back to the bsky.social default.
+ */
+export function reconnectOAuthUrl(account: Account): string {
+    if (account.platform !== 'bluesky') {
+        return OAuthConnectionController.redirect.url({
+            platform: account.platform,
+        });
+    }
+
+    return BlueskyOAuthController.redirect.url({
+        query: account.pds_url ? { pds_url: account.pds_url } : {},
+    });
+}
+
 type Props = {
     accounts: Account[];
     capabilities: Capability[];
@@ -47,12 +65,7 @@ export default function ConnectedAccounts({
     };
 
     const reconnectOAuth = (account: Account) => {
-        window.location.href =
-            account.platform === 'bluesky'
-                ? BlueskyOAuthController.redirect.url()
-                : OAuthConnectionController.redirect.url({
-                      platform: account.platform,
-                  });
+        window.location.href = reconnectOAuthUrl(account);
     };
 
     const { flash } = usePage().props;

--- a/routes/accounts.php
+++ b/routes/accounts.php
@@ -3,10 +3,15 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\ConnectedAccounts\BlueskyConnectionController;
+use App\Http\Controllers\ConnectedAccounts\BlueskyOAuthController;
 use App\Http\Controllers\ConnectedAccounts\ConnectedAccountController;
 use App\Http\Controllers\ConnectedAccounts\OAuthConnectionController;
+use App\Http\Controllers\OAuth\BlueskyClientMetadataController;
 use App\Models\ConnectedAccount;
 use Illuminate\Support\Facades\Route;
+
+Route::get('oauth/bluesky/client-metadata.json', BlueskyClientMetadataController::class)
+    ->name('oauth.bluesky.metadata');
 
 // Route-model binding runs in SubstituteBindings, which executes before the
 // appended WorkspaceMiddleware sets the workspace Context — so the model's global
@@ -19,6 +24,14 @@ Route::bind('account', fn (string $value): ConnectedAccount => ConnectedAccount:
 
 Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::get('accounts', [ConnectedAccountController::class, 'index'])->name('accounts.index');
+
+    Route::get('accounts/connect/bluesky/oauth', [BlueskyOAuthController::class, 'redirect'])
+        ->middleware('throttle:10,1')
+        ->name('accounts.bluesky.oauth');
+
+    Route::get('accounts/callback/bluesky/oauth', [BlueskyOAuthController::class, 'callback'])
+        ->middleware('throttle:10,1')
+        ->name('accounts.bluesky.oauth.callback');
 
     Route::get('accounts/connect/{platform}', [OAuthConnectionController::class, 'redirect'])
         ->middleware('throttle:10,1')

--- a/tests/Feature/ConnectedAccounts/AccountsPageTest.php
+++ b/tests/Feature/ConnectedAccounts/AccountsPageTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use App\Enums\Platform;
 use App\Enums\WorkspaceRole;
 use App\Models\ConnectedAccount;
+use App\Models\ConnectedAccountSecret;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Models\WorkspaceMembership;
@@ -44,6 +46,50 @@ test('the accounts page lists accounts and exposes capabilities and canManage to
             ->where('accounts.0.max_text_length', 25_000)
             ->where('accounts.0.is_default', false)
             ->missing('accounts.0.secret'),
+        );
+});
+
+test('the accounts page exposes a saved custom PDS so reconnect can replay it', function () {
+    $owner = User::factory()->create(['email_verified_at' => now()]);
+    $workspace = Workspace::factory()->create(['owner_id' => $owner->id]);
+    WorkspaceMembership::factory()->owner()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $owner->id,
+    ]);
+    $owner->forceFill(['current_workspace_id' => $workspace->id])->save();
+
+    $default = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'platform' => Platform::Bluesky,
+        'handle' => '@default-pds',
+        'auth_method' => 'oauth',
+        'created_at' => now()->subMinute(),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $default->id,
+        'session' => ['pds' => 'https://bsky.social'],
+    ]);
+
+    $custom = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'platform' => Platform::Bluesky,
+        'handle' => '@custom',
+        'auth_method' => 'oauth',
+        'created_at' => now(),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $custom->id,
+        'session' => ['pds' => 'https://pds.example'],
+    ]);
+
+    test()->actingAs($owner)->get('/accounts')
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('accounts/index')
+            ->has('accounts', 2)
+            ->where('accounts.0.handle', '@custom')
+            ->where('accounts.0.pds_url', 'https://pds.example')
+            ->where('accounts.1.handle', '@default-pds')
+            ->where('accounts.1.pds_url', null),
         );
 });
 

--- a/tests/Feature/ConnectedAccounts/ConnectBlueskyOAuthTest.php
+++ b/tests/Feature/ConnectedAccounts/ConnectBlueskyOAuthTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Enums\Platform;
+use App\Enums\WorkspaceRole;
+use App\Models\ConnectedAccount;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+function blueskyOAuthOwner(): array
+{
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'role' => WorkspaceRole::Owner,
+    ]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    test()->actingAs($user);
+
+    return [$user, $workspace];
+}
+
+function fakeDefaultBlueskyOAuthDiscovery(): void
+{
+    Http::fake(function (Request $request) {
+        $url = $request->url();
+
+        return match (true) {
+            $url === 'https://bsky.social/.well-known/oauth-protected-resource' => Http::response([], 404),
+            $url === 'https://bsky.social/.well-known/oauth-authorization-server' => Http::response([
+                'issuer' => 'https://bsky.social',
+                'authorization_endpoint' => 'https://bsky.social/oauth/authorize',
+                'token_endpoint' => 'https://bsky.social/oauth/token',
+                'pushed_authorization_request_endpoint' => 'https://bsky.social/oauth/par',
+            ]),
+            $url === 'https://bsky.social/oauth/par' => Http::response(['request_uri' => 'urn:request:123'], 201, ['DPoP-Nonce' => 'nonce-1']),
+            $url === 'https://bsky.social/oauth/token' => Http::response([
+                'access_token' => 'access-oauth',
+                'refresh_token' => 'refresh-oauth',
+                'expires_in' => 3600,
+                'sub' => 'did:plc:abc',
+                'scope' => 'atproto transition:generic',
+            ], 200, ['DPoP-Nonce' => 'nonce-2']),
+            str_contains($url, 'plc.directory/did:plc:abc') => Http::response([
+                'service' => [['type' => 'AtprotoPersonalDataServer', 'serviceEndpoint' => 'https://pds.example']],
+            ]),
+            str_contains($url, 'app.bsky.actor.getProfile') => Http::response([
+                'handle' => 'ada.bsky.social',
+                'displayName' => 'Ada',
+                'avatar' => 'https://cdn.example/ada.jpg',
+            ]),
+            default => Http::response([], 404),
+        };
+    });
+}
+
+test('bluesky oauth client metadata is public', function () {
+    test()->get(route('oauth.bluesky.metadata'))
+        ->assertOk()
+        ->assertJsonPath('dpop_bound_access_tokens', true)
+        ->assertJsonPath('scope', 'atproto transition:generic')
+        ->assertJsonPath('token_endpoint_auth_method', 'none');
+});
+
+test('an owner can start bluesky oauth without a login hint', function () {
+    blueskyOAuthOwner();
+    fakeDefaultBlueskyOAuthDiscovery();
+
+    test()->get(route('accounts.bluesky.oauth'))
+        ->assertRedirect('https://bsky.social/oauth/authorize?client_id='.urlencode(route('oauth.bluesky.metadata')).'&request_uri=urn%3Arequest%3A123');
+
+    expect(session('accounts.bluesky.oauth'))->toHaveCount(1);
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://bsky.social/oauth/par'
+        && $request->hasHeader('DPoP')
+        && ! isset($request['login_hint'])
+        && $request['scope'] === 'atproto transition:generic');
+});
+
+test('bluesky oauth can start from an advanced service url', function () {
+    blueskyOAuthOwner();
+
+    Http::fake(function (Request $request) {
+        $url = $request->url();
+
+        return match (true) {
+            $url === 'https://pds.example/.well-known/oauth-protected-resource' => Http::response([
+                'authorization_servers' => ['https://auth.example'],
+            ]),
+            $url === 'https://auth.example/.well-known/oauth-authorization-server' => Http::response([
+                'issuer' => 'https://auth.example',
+                'authorization_endpoint' => 'https://auth.example/oauth/authorize',
+                'token_endpoint' => 'https://auth.example/oauth/token',
+                'pushed_authorization_request_endpoint' => 'https://auth.example/oauth/par',
+            ]),
+            $url === 'https://auth.example/oauth/par' => Http::response(['request_uri' => 'urn:request:456'], 201, ['DPoP-Nonce' => 'nonce-1']),
+            default => Http::response([], 404),
+        };
+    });
+
+    test()->get(route('accounts.bluesky.oauth', ['pds_url' => 'https://pds.example']))
+        ->assertRedirect('https://auth.example/oauth/authorize?client_id='.urlencode(route('oauth.bluesky.metadata')).'&request_uri=urn%3Arequest%3A456');
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://auth.example/oauth/par'
+        && ! isset($request['login_hint']));
+});
+
+test('bluesky oauth callback stores an oauth account', function () {
+    [, $workspace] = blueskyOAuthOwner();
+    fakeDefaultBlueskyOAuthDiscovery();
+
+    test()->get(route('accounts.bluesky.oauth'));
+    $state = array_key_first(session('accounts.bluesky.oauth'));
+
+    test()->get(route('accounts.bluesky.oauth.callback', [
+        'state' => $state,
+        'code' => 'code-123',
+        'iss' => 'https://bsky.social',
+    ]))->assertRedirect(route('accounts.index'))->assertSessionHas('success');
+
+    $account = ConnectedAccount::withoutGlobalScopes()->where('workspace_id', $workspace->id)->first();
+
+    expect($account->platform)->toBe(Platform::Bluesky)
+        ->and($account->auth_method)->toBe('oauth')
+        ->and($account->handle)->toBe('@ada.bsky.social')
+        ->and($account->secret->access_token)->toBe('access-oauth')
+        ->and($account->secret->refresh_token)->toBe('refresh-oauth')
+        ->and($account->secret->session)->toHaveKeys(['pds', 'auth_server', 'token_endpoint', 'dpop_private_jwk'])
+        ->and($account->secret->session['pds'])->toBe('https://pds.example');
+});

--- a/tests/Feature/Publishing/BlueskyPublishConnectorTest.php
+++ b/tests/Feature/Publishing/BlueskyPublishConnectorTest.php
@@ -6,6 +6,7 @@ use App\Enums\Platform;
 use App\Models\ConnectedAccount;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
+use App\Services\Atproto\DPoP;
 use App\Services\Media\CompressionResult;
 use App\Services\Media\ImageCompressor;
 use App\Services\Publishing\Connectors\BlueskyPublishConnector;
@@ -39,6 +40,33 @@ test('bluesky creates a single post and returns its uri', function () {
 
     expect($result->isSuccessful())->toBeTrue()
         ->and($result->remoteIds)->toBe(['at://did:plc:me/app.bsky.feed.post/1']);
+});
+
+test('bluesky oauth publish uses dpop authorization', function () {
+    Http::fake([
+        '*com.atproto.repo.createRecord' => Http::response(['uri' => 'at://did:plc:me/app.bsky.feed.post/1', 'cid' => 'cid1']),
+    ]);
+
+    $context = bskyContext(['oauth post']);
+    $context = new PublishContext(
+        target: $context->target,
+        segments: $context->segments,
+        media: $context->media,
+        account: $context->account,
+        credentials: ['session' => [
+            'accessJwt' => 'oauth-token',
+            'pds' => 'https://bsky.social',
+            'dpop_private_jwk' => app(DPoP::class)->generateKey(),
+            'dpop_nonce' => 'nonce-1',
+        ]],
+    );
+
+    $result = app(BlueskyPublishConnector::class)->publish($context);
+
+    expect($result->isSuccessful())->toBeTrue();
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'com.atproto.repo.createRecord')
+        && $request->hasHeader('Authorization', 'DPoP oauth-token')
+        && $request->hasHeader('DPoP'));
 });
 
 test('bluesky resolves handles and sends mention facets', function () {

--- a/tests/Feature/Publishing/RefreshExpiringTokensTest.php
+++ b/tests/Feature/Publishing/RefreshExpiringTokensTest.php
@@ -4,6 +4,7 @@ use App\Enums\ConnectedAccountStatus;
 use App\Enums\Platform;
 use App\Models\ConnectedAccount;
 use App\Models\ConnectedAccountSecret;
+use App\Services\Atproto\DPoP;
 use Illuminate\Support\Facades\Http;
 
 test('it proactively refreshes accounts expiring within six hours', function () {
@@ -59,6 +60,45 @@ test('it skips accounts that expire outside the proactive refresh window', funct
     $this->artisan('accounts:refresh-tokens')->assertExitCode(0);
 
     Http::assertNothingSent();
+});
+
+test('it proactively refreshes expiring bluesky oauth accounts', function () {
+    $key = app(DPoP::class)->generateKey();
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::Bluesky->value,
+        'auth_method' => 'oauth',
+        'token_expires_at' => now()->addHours(5),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'access_token' => 'old-access',
+        'refresh_token' => 'old-refresh',
+        'session' => [
+            'token_endpoint' => 'https://auth.bsky.test/oauth/token',
+            'client_id' => 'https://app.test/oauth/bluesky/client-metadata.json',
+            'dpop_private_jwk' => $key,
+        ],
+    ]);
+
+    Http::fake([
+        'https://auth.bsky.test/oauth/token' => Http::response([
+            'access_token' => 'fresh-access',
+            'refresh_token' => 'fresh-refresh',
+            'expires_in' => 3600,
+        ], 200, ['DPoP-Nonce' => 'fresh-nonce']),
+    ]);
+
+    $this->artisan('accounts:refresh-tokens')->assertExitCode(0);
+
+    $account->refresh();
+    expect($account->secret->access_token)->toBe('fresh-access')
+        ->and($account->secret->refresh_token)->toBe('fresh-refresh')
+        ->and($account->secret->session['dpop_nonce'])->toBe('fresh-nonce')
+        ->and($account->refresh_failed_at)->toBeNull();
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.bsky.test/oauth/token'
+        && $request->hasHeader('DPoP')
+        && $request['grant_type'] === 'refresh_token');
 });
 
 test('token refresh health check is scheduled every fifteen minutes', function () {

--- a/tests/Unit/ConnectedAccounts/DPoPTest.php
+++ b/tests/Unit/ConnectedAccounts/DPoPTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Services\Atproto\DPoP;
+
+function base64UrlJson(string $part): array
+{
+    return json_decode(base64_decode(strtr($part, '-_', '+/').str_repeat('=', (4 - strlen($part) % 4) % 4), true), true, flags: JSON_THROW_ON_ERROR);
+}
+
+test('it creates signed dpop proofs with public jwk metadata', function () {
+    $dpop = app(DPoP::class);
+    $key = $dpop->generateKey();
+    $proof = $dpop->proof('post', 'https://bsky.social/xrpc/com.atproto.repo.createRecord?x=1', $key, 'access-token', 'nonce-1');
+    [$header, $payload, $signature] = explode('.', $proof);
+
+    expect(base64UrlJson($header))
+        ->toMatchArray(['typ' => 'dpop+jwt', 'alg' => 'ES256'])
+        ->and(base64UrlJson($header)['jwk'])->toHaveKeys(['kty', 'crv', 'x', 'y'])
+        ->and(base64UrlJson($payload))->toMatchArray([
+            'htm' => 'POST',
+            'htu' => 'https://bsky.social/xrpc/com.atproto.repo.createRecord',
+            'nonce' => 'nonce-1',
+        ])
+        ->and($signature)->not->toBeEmpty();
+});

--- a/tests/Unit/Publishing/TokenManagerTest.php
+++ b/tests/Unit/Publishing/TokenManagerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Enums\ConnectedAccountStatus;
+use App\Enums\Platform;
+use App\Models\ConnectedAccount;
+use App\Models\ConnectedAccountSecret;
+use App\Services\Atproto\DPoP;
+use App\Services\Publishing\TokenManager;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+it('refreshes bluesky oauth tokens with dpop and returns a bluesky session payload', function () {
+    $key = app(DPoP::class)->generateKey();
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::Bluesky->value,
+        'auth_method' => 'oauth',
+        'token_expires_at' => now()->subMinute(),
+        'status' => ConnectedAccountStatus::NeedsAttention->value,
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'access_token' => 'old-access',
+        'refresh_token' => 'old-refresh',
+        'session' => [
+            'pds' => 'https://pds.example',
+            'token_endpoint' => 'https://auth.example/oauth/token',
+            'client_id' => 'https://app.example/oauth/bluesky/client-metadata.json',
+            'dpop_private_jwk' => $key,
+            'dpop_nonce' => 'old-nonce',
+        ],
+    ]);
+
+    Http::fake([
+        'https://auth.example/oauth/token' => Http::response([
+            'access_token' => 'new-access',
+            'refresh_token' => 'new-refresh',
+            'expires_in' => 3600,
+        ], 200, ['DPoP-Nonce' => 'new-nonce']),
+    ]);
+
+    $credentials = app(TokenManager::class)->fresh($account);
+
+    expect($credentials['session']['accessJwt'])->toBe('new-access')
+        ->and($credentials['session']['dpop_nonce'])->toBe('new-nonce')
+        ->and($account->fresh()->status)->toBe(ConnectedAccountStatus::Active)
+        ->and($account->secret->refresh()->refresh_token)->toBe('new-refresh');
+
+    Http::assertSent(fn (Request $request): bool => $request->hasHeader('DPoP')
+        && $request['grant_type'] === 'refresh_token'
+        && $request['client_id'] === 'https://app.example/oauth/bluesky/client-metadata.json');
+});


### PR DESCRIPTION
## Summary

- Adds Bluesky OAuth connection and reconnect flows, including public client metadata, callback handling, and optional custom service URL support.
- Adds DPoP proof generation and uses DPoP-bound authorization for Bluesky publishing, uploads, deletes, and resumed threads.
- Extends token refresh handling so Bluesky OAuth accounts refresh proactively alongside other expiring OAuth accounts.
- Adds feature and unit coverage for Bluesky OAuth setup, DPoP proofs, token refresh, and publish authorization.