### PR TITLE
Fix animated GIF publishing on X and Bluesky

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         curl \
         jq \
+        ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 # Install the Bun binary for the target architecture (amd64 -> x64, arm64 -> aarch64).
 # TARGETARCH is provided automatically by buildx.

--- a/app/Enums/ErrorKind.php
+++ b/app/Enums/ErrorKind.php
@@ -13,13 +13,15 @@ enum ErrorKind: string
     case Network = 'network';
     case ServerError = 'server_error';
     case MediaProcessing = 'media_processing';
+    /** A required server-side capability is missing (e.g. a media tool isn't installed); retrying can't fix it. */
+    case Unsupported = 'unsupported';
     case Unknown = 'unknown';
 
     public function isRetryable(): bool
     {
         return match ($this) {
             self::RateLimited, self::Network, self::ServerError, self::MediaProcessing => true,
-            self::AuthExpired, self::Validation, self::DuplicateContent, self::Unknown => false,
+            self::AuthExpired, self::Validation, self::DuplicateContent, self::Unsupported, self::Unknown => false,
         };
     }
 }

--- a/app/Enums/Platform.php
+++ b/app/Enums/Platform.php
@@ -138,7 +138,7 @@ enum Platform: string
     public function maxMediaBytes(): int
     {
         return match ($this) {
-            self::Bluesky => 1_048_576,
+            self::Bluesky => 2_000_000,
             self::X => 5_242_880,
             self::LinkedIn => 8_388_608,
         };
@@ -181,7 +181,7 @@ enum Platform: string
         return match ($this) {
             self::X => 536_870_912,        // 512 MB
             self::LinkedIn => 524_288_000, // 500 MB (organic feed)
-            self::Bluesky => 104_857_600,  // 100 MB
+            self::Bluesky => 100_000_000,
         };
     }
 

--- a/app/Services/Media/ConvertedVideo.php
+++ b/app/Services/Media/ConvertedVideo.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Media;
+
+final readonly class ConvertedVideo
+{
+    public function __construct(
+        public string $disk,
+        public string $path,
+        public int $sizeBytes,
+    ) {}
+}

--- a/app/Services/Media/GifToMp4ConversionFailed.php
+++ b/app/Services/Media/GifToMp4ConversionFailed.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Media;
+
+use RuntimeException;
+
+class GifToMp4ConversionFailed extends RuntimeException {}

--- a/app/Services/Media/GifToMp4Converter.php
+++ b/app/Services/Media/GifToMp4Converter.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Media;
+
+use App\Models\PostMedia;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+
+class GifToMp4Converter
+{
+    private const int TIMEOUT_SECONDS = 300;
+
+    private const array CRF_STEPS = [23, 28, 33, 38];
+
+    public function convert(PostMedia $media, int $maxBytes): ConvertedVideo
+    {
+        if ($media->mime !== 'image/gif') {
+            throw new GifToMp4ConversionFailed('Only GIF media can be converted to MP4.');
+        }
+
+        $disk = Storage::disk($media->disk);
+        $derivedPath = $this->derivedPath($media);
+
+        if ($disk->exists($derivedPath)) {
+            $size = (int) $disk->size($derivedPath);
+
+            if ($size <= $maxBytes) {
+                return new ConvertedVideo($media->disk, $derivedPath, $size);
+            }
+
+            $disk->delete($derivedPath);
+        }
+
+        $tempDir = storage_path('app/tmp/gif-to-mp4/'.Str::uuid());
+        File::ensureDirectoryExists($tempDir);
+
+        $input = $tempDir.'/input.gif';
+        $output = $tempDir.'/output.mp4';
+
+        try {
+            $stream = $disk->readStream($media->path);
+
+            if ($stream === null) {
+                throw new GifToMp4ConversionFailed('Could not read GIF media.');
+            }
+
+            file_put_contents($input, stream_get_contents($stream));
+            fclose($stream);
+
+            $this->encode($input, $output, $maxBytes);
+
+            $outputStream = fopen($output, 'rb');
+
+            if ($outputStream === false) {
+                throw new GifToMp4ConversionFailed('Could not read converted GIF video.');
+            }
+
+            $disk->put($derivedPath, $outputStream);
+            fclose($outputStream);
+
+            $size = (int) $disk->size($derivedPath);
+
+            if ($size > $maxBytes) {
+                $disk->delete($derivedPath);
+
+                throw new GifToMp4OutputTooLarge('Converted GIF exceeds the Bluesky video size limit.');
+            }
+
+            return new ConvertedVideo($media->disk, $derivedPath, $size);
+        } finally {
+            File::deleteDirectory($tempDir);
+        }
+    }
+
+    private function derivedPath(PostMedia $media): string
+    {
+        return 'media/'.$media->workspace_id.'/derived/'.$media->id.'.mp4';
+    }
+
+    private function encode(string $input, string $output, int $maxBytes): void
+    {
+        foreach (self::CRF_STEPS as $crf) {
+            @unlink($output);
+
+            $process = new Process([
+                'ffmpeg',
+                '-hide_banner',
+                '-loglevel',
+                'error',
+                '-y',
+                '-i',
+                $input,
+                '-an',
+                '-movflags',
+                '+faststart',
+                '-pix_fmt',
+                'yuv420p',
+                '-vf',
+                'scale=trunc((iw+1)/2)*2:trunc((ih+1)/2)*2',
+                '-c:v',
+                'libx264',
+                '-preset',
+                'veryfast',
+                '-crf',
+                (string) $crf,
+                $output,
+            ]);
+            $process->setTimeout(self::TIMEOUT_SECONDS);
+
+            try {
+                $process->mustRun();
+            } catch (ProcessFailedException|ProcessTimedOutException $e) {
+                throw new GifToMp4ConversionFailed('Could not convert GIF to MP4.', previous: $e);
+            }
+
+            if (! is_file($output) || filesize($output) === 0) {
+                throw new GifToMp4ConversionFailed('Converted GIF video was empty.');
+            }
+
+            if ((int) filesize($output) <= $maxBytes) {
+                return;
+            }
+        }
+
+        throw new GifToMp4OutputTooLarge('Converted GIF exceeds the Bluesky video size limit.');
+    }
+}

