### PR TITLE
fix(bluesky): block one-GIF/no-mix rule before posting

### DIFF
--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -19,6 +19,10 @@ import {
     type ComposerState,
 } from '@/lib/compose/composer-state';
 import {
+    wouldMixVideoAndImages,
+    wouldViolateBlueskyGif,
+} from '@/lib/compose/media-rules';
+import {
     replaceMentionLabel,
     replaceMentionTokens,
     savedMentionToPlaceholder,
@@ -302,6 +306,21 @@ export default function Composer({
     // the editor as a batch (edited one at a time).
     async function handleAddedFiles(files: FileList | File[]): Promise<void> {
         const all = Array.from(files);
+
+        // Bluesky publishes a GIF as video and allows only one, unmixed. Block it
+        // up front (same as the one-video rule) so it never reaches publishing —
+        // only when a Bluesky account is a target, since LinkedIn allows GIF+images.
+        const targetsBluesky = tabAccounts.some(
+            (a) => a.platform === 'bluesky',
+        );
+        if (targetsBluesky && wouldViolateBlueskyGif(state.media, all)) {
+            toast.error(
+                'Bluesky supports one animated GIF per post, and it cannot be mixed with other media.',
+            );
+
+            return;
+        }
+
         const videos = all.filter((f) => f.type.startsWith('video/'));
         // Anything that isn't a video is treated as an image: some clipboard
         // pastes report an empty/unknown MIME type, and the server validates the
@@ -310,12 +329,7 @@ export default function Composer({
 
         // A post is one video OR images, never both — decide before uploading
         // anything, so a mixed drop doesn't half-attach the video.
-        const hasVideo = state.media.some((m) => m.kind === 'video');
-        const hasImage = state.media.some((m) => m.kind !== 'video');
-        if (
-            (videos.length > 0 && (images.length > 0 || hasImage)) ||
-            (images.length > 0 && hasVideo)
-        ) {
+        if (wouldMixVideoAndImages(state.media, all)) {
             toast.error('A post can contain one video or images, not both.');
 
             return;

--- a/resources/js/lib/compose/__tests__/media-rules.test.ts
+++ b/resources/js/lib/compose/__tests__/media-rules.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    wouldMixVideoAndImages,
+    wouldViolateBlueskyGif,
+} from '@/lib/compose/media-rules';
+import type { MediaView } from '@/types/compose';
+
+function media(mime: string): Pick<MediaView, 'mime'> {
+    return { mime };
+}
+
+function attached(kind: MediaView['kind']): Pick<MediaView, 'kind'> {
+    return { kind };
+}
+
+function file(type: string): File {
+    return new File([''], 'f', { type });
+}
+
+const gif = () => file('image/gif');
+const png = () => file('image/png');
+const mp4 = () => file('video/mp4');
+
+describe('wouldViolateBlueskyGif', () => {
+    it('allows a single GIF on its own', () => {
+        expect(wouldViolateBlueskyGif([], [gif()])).toBe(false);
+    });
+
+    it('allows images with no GIF', () => {
+        expect(wouldViolateBlueskyGif([media('image/png')], [png()])).toBe(
+            false,
+        );
+    });
+
+    it('allows an empty batch', () => {
+        expect(wouldViolateBlueskyGif([], [])).toBe(false);
+    });
+
+    it('blocks a GIF dropped alongside an image in the same batch', () => {
+        expect(wouldViolateBlueskyGif([], [gif(), png()])).toBe(true);
+    });
+
+    it('blocks a GIF added to already-attached media', () => {
+        expect(wouldViolateBlueskyGif([media('image/png')], [gif()])).toBe(
+            true,
+        );
+    });
+
+    it('blocks other media added to an already-attached GIF', () => {
+        expect(wouldViolateBlueskyGif([media('image/gif')], [png()])).toBe(
+            true,
+        );
+    });
+
+    it('blocks a second GIF', () => {
+        expect(wouldViolateBlueskyGif([media('image/gif')], [gif()])).toBe(
+            true,
+        );
+        expect(wouldViolateBlueskyGif([], [gif(), gif()])).toBe(true);
+    });
+
+    it('blocks a GIF mixed with a video', () => {
+        expect(wouldViolateBlueskyGif([media('video/mp4')], [gif()])).toBe(
+            true,
+        );
+        expect(wouldViolateBlueskyGif([], [gif(), mp4()])).toBe(true);
+    });
+});
+
+describe('wouldMixVideoAndImages', () => {
+    it('allows images only', () => {
+        expect(wouldMixVideoAndImages([], [png(), gif()])).toBe(false);
+        expect(wouldMixVideoAndImages([attached('image')], [png()])).toBe(
+            false,
+        );
+    });
+
+    it('allows a single video on its own', () => {
+        expect(wouldMixVideoAndImages([], [mp4()])).toBe(false);
+    });
+
+    it('allows an empty batch', () => {
+        expect(wouldMixVideoAndImages([], [])).toBe(false);
+    });
+
+    it('blocks a video dropped alongside an image', () => {
+        expect(wouldMixVideoAndImages([], [mp4(), png()])).toBe(true);
+    });
+
+    it('blocks a video added to attached images', () => {
+        expect(wouldMixVideoAndImages([attached('image')], [mp4()])).toBe(true);
+    });
+
+    it('blocks images added to an attached video', () => {
+        expect(wouldMixVideoAndImages([attached('video')], [png()])).toBe(true);
+    });
+
+    // The batch-level rule only guards against mixing kinds; a second video is
+    // caught later by the per-file upload loop, not here.
+    it('does not block a second video at the batch level', () => {
+        expect(wouldMixVideoAndImages([attached('video')], [mp4()])).toBe(
+            false,
+        );
+    });
+});

--- a/resources/js/lib/compose/media-rules.ts
+++ b/resources/js/lib/compose/media-rules.ts
@@ -1,0 +1,42 @@
+import type { MediaView } from '@/types/compose';
+
+/** Matches the app-wide GIF convention: any `image/gif` is treated as animated. */
+const GIF_MIME = 'image/gif';
+
+/**
+ * A post carries one video OR images, never both. Given the already-attached
+ * media and an incoming batch, returns whether the batch would mix the two — a
+ * video joining images, or images joining a video.
+ */
+export function wouldMixVideoAndImages(
+    existing: Pick<MediaView, 'kind'>[],
+    incoming: File[],
+): boolean {
+    const videos = incoming.filter((f) => f.type.startsWith('video/'));
+    const images = incoming.filter((f) => !f.type.startsWith('video/'));
+    const hasVideo = existing.some((m) => m.kind === 'video');
+    const hasImage = existing.some((m) => m.kind !== 'video');
+
+    return (
+        (videos.length > 0 && (images.length > 0 || hasImage)) ||
+        (images.length > 0 && hasVideo)
+    );
+}
+
+/**
+ * Bluesky allows one animated GIF per post and won't mix it with other media.
+ * Given the already-attached media and an incoming batch, returns whether the
+ * resulting set would break that rule — one predicate covering every branch:
+ * GIF + other media, other media + existing GIF, and a second GIF.
+ */
+export function wouldViolateBlueskyGif(
+    existing: Pick<MediaView, 'mime'>[],
+    incoming: File[],
+): boolean {
+    const gifTotal =
+        existing.filter((m) => m.mime === GIF_MIME).length +
+        incoming.filter((f) => f.type === GIF_MIME).length;
+    const total = existing.length + incoming.length;
+
+    return gifTotal >= 1 && (total > 1 || gifTotal > 1);
+}

--- a/resources/js/pages/engagement/components/use-reply-media.tsx
+++ b/resources/js/pages/engagement/components/use-reply-media.tsx
@@ -9,6 +9,10 @@ import { ImageEditor } from '@/components/compose/image-editor';
 import { MediaChips } from '@/components/compose/media-chips';
 import { useMediaUploads } from '@/hooks/compose/use-media-uploads';
 import {
+    wouldMixVideoAndImages,
+    wouldViolateBlueskyGif,
+} from '@/lib/compose/media-rules';
+import {
     defaultSettings,
     type EditSettings,
     normalizeSettings,
@@ -226,15 +230,21 @@ export function useReplyMedia({
 
     async function handleAddedFiles(files: FileList | File[]): Promise<void> {
         const all = Array.from(files);
+
+        // Bluesky publishes a GIF as video and allows only one, unmixed. Block it
+        // up front (same as the one-video rule below) so it never reaches posting.
+        if (platform === 'bluesky' && wouldViolateBlueskyGif(media, all)) {
+            toast.error(
+                'Bluesky supports one animated GIF per post, and it cannot be mixed with other media.',
+            );
+
+            return;
+        }
+
         const videos = all.filter((f) => f.type.startsWith('video/'));
         const images = all.filter((f) => !f.type.startsWith('video/'));
 
-        const hasVideoNow = media.some((m) => m.kind === 'video');
-        const hasImageNow = media.some((m) => m.kind !== 'video');
-        if (
-            (videos.length > 0 && (images.length > 0 || hasImageNow)) ||
-            (images.length > 0 && hasVideoNow)
-        ) {
+        if (wouldMixVideoAndImages(media, all)) {
             toast.error('A reply can contain one video or images, not both.');
 
             return;


### PR DESCRIPTION
## What

Bluesky publishes an animated GIF as video and supports **one GIF per post, unmixed with other media**. Until now that constraint only surfaced as a publish-time failure (`BlueskyPublishConnector::ensureGifVideoReady`) — the user attached media, drafted, hit publish, then got the error.

This adds an **attach-time guard** that rejects the conflict up front, reusing the same mechanism as the existing "one video OR images, not both" rule (a `toast.error` in `handleAddedFiles`), in both the **composer** and **engagement replies**.

The GIF block is **Bluesky-conditional** (only when a Bluesky account is a selected target) because LinkedIn legitimately allows a GIF alongside other images.

## How

- New `resources/js/lib/compose/media-rules.ts` with two pure predicates:
  - `wouldViolateBlueskyGif(existing, incoming)` — GIF + other media, other media + existing GIF, or a second GIF.
  - `wouldMixVideoAndImages(existing, incoming)` — extracted from the previously-duplicated inline check in the composer and reply hook.
- Wired into `composer.tsx` and `use-reply-media.tsx`.
- No backend changes — the publish-time guard stays as the final safety net.

## Tests

- `resources/js/lib/compose/__tests__/media-rules.test.ts` — 15 unit tests covering both predicates.
- tsc / oxlint / oxfmt clean.

## Manual QA

- Bluesky selected: GIF then image → blocked; image then GIF → blocked; two GIFs → blocked; single GIF alone → allowed (publishes as video).
- LinkedIn only: GIF + image still allowed.
- Composer + engagement reply video/image mixing still behaves as before.