--- a/app/Services/Media/GifToMp4Converter.php
+++ b/app/Services/Media/GifToMp4Converter.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 class GifToMp4Converter
@@ -37,6 +38,17 @@ class GifToMp4Converter
             $disk->delete($derivedPath);
         }
 
+        // Resolve ffmpeg up front so a missing binary fails fast with an actionable,
+        // non-retryable error rather than surfacing as an opaque process failure that
+        // the publish loop would treat as transient and retry.
+        $ffmpeg = (new ExecutableFinder)->find('ffmpeg');
+
+        if ($ffmpeg === null) {
+            throw new GifToMp4ConverterUnavailable(
+                'Cannot publish this GIF: video conversion is unavailable because ffmpeg is not installed on the server.',
+            );
+        }
+
         $tempDir = storage_path('app/tmp/gif-to-mp4/'.Str::uuid());
         File::ensureDirectoryExists($tempDir);
 
@@ -44,16 +56,31 @@ class GifToMp4Converter
         $output = $tempDir.'/output.mp4';
 
         try {
-            $stream = $disk->readStream($media->path);
+            $source = $disk->readStream($media->path);
 
-            if ($stream === null) {
+            if ($source === null) {
                 throw new GifToMp4ConversionFailed('Could not read GIF media.');
             }
 
-            file_put_contents($input, stream_get_contents($stream));
-            fclose($stream);
+            // Stream the source onto local disk rather than buffering the whole GIF in
+            // memory, matching how the upload path streams bytes.
+            $local = fopen($input, 'wb');
 
-            $this->encode($input, $output, $maxBytes);
+            if ($local === false) {
+                fclose($source);
+
+                throw new GifToMp4ConversionFailed('Could not open a temporary file for GIF conversion.');
+            }
+
+            $copied = stream_copy_to_stream($source, $local);
+            fclose($source);
+            fclose($local);
+
+            if ($copied === false) {
+                throw new GifToMp4ConversionFailed('Could not read GIF media.');
+            }
+
+            $this->encode($ffmpeg, $input, $output, $maxBytes);
 
             $outputStream = fopen($output, 'rb');
 
@@ -83,13 +110,13 @@ class GifToMp4Converter
         return 'media/'.$media->workspace_id.'/derived/'.$media->id.'.mp4';
     }
 
-    private function encode(string $input, string $output, int $maxBytes): void
+    private function encode(string $ffmpeg, string $input, string $output, int $maxBytes): void
     {
         foreach (self::CRF_STEPS as $crf) {
             @unlink($output);
 
             $process = new Process([
-                'ffmpeg',
+                $ffmpeg,
                 '-hide_banner',
                 '-loglevel',
                 'error',

--- a/app/Services/Media/GifToMp4ConverterUnavailable.php
+++ b/app/Services/Media/GifToMp4ConverterUnavailable.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Media;
+
+/**
+ * The ffmpeg binary needed to convert GIFs to MP4 is not installed on the server.
+ * A configuration problem, not a transient one — retrying can't fix it.
+ */
+final class GifToMp4ConverterUnavailable extends GifToMp4ConversionFailed {}

--- a/app/Services/Media/GifToMp4OutputTooLarge.php
+++ b/app/Services/Media/GifToMp4OutputTooLarge.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Media;
+
+class GifToMp4OutputTooLarge extends GifToMp4ConversionFailed {}

--- a/app/Services/Media/GifToMp4OutputTooLarge.php
+++ b/app/Services/Media/GifToMp4OutputTooLarge.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 namespace App\Services\Media;
 
-class GifToMp4OutputTooLarge extends GifToMp4ConversionFailed {}
+final class GifToMp4OutputTooLarge extends GifToMp4ConversionFailed {}

--- a/app/Services/Publishing/Connectors/BlueskyPublishConnector.php
+++ b/app/Services/Publishing/Connectors/BlueskyPublishConnector.php
@@ -12,9 +12,14 @@ use App\Enums\Platform;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
 use App\Services\Atproto\DPoP;
+use App\Services\Media\ConvertedVideo;
+use App\Services\Media\GifToMp4ConversionFailed;
+use App\Services\Media\GifToMp4Converter;
+use App\Services\Media\GifToMp4OutputTooLarge;
 use App\Services\Media\ImageCompressor;
 use App\Services\Publishing\Connectors\Concerns\MapsHttpErrors;
 use App\Services\Publishing\Contracts\PublishConnector;
+use Closure;
 use GuzzleHttp\Psr7\Utils;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Factory as HttpFactory;
@@ -35,6 +40,7 @@ class BlueskyPublishConnector implements PublishConnector
         private readonly HttpFactory $http,
         private readonly ImageCompressor $imageCompressor,
         private readonly DPoP $dpop,
+        private readonly GifToMp4Converter $gifToMp4Converter,
     ) {}
 
     public function publish(PublishContext $context): PublishResult
@@ -53,6 +59,10 @@ class BlueskyPublishConnector implements PublishConnector
         try {
             // Video takes precedence over images on the root post only.
             $videoMedia = array_values(array_filter($context->media, fn (PostMedia $m): bool => $m->isVideo()));
+            $gifMedia = array_values(array_filter(
+                $context->media,
+                fn (PostMedia $m): bool => ! $m->isVideo() && $m->mime === 'image/gif',
+            ));
 
             if ($rootUri === null && $videoMedia !== []) {
                 $ready = $this->ensureVideoReady($context, $videoMedia[0], $pds, $jwt, $did, $session);
@@ -60,6 +70,12 @@ class BlueskyPublishConnector implements PublishConnector
                     return $ready;
                 }
                 $embed = $this->videoEmbed($context, $videoMedia[0]);
+            } elseif ($rootUri === null && $gifMedia !== []) {
+                $ready = $this->ensureGifVideoReady($context, $gifMedia, $pds, $jwt, $did, $session);
+                if (! $ready->isSuccessful()) {
+                    return $ready;
+                }
+                $embed = $this->videoEmbed($context, $gifMedia[0], 'gif');
             } else {
                 // Media rides on the root post only; uploaded once, then embedded below.
                 $embed = $rootUri === null ? $this->uploadImages($context->media, $pds, $jwt, $session) : null;
@@ -127,6 +143,8 @@ class BlueskyPublishConnector implements PublishConnector
             }
         } catch (BlueskyRequestFailed $e) {
             return $this->mapFailure($e->response);
+        } catch (BlueskyValidationFailed $e) {
+            return PublishResult::failure(ErrorKind::Validation, $e->getMessage());
         } catch (ConnectionException $e) {
             return PublishResult::failure(ErrorKind::Network, $e->getMessage());
         }
@@ -186,12 +204,57 @@ class BlueskyPublishConnector implements PublishConnector
      */
     private function ensureVideoReady(PublishContext $context, PostMedia $media, string $pds, string $jwt, string $did, array $session): PublishResult
     {
+        return $this->ensureVideoUploadReady(
+            $context,
+            $media,
+            fn (): string => $this->uploadVideo($media, $pds, $jwt, $did, $session),
+        );
+    }
+
+    /**
+     * @param  list<PostMedia>  $media
+     * @param  array<string, mixed>  $session
+     */
+    private function ensureGifVideoReady(PublishContext $context, array $media, string $pds, string $jwt, string $did, array $session): PublishResult
+    {
+        if (count($context->media) > 1 || count($media) > 1) {
+            return PublishResult::failure(
+                ErrorKind::Validation,
+                'Bluesky supports one animated GIF per post, and it cannot be mixed with other media.',
+            );
+        }
+
+        $item = $media[0];
+
+        try {
+            return $this->ensureVideoUploadReady(
+                $context,
+                $item,
+                function () use ($item, $pds, $jwt, $did, $session): string {
+                    $converted = $this->gifToMp4Converter->convert($item, Platform::Bluesky->maxVideoBytes());
+
+                    return $this->uploadConvertedVideo($converted, $pds, $jwt, $did, $session);
+                },
+                'GIF',
+            );
+        } catch (GifToMp4OutputTooLarge $e) {
+            return PublishResult::failure(ErrorKind::Validation, $e->getMessage());
+        } catch (GifToMp4ConversionFailed $e) {
+            return PublishResult::failure(ErrorKind::ServerError, $e->getMessage());
+        }
+    }
+
+    /**
+     * @param  Closure(): string  $upload
+     */
+    private function ensureVideoUploadReady(PublishContext $context, PostMedia $media, Closure $upload, string $label = 'video'): PublishResult
+    {
         $state = new MediaUploadState($context->target->media_upload_state);
         $jobId = $state->remoteRef($media->id);
 
         try {
             if ($jobId === null) {
-                $jobId = $this->uploadVideo($media, $pds, $jwt, $did, $session);
+                $jobId = $upload();
                 $state->markUploaded($media->id, $jobId);
                 $context->target->forceFill(['media_upload_state' => $state->toArray()])->save();
             }
@@ -207,7 +270,7 @@ class BlueskyPublishConnector implements PublishConnector
                     // 5-attempt publish-failure budget.
                     return PublishResult::failure(
                         ErrorKind::MediaProcessing,
-                        'Could not check video processing status; will retry.',
+                        "Could not check {$label} processing status; will retry.",
                         retryAfter: $this->retryAfter($status) ?? 6,
                     );
                 }
@@ -219,11 +282,11 @@ class BlueskyPublishConnector implements PublishConnector
             $jobState = (string) $status->json('jobStatus.state', '');
 
             if ($jobState === 'JOB_STATE_FAILED') {
-                return PublishResult::failure(ErrorKind::ServerError, (string) $status->json('jobStatus.error', 'Bluesky failed to process the video.'));
+                return PublishResult::failure(ErrorKind::ServerError, (string) $status->json('jobStatus.error', "Bluesky failed to process the {$label}."));
             }
 
             if ($jobState !== 'JOB_STATE_COMPLETED') {
-                return PublishResult::failure(ErrorKind::MediaProcessing, 'Video is still processing on Bluesky.', retryAfter: 6);
+                return PublishResult::failure(ErrorKind::MediaProcessing, ucfirst($label).' is still processing on Bluesky.', retryAfter: 6);
             }
 
             // Stash the completed blob in media_upload_state so videoEmbed() can read it.
@@ -244,6 +307,22 @@ class BlueskyPublishConnector implements PublishConnector
      */
     private function uploadVideo(PostMedia $media, string $pds, string $jwt, string $did, array $session): string
     {
+        return $this->uploadVideoFile($media->disk, $media->path, $pds, $jwt, $did, $session);
+    }
+
+    /**
+     * @param  array<string, mixed>  $session
+     */
+    private function uploadConvertedVideo(ConvertedVideo $video, string $pds, string $jwt, string $did, array $session): string
+    {
+        return $this->uploadVideoFile($video->disk, $video->path, $pds, $jwt, $did, $session, 'animation.mp4');
+    }
+
+    /**
+     * @param  array<string, mixed>  $session
+     */
+    private function uploadVideoFile(string $diskName, string $path, string $pds, string $jwt, string $did, array $session, string $name = 'video.mp4'): string
+    {
         $pdsHost = (string) parse_url($pds, PHP_URL_HOST);
 
         $auth = $this->getAuthorized($pds.'/xrpc/com.atproto.server.getServiceAuth', $jwt, $session, [
@@ -260,10 +339,10 @@ class BlueskyPublishConnector implements PublishConnector
 
         // Stream the file as the request body (wrap the disk resource as a PSR-7 stream)
         // so the whole video is never resident in memory.
-        $body = Utils::streamFor(Storage::disk($media->disk)->readStream($media->path));
+        $body = Utils::streamFor(Storage::disk($diskName)->readStream($path));
 
         $upload = $this->http->withToken($serviceToken)->withBody($body, 'video/mp4')
-            ->post(self::VIDEO_SERVICE.'/xrpc/app.bsky.video.uploadVideo?did='.rawurlencode($did).'&name=video.mp4');
+            ->post(self::VIDEO_SERVICE.'/xrpc/app.bsky.video.uploadVideo?did='.rawurlencode($did).'&name='.rawurlencode($name));
 
         // Re-uploading identical bytes returns 409 already_exists but still carries the jobId.
         if ($upload->failed() && $upload->json('error') !== 'already_exists') {
@@ -276,13 +355,17 @@ class BlueskyPublishConnector implements PublishConnector
     /**
      * Build an `app.bsky.embed.video` embed using the blob stashed in media_upload_state.
      *
-     * @return array{'$type': string, video: array<string, mixed>, alt?: string}
+     * @return array{'$type': string, video: array<string, mixed>, alt?: string, presentation?: string}
      */
-    private function videoEmbed(PublishContext $context, PostMedia $media): array
+    private function videoEmbed(PublishContext $context, PostMedia $media, ?string $presentation = null): array
     {
         $blob = (new MediaUploadState($context->target->media_upload_state))->blob($media->id);
 
         $embed = ['$type' => 'app.bsky.embed.video', 'video' => $blob];
+
+        if ($presentation !== null) {
+            $embed['presentation'] = $presentation;
+        }
 
         if (($media->alt_text ?? '') !== '') {
             $embed['alt'] = (string) $media->alt_text;
@@ -311,6 +394,10 @@ class BlueskyPublishConnector implements PublishConnector
         foreach ($media as $item) {
             $bytes = (string) Storage::disk($item->disk)->get($item->path);
             $compressed = $this->imageCompressor->compressToFit($bytes, Platform::Bluesky->maxMediaBytes(), $item->mime, Platform::Bluesky->allowedMime());
+
+            if (strlen($compressed->bytes) > Platform::Bluesky->maxMediaBytes()) {
+                throw new BlueskyValidationFailed('Bluesky images must be 2 MB or smaller.');
+            }
 
             $response = $this->postBodyAuthorized($pds.'/xrpc/com.atproto.repo.uploadBlob', $jwt, $session, $compressed->bytes, $compressed->mime);
 
@@ -505,3 +592,10 @@ final class BlueskyRequestFailed extends \RuntimeException
         parent::__construct('Bluesky request failed.');
     }
 }
+
+/**
+ * Internal signal for deterministic media validation before a request reaches Bluesky.
+ *
+ * @internal
+ */
+final class BlueskyValidationFailed extends \RuntimeException {}

--- a/app/Services/Publishing/Connectors/BlueskyPublishConnector.php
+++ b/app/Services/Publishing/Connectors/BlueskyPublishConnector.php
@@ -15,6 +15,7 @@ use App\Services\Atproto\DPoP;
 use App\Services\Media\ConvertedVideo;
 use App\Services\Media\GifToMp4ConversionFailed;
 use App\Services\Media\GifToMp4Converter;
+use App\Services\Media\GifToMp4ConverterUnavailable;
 use App\Services\Media\GifToMp4OutputTooLarge;
 use App\Services\Media\ImageCompressor;
 use App\Services\Publishing\Connectors\Concerns\MapsHttpErrors;
@@ -238,6 +239,9 @@ class BlueskyPublishConnector implements PublishConnector
                 },
                 'GIF',
             );
+        } catch (GifToMp4ConverterUnavailable $e) {
+            // ffmpeg is missing on the server — a config problem, not a transient one.
+            return PublishResult::failure(ErrorKind::Unsupported, $e->getMessage());
         } catch (GifToMp4OutputTooLarge $e) {
             return PublishResult::failure(ErrorKind::Validation, $e->getMessage());
         } catch (GifToMp4ConversionFailed $e) {

--- a/app/Services/Publishing/Connectors/XConnector.php
+++ b/app/Services/Publishing/Connectors/XConnector.php
@@ -34,6 +34,8 @@ class XConnector implements PublishConnector
 
     private const int APPEND_CHUNK = 4 * 1024 * 1024;
 
+    private const int GIF_MAX_BYTES = 15 * 1024 * 1024;
+
     public function __construct(
         private readonly HttpFactory $http,
         private readonly ImageCompressor $imageCompressor,
@@ -46,9 +48,19 @@ class XConnector implements PublishConnector
 
         try {
             $videoMedia = array_values(array_filter($context->media, fn (PostMedia $m): bool => $m->isVideo()));
+            $gifMedia = array_values(array_filter(
+                $context->media,
+                fn (PostMedia $m): bool => ! $m->isVideo() && $m->mime === 'image/gif',
+            ));
 
             if ($videoMedia !== []) {
                 $ready = $this->ensureVideoReady($context, $videoMedia[0], $token);
+                if (! $ready->isSuccessful()) {
+                    return $ready;
+                }
+                $mediaIds = [(string) $ready->remoteIds[0]];
+            } elseif ($gifMedia !== []) {
+                $ready = $this->ensureGifReady($context, $gifMedia, $token);
                 if (! $ready->isSuccessful()) {
                     return $ready;
                 }
@@ -122,12 +134,51 @@ class XConnector implements PublishConnector
      */
     private function ensureVideoReady(PublishContext $context, PostMedia $media, string $token): PublishResult
     {
+        return $this->ensureChunkedMediaReady($context, $media, $token, 'video/mp4', 'tweet_video', 'video');
+    }
+
+    /**
+     * @param  list<PostMedia>  $media
+     */
+    private function ensureGifReady(PublishContext $context, array $media, string $token): PublishResult
+    {
+        if (count($context->media) > 1 || count($media) > 1) {
+            return PublishResult::failure(
+                ErrorKind::Validation,
+                'X supports one GIF per post, and a GIF cannot be mixed with other media.',
+            );
+        }
+
+        $item = $media[0];
+        $size = (int) Storage::disk($item->disk)->size($item->path);
+
+        if ($size > self::GIF_MAX_BYTES) {
+            return PublishResult::failure(
+                ErrorKind::Validation,
+                'X GIF uploads must be 15 MB or smaller.',
+            );
+        }
+
+        return $this->ensureChunkedMediaReady($context, $item, $token, 'image/gif', 'tweet_gif', 'GIF');
+    }
+
+    /**
+     * Upload (once) and poll the async media processing state.
+     */
+    private function ensureChunkedMediaReady(
+        PublishContext $context,
+        PostMedia $media,
+        string $token,
+        string $mediaType,
+        string $mediaCategory,
+        string $label,
+    ): PublishResult {
         $state = new MediaUploadState($context->target->media_upload_state);
         $mediaId = $state->remoteRef($media->id);
 
         try {
             if ($mediaId === null) {
-                $mediaId = $this->uploadVideoChunks($media, $token);
+                $mediaId = $this->uploadChunks($media, $token, $mediaType, $mediaCategory);
                 $state->markUploaded($media->id, $mediaId);
                 $context->target->forceFill(['media_upload_state' => $state->toArray()])->save();
             }
@@ -143,7 +194,7 @@ class XConnector implements PublishConnector
                     // 5-attempt publish-failure budget.
                     return PublishResult::failure(
                         ErrorKind::MediaProcessing,
-                        'Could not check video processing status; will retry.',
+                        "Could not check {$label} processing status; will retry.",
                         retryAfter: $this->retryAfter($status) ?? 6,
                     );
                 }
@@ -156,13 +207,13 @@ class XConnector implements PublishConnector
             $stateName = (string) ($info['state'] ?? 'succeeded');
 
             if ($stateName === 'failed') {
-                return PublishResult::failure(ErrorKind::ServerError, 'X failed to process the video.');
+                return PublishResult::failure(ErrorKind::ServerError, "X failed to process the {$label}.");
             }
 
             if ($stateName !== 'succeeded') {
                 return PublishResult::failure(
                     ErrorKind::MediaProcessing,
-                    'Video is still processing on X.',
+                    ucfirst($label).' is still processing on X.',
                     retryAfter: (int) ($info['check_after_secs'] ?? 5),
                 );
             }
@@ -173,16 +224,16 @@ class XConnector implements PublishConnector
         }
     }
 
-    private function uploadVideoChunks(PostMedia $media, string $token): string
+    private function uploadChunks(PostMedia $media, string $token, string $mediaType, string $mediaCategory): string
     {
         $disk = Storage::disk($media->disk);
         $total = (int) $disk->size($media->path);
 
         $init = $this->http->withToken($token)->acceptJson()
             ->post(self::MEDIA_BASE.'/initialize', [
-                'media_type' => 'video/mp4',
+                'media_type' => $mediaType,
                 'total_bytes' => $total,
-                'media_category' => 'tweet_video',
+                'media_category' => $mediaCategory,
             ]);
         if ($init->failed()) {
             throw new XRequestFailed($init);

--- a/resources/js/components/compose/__tests__/media-chips.test.ts
+++ b/resources/js/components/compose/__tests__/media-chips.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const source = () =>
+    readFileSync(
+        resolve(
+            process.cwd(),
+            'resources/js/components/compose/media-chips.tsx',
+        ),
+        'utf8',
+    );
+
+describe('media chips', () => {
+    it('marks bluesky gif attachments as video-published gifs', () => {
+        const chips = source();
+
+        expect(chips).toContain("activePlatform === 'bluesky'");
+        expect(chips).toContain("m.mime === 'image/gif'");
+        expect(chips).toContain('Bluesky will publish this GIF as video');
+        expect(chips).toContain('<Film');
+    });
+});

--- a/resources/js/components/compose/__tests__/media-chips.test.ts
+++ b/resources/js/components/compose/__tests__/media-chips.test.ts
@@ -21,4 +21,11 @@ describe('media chips', () => {
         expect(chips).toContain('Bluesky will publish this GIF as video');
         expect(chips).toContain('<Film');
     });
+
+    it('never marks a gif as editable (the beautifier would flatten it)', () => {
+        const chips = source();
+
+        // Image chips are editable only when the item is not a GIF.
+        expect(chips).toContain('Boolean(onImageClick) && !isGif');
+    });
 });

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -340,9 +340,22 @@ export default function Composer({
         if (images.length === 0) {
             return;
         }
+
+        // GIFs skip the beautifier: it composes to a static PNG, which would strip
+        // the animation. Upload them as-is; the rest open the editor as a batch.
+        const gifs = images.filter((f) => f.type === 'image/gif');
+        const editable = images.filter((f) => f.type !== 'image/gif');
+
+        if (gifs.length > 0) {
+            void mediaUploads.handleFiles(gifs);
+        }
+
+        if (editable.length === 0) {
+            return;
+        }
         setEditing({
             kind: 'batch',
-            items: images.map((f) => ({
+            items: editable.map((f) => ({
                 file: f,
                 url: URL.createObjectURL(f),
             })),
@@ -377,7 +390,8 @@ export default function Composer({
     // source + settings; a plain one is beautified from scratch.
     function openImage(mediaId: string) {
         const m = state.media.find((x) => x.id === mediaId);
-        if (!m || m.kind === 'video') {
+        // GIFs have no editor — the beautifier would flatten them to a static PNG.
+        if (!m || m.kind === 'video' || m.mime === 'image/gif') {
             return;
         }
         if (m.edit_settings && m.source_url) {

--- a/resources/js/components/compose/media-chips.tsx
+++ b/resources/js/components/compose/media-chips.tsx
@@ -161,15 +161,15 @@ export function MediaChips({
         <div className="ml-0.5 flex items-center gap-2">
             {media.map((m, idx) => {
                 const excluded = isExcluded(m.id);
-                // Both kinds open an editor on click. Videos are always
-                // editable (trim works without an encoder); the editor hides the
-                // crop tools when the browser can't re-encode.
+                const isGif = m.mime === 'image/gif';
+                // Videos open the trim editor; static images open the beautifier.
+                // GIFs open neither — the beautifier would flatten them to a static
+                // PNG — so they're attach-only.
                 const canEdit =
                     m.kind === 'video'
                         ? Boolean(onVideoClick)
-                        : Boolean(onImageClick);
-                const blueskyGif =
-                    activePlatform === 'bluesky' && m.mime === 'image/gif';
+                        : Boolean(onImageClick) && !isGif;
+                const blueskyGif = activePlatform === 'bluesky' && isGif;
 
                 return (
                     <Tooltip key={m.id}>

--- a/resources/js/components/compose/media-chips.tsx
+++ b/resources/js/components/compose/media-chips.tsx
@@ -1,4 +1,4 @@
-import { Eye, EyeOff, X } from 'lucide-react';
+import { Eye, EyeOff, Film, X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useRef, useState } from 'react';
 
@@ -168,6 +168,8 @@ export function MediaChips({
                     m.kind === 'video'
                         ? Boolean(onVideoClick)
                         : Boolean(onImageClick);
+                const blueskyGif =
+                    activePlatform === 'bluesky' && m.mime === 'image/gif';
 
                 return (
                     <Tooltip key={m.id}>
@@ -277,10 +279,22 @@ export function MediaChips({
                                         )}
                                     </button>
                                 )}
+                                {blueskyGif && (
+                                    <span className="absolute -right-1 -bottom-1 z-10 grid size-4 place-items-center rounded-full border border-background bg-amber-500 text-white shadow-sm">
+                                        <Film
+                                            className="size-2.5"
+                                            aria-hidden="true"
+                                        />
+                                    </span>
+                                )}
                             </div>
                         </TooltipTrigger>
                         <TooltipContent side="bottom" className="text-[11px]">
-                            {canEdit ? 'Click to edit' : 'Attached media'}
+                            {blueskyGif
+                                ? 'Bluesky will publish this GIF as video'
+                                : canEdit
+                                  ? 'Click to edit'
+                                  : 'Attached media'}
                         </TooltipContent>
                     </Tooltip>
                 );

--- a/tests/Feature/Publishing/BlueskyPublishConnectorTest.php
+++ b/tests/Feature/Publishing/BlueskyPublishConnectorTest.php
@@ -293,3 +293,25 @@ test('bluesky compresses oversized images via the compressor before upload', fun
         && $request->body() === 'small-bytes'
         && $request->hasHeader('Content-Type', 'image/webp'));
 });
+
+test('bluesky rejects images over the embed image byte limit before upload', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/big.png', str_repeat('p', Platform::Bluesky->maxMediaBytes() + 1));
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/big.png',
+        'mime' => 'image/png',
+        'alt_text' => 'big image',
+    ]);
+
+    Http::fake();
+
+    $result = app(BlueskyPublishConnector::class)->publish(bskyContext(['look'], [$media]));
+
+    expect($result->isSuccessful())->toBeFalse()
+        ->and($result->errorKind)->toBe(ErrorKind::Validation)
+        ->and($result->errorMessage)->toContain('Bluesky images must be 2 MB or smaller');
+
+    Http::assertNothingSent();
+});

--- a/tests/Feature/Publishing/BlueskyVideoConnectorTest.php
+++ b/tests/Feature/Publishing/BlueskyVideoConnectorTest.php
@@ -10,6 +10,7 @@ use App\Models\PostMedia;
 use App\Models\PostTarget;
 use App\Services\Media\ConvertedVideo;
 use App\Services\Media\GifToMp4Converter;
+use App\Services\Media\GifToMp4ConverterUnavailable;
 use App\Services\Media\GifToMp4OutputTooLarge;
 use App\Services\Publishing\Connectors\BlueskyPublishConnector;
 use Illuminate\Support\Facades\Http;
@@ -148,6 +149,30 @@ test('oversized converted gifs fail before calling bluesky', function (): void {
     expect($result->isSuccessful())->toBeFalse()
         ->and($result->errorKind)->toBe(ErrorKind::Validation)
         ->and($result->errorMessage)->toContain('Bluesky video size limit');
+
+    Http::assertNothingSent();
+});
+
+test('a missing ffmpeg fails terminally rather than retrying forever', function (): void {
+    $account = ConnectedAccount::factory()->state(['platform' => 'bluesky', 'remote_account_id' => 'did:plc:abc'])->create();
+    $media = PostMedia::factory()->create(['disk' => 'public', 'path' => 'media/ws/a.gif', 'mime' => 'image/gif']);
+    $target = PostTarget::factory()->for($account, 'account')->create();
+
+    $converter = Mockery::mock(GifToMp4Converter::class);
+    $converter->shouldReceive('convert')
+        ->once()
+        ->andThrow(new GifToMp4ConverterUnavailable('Cannot publish this GIF: video conversion is unavailable because ffmpeg is not installed on the server.'));
+    app()->instance(GifToMp4Converter::class, $converter);
+
+    Http::fake();
+
+    $ctx = new PublishContext($target, ['gif'], [$media], $account, blueskyVideoCredentials());
+    $result = app(BlueskyPublishConnector::class)->publish($ctx);
+
+    expect($result->isSuccessful())->toBeFalse()
+        ->and($result->errorKind)->toBe(ErrorKind::Unsupported)
+        ->and($result->errorKind->isRetryable())->toBeFalse()
+        ->and($result->errorMessage)->toContain('ffmpeg is not installed');
 
     Http::assertNothingSent();
 });

--- a/tests/Feature/Publishing/BlueskyVideoConnectorTest.php
+++ b/tests/Feature/Publishing/BlueskyVideoConnectorTest.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 use App\Dto\Publishing\PublishContext;
 use App\Enums\ErrorKind;
+use App\Enums\Platform;
 use App\Models\ConnectedAccount;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
+use App\Services\Media\ConvertedVideo;
+use App\Services\Media\GifToMp4Converter;
+use App\Services\Media\GifToMp4OutputTooLarge;
 use App\Services\Publishing\Connectors\BlueskyPublishConnector;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
@@ -58,6 +62,94 @@ test('completed job embeds the blob and posts on resume', function (): void {
     expect($result->isSuccessful())->toBeTrue();
     Http::assertSent(fn ($req) => str_contains($req->url(), 'createRecord')
         && data_get($req->data(), 'record.embed.$type') === 'app.bsky.embed.video');
+});
+
+test('gif media is converted to mp4 and embedded as gif video', function (): void {
+    $account = ConnectedAccount::factory()->state(['platform' => 'bluesky', 'remote_account_id' => 'did:plc:abc'])->create();
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/ws/animation.gif',
+        'mime' => 'image/gif',
+        'alt_text' => 'animated chart',
+    ]);
+    Storage::disk('public')->put('media/ws/animation.gif', 'gif-bytes');
+    Storage::disk('public')->put('media/ws/animation.mp4', 'mp4-bytes');
+    $target = PostTarget::factory()->for($account, 'account')->create();
+
+    $converter = Mockery::mock(GifToMp4Converter::class);
+    $converter->shouldReceive('convert')
+        ->once()
+        ->withArgs(fn (PostMedia $item, int $maxBytes): bool => $item->is($media) && $maxBytes === Platform::Bluesky->maxVideoBytes())
+        ->andReturn(new ConvertedVideo('public', 'media/ws/animation.mp4', strlen('mp4-bytes')));
+    app()->instance(GifToMp4Converter::class, $converter);
+
+    Http::fake([
+        '*/xrpc/com.atproto.server.getServiceAuth*' => Http::response(['token' => 'svc'], 200),
+        'video.bsky.app/xrpc/app.bsky.video.uploadVideo*' => Http::response(['jobId' => 'gif-job'], 200),
+        'video.bsky.app/xrpc/app.bsky.video.getJobStatus*' => Http::response([
+            'jobStatus' => ['state' => 'JOB_STATE_COMPLETED', 'blob' => ['$type' => 'blob', 'ref' => ['$link' => 'gifcid']]],
+        ], 200),
+        '*/xrpc/com.atproto.repo.createRecord' => Http::response(['uri' => 'at://did:plc:abc/app.bsky.feed.post/1', 'cid' => 'cid1'], 200),
+    ]);
+
+    $ctx = new PublishContext($target, ['gif'], [$media], $account, blueskyVideoCredentials());
+    $result = app(BlueskyPublishConnector::class)->publish($ctx);
+
+    expect($result->isSuccessful())->toBeTrue()
+        ->and($target->fresh()->media_upload_state[$media->id]['remote_ref'])->toBe('gif-job');
+
+    Http::assertSent(fn ($req): bool => str_contains($req->url(), 'uploadVideo')
+        && str_contains($req->url(), 'name=animation.mp4'));
+
+    Http::assertSent(fn ($req): bool => str_contains($req->url(), 'createRecord')
+        && data_get($req->data(), 'record.embed.$type') === 'app.bsky.embed.video'
+        && data_get($req->data(), 'record.embed.presentation') === 'gif'
+        && data_get($req->data(), 'record.embed.alt') === 'animated chart');
+});
+
+test('gif media cannot be mixed with other media on bluesky', function (): void {
+    $account = ConnectedAccount::factory()->state(['platform' => 'bluesky', 'remote_account_id' => 'did:plc:abc'])->create();
+    $gif = PostMedia::factory()->create(['disk' => 'public', 'path' => 'media/ws/a.gif', 'mime' => 'image/gif']);
+    $image = PostMedia::factory()->create(['disk' => 'public', 'path' => 'media/ws/a.jpg', 'mime' => 'image/jpeg']);
+    $target = PostTarget::factory()->for($account, 'account')->create();
+
+    $converter = Mockery::mock(GifToMp4Converter::class);
+    $converter->shouldNotReceive('convert');
+    app()->instance(GifToMp4Converter::class, $converter);
+
+    Http::fake();
+
+    $ctx = new PublishContext($target, ['gif'], [$gif, $image], $account, blueskyVideoCredentials());
+    $result = app(BlueskyPublishConnector::class)->publish($ctx);
+
+    expect($result->isSuccessful())->toBeFalse()
+        ->and($result->errorKind)->toBe(ErrorKind::Validation)
+        ->and($result->errorMessage)->toContain('one animated GIF');
+
+    Http::assertNothingSent();
+});
+
+test('oversized converted gifs fail before calling bluesky', function (): void {
+    $account = ConnectedAccount::factory()->state(['platform' => 'bluesky', 'remote_account_id' => 'did:plc:abc'])->create();
+    $media = PostMedia::factory()->create(['disk' => 'public', 'path' => 'media/ws/a.gif', 'mime' => 'image/gif']);
+    $target = PostTarget::factory()->for($account, 'account')->create();
+
+    $converter = Mockery::mock(GifToMp4Converter::class);
+    $converter->shouldReceive('convert')
+        ->once()
+        ->andThrow(new GifToMp4OutputTooLarge('Converted GIF exceeds the Bluesky video size limit.'));
+    app()->instance(GifToMp4Converter::class, $converter);
+
+    Http::fake();
+
+    $ctx = new PublishContext($target, ['gif'], [$media], $account, blueskyVideoCredentials());
+    $result = app(BlueskyPublishConnector::class)->publish($ctx);
+
+    expect($result->isSuccessful())->toBeFalse()
+        ->and($result->errorKind)->toBe(ErrorKind::Validation)
+        ->and($result->errorMessage)->toContain('Bluesky video size limit');
+
+    Http::assertNothingSent();
 });
 
 test('transient 503 on job-status poll returns MediaProcessing (not ServerError)', function (): void {

--- a/tests/Feature/Publishing/XConnectorTest.php
+++ b/tests/Feature/Publishing/XConnectorTest.php
@@ -214,6 +214,66 @@ test('x uploads media to the v2 endpoint and attaches data.id to the first tweet
         && ($request['media']['media_ids'] ?? null) === ['99001']);
 });
 
+test('x uploads gifs through the async tweet_gif flow', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/animation.gif', 'gif-bytes');
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/animation.gif',
+        'mime' => 'image/gif',
+        'size_bytes' => strlen('gif-bytes'),
+    ]);
+
+    Http::fake([
+        'https://api.x.com/2/media/upload/initialize' => Http::response(['data' => ['id' => 'gif123']], 200),
+        'https://api.x.com/2/media/upload/gif123/append' => Http::response([], 200),
+        'https://api.x.com/2/media/upload/gif123/finalize' => Http::response(['data' => ['processing_info' => ['state' => 'succeeded']]], 200),
+        'https://api.x.com/2/media/upload*' => Http::response(['data' => ['processing_info' => ['state' => 'succeeded']]], 200),
+        'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => 'tweet1']], 201),
+    ]);
+
+    $result = app(XConnector::class)->publish(xContext(['gif'], [$media]));
+
+    expect($result->isSuccessful())->toBeTrue()
+        ->and($result->remoteIds)->toBe(['tweet1']);
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://api.x.com/2/media/upload/initialize'
+        && $request['media_category'] === 'tweet_gif'
+        && $request['media_type'] === 'image/gif'
+        && $request['total_bytes'] === strlen('gif-bytes'));
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://api.twitter.com/2/tweets'
+        && ($request['media']['media_ids'] ?? null) === ['gif123']);
+});
+
+test('x rejects mixing a gif with other media before calling the api', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/animation.gif', 'gif-bytes');
+    Storage::disk('public')->put('media/cat.jpg', 'image-bytes');
+
+    $gif = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/animation.gif',
+        'mime' => 'image/gif',
+    ]);
+    $image = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/cat.jpg',
+        'mime' => 'image/jpeg',
+    ]);
+
+    Http::fake();
+
+    $result = app(XConnector::class)->publish(xContext(['mixed'], [$gif, $image]));
+
+    expect($result->isSuccessful())->toBeFalse()
+        ->and($result->errorKind)->toBe(ErrorKind::Validation)
+        ->and($result->errorMessage)->toContain('one GIF');
+
+    Http::assertNothingSent();
+});
+
 test('x omits an empty text field for a media-only post', function () {
     Storage::fake('public');
     Storage::disk('public')->put('media/cat.jpg', 'image-bytes');

--- a/tests/Unit/ErrorKindTest.php
+++ b/tests/Unit/ErrorKindTest.php
@@ -12,6 +12,7 @@ test('terminal kinds report not retryable', function () {
     expect(ErrorKind::AuthExpired->isRetryable())->toBeFalse()
         ->and(ErrorKind::Validation->isRetryable())->toBeFalse()
         ->and(ErrorKind::DuplicateContent->isRetryable())->toBeFalse()
+        ->and(ErrorKind::Unsupported->isRetryable())->toBeFalse()
         ->and(ErrorKind::Unknown->isRetryable())->toBeFalse();
 });
 

--- a/tests/Unit/GifToMp4ConverterTest.php
+++ b/tests/Unit/GifToMp4ConverterTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Models\PostMedia;
+use App\Services\Media\GifToMp4ConversionFailed;
+use App\Services\Media\GifToMp4Converter;
+use Illuminate\Support\Facades\Storage;
+
+test('gif converter reuses an existing derived mp4', function (): void {
+    Storage::fake('public');
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/source.gif',
+        'mime' => 'image/gif',
+    ]);
+    $derived = 'media/'.$media->workspace_id.'/derived/'.$media->id.'.mp4';
+    Storage::disk('public')->put($derived, 'mp4-bytes');
+
+    $converted = app(GifToMp4Converter::class)->convert($media, 1000);
+
+    expect($converted->disk)->toBe('public')
+        ->and($converted->path)->toBe($derived)
+        ->and($converted->sizeBytes)->toBe(strlen('mp4-bytes'));
+});
+
+test('gif converter rejects non gif media', function (): void {
+    $media = PostMedia::factory()->create(['mime' => 'image/jpeg']);
+
+    expect(fn () => app(GifToMp4Converter::class)->convert($media, 1000))
+        ->toThrow(GifToMp4ConversionFailed::class);
+});

--- a/tests/Unit/PlatformVideoLimitsTest.php
+++ b/tests/Unit/PlatformVideoLimitsTest.php
@@ -7,7 +7,7 @@ test('per-platform video limits match the spec', function (): void {
         ->and(Platform::X->maxVideoDurationSeconds())->toBe(140)
         ->and(Platform::LinkedIn->maxVideoBytes())->toBe(524_288_000)
         ->and(Platform::LinkedIn->maxVideoDurationSeconds())->toBe(1800)
-        ->and(Platform::Bluesky->maxVideoBytes())->toBe(104_857_600)
+        ->and(Platform::Bluesky->maxVideoBytes())->toBe(100_000_000)
         ->and(Platform::Bluesky->maxVideoDurationSeconds())->toBe(180)
         ->and(Platform::X->allowedVideoMime())->toBe(['video/mp4']);
 });

--- a/tests/Unit/Posts/PlatformLimitsTest.php
+++ b/tests/Unit/Posts/PlatformLimitsTest.php
@@ -23,6 +23,7 @@ test('only linkedin caps the thread length', function () {
 test('media constraints match each platform', function () {
     expect(Platform::X->maxMedia())->toBe(4)
         ->and(Platform::LinkedIn->maxMedia())->toBe(9)
+        ->and(Platform::Bluesky->maxMediaBytes())->toBe(2_000_000)
         ->and(Platform::Bluesky->allowedMime())->toContain('image/webp')
         ->and(Platform::LinkedIn->allowedMime())->toContain('image/gif');
 });


### PR DESCRIPTION
Animated GIFs were being handled like regular image attachments. That fails on X because animated GIFs need the async `tweet_gif` media upload flow, and on Bluesky they can either hit the image blob limit or publish without animation.

## Summary

- Fix animated GIF publishing on X by using the async `tweet_gif` media flow.
- Preserve GIF animation on Bluesky by converting GIFs to MP4 and embedding them as `presentation: gif` video.
- Add focused validation and a small composer hint for Bluesky GIF handling.

## Testing

- Manually published an animated GIF successfully to X and Bluesky.
- Added coverage for the X upload path, Bluesky GIF conversion/publishing, platform limits, and the media chip hint.