### PR TITLE
fix(compose): resolve 422 on edited-video upload + allow media storage host in CSP

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -64,6 +64,15 @@ class SecurityHeaders
 
     protected function contentSecurityPolicy(string $nonce): string
     {
+        // The remote storage origin (empty on local/public-disk deployments) is
+        // needed both to XHR-PUT direct-to-storage uploads / GET the video
+        // editor's source (connect-src) and to play back a signed video URL in a
+        // <video> element (media-src). Adding it only when the disk is remote
+        // keeps local and public-disk deployments on the tightest policy.
+        $storage = $this->storageOrigins();
+        $connect = trim("'self' blob: ".implode(' ', $storage));
+        $media = trim("'self' blob: ".implode(' ', $storage));
+
         $directives = [
             "default-src 'self'",
             "script-src 'self' 'nonce-{$nonce}' 'strict-dynamic'",
@@ -72,8 +81,13 @@ class SecurityHeaders
             // XSS risk and script-src remains strict.
             "style-src 'self' 'unsafe-inline'",
             "img-src 'self' data: blob: https:",
+            // blob: backs the composer's local video preview (URL.createObjectURL);
+            // the storage origin backs playback of an already-uploaded video served
+            // from a signed remote URL. Without media-src both fall through to
+            // default-src 'self' and are blocked.
+            "media-src {$media}",
             "font-src 'self' data:",
-            "connect-src 'self' blob:",
+            "connect-src {$connect}",
             "frame-ancestors 'none'",
             "base-uri 'self'",
             "form-action 'self'",
@@ -81,5 +95,56 @@ class SecurityHeaders
         ];
 
         return implode('; ', $directives);
+    }
+
+    /**
+     * CSP source origins for the deployment's media storage host. Empty unless
+     * the default disk is remote (s3), so local/public-disk deployments keep the
+     * tightest policy. Derived from the configured public URL and API endpoint;
+     * an s3 disk with neither configured (vanilla AWS, whose virtual-hosted,
+     * region-derived presign host can't be predicted cheaply here) falls back to
+     * `https:` so uploads and playback still work.
+     *
+     * @return list<string>
+     */
+    private function storageOrigins(): array
+    {
+        if (config('filesystems.default') !== 's3') {
+            return [];
+        }
+
+        $origins = [];
+
+        foreach (['filesystems.disks.s3.url', 'filesystems.disks.s3.endpoint'] as $key) {
+            $origin = $this->originOf((string) config($key));
+
+            if ($origin !== null) {
+                $origins[$origin] = $origin;
+            }
+        }
+
+        return $origins === [] ? ['https:'] : array_values($origins);
+    }
+
+    /**
+     * Reduce a URL to its CSP-source origin (`scheme://host[:port]`), or null if
+     * it lacks a usable scheme and host.
+     */
+    private function originOf(string $url): ?string
+    {
+        if ($url === '') {
+            return null;
+        }
+
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        $host = parse_url($url, PHP_URL_HOST);
+
+        if (! is_string($scheme) || ! is_string($host) || $host === '') {
+            return null;
+        }
+
+        $port = parse_url($url, PHP_URL_PORT);
+
+        return $scheme.'://'.$host.(is_int($port) ? ':'.$port : '');
     }
 }

--- a/resources/js/lib/compose/__tests__/read-video-metadata.test.ts
+++ b/resources/js/lib/compose/__tests__/read-video-metadata.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+import { readVideoMetadata } from '@/lib/compose/video';
+
+type Handler = (() => void) | null;
+
+/**
+ * A controllable stand-in for an <video> element. jsdom's HTMLMediaElement
+ * never fires loadedmetadata/seeked nor populates videoWidth, so the flaky
+ * freshly-muxed-blob sequence the hardening targets can't be reproduced with a
+ * real element — this fake lets the test drive those events deterministically.
+ */
+class FakeVideo {
+    preload = '';
+    muted = false;
+    videoWidth = 0;
+    videoHeight = 0;
+    duration = Number.NaN;
+    src = '';
+    onloadedmetadata: Handler = null;
+    onseeked: Handler = null;
+    onerror: Handler = null;
+    seeks: number[] = [];
+    /** Duration the "browser" resolves once nudged with a seek-to-end. */
+    resolvedDuration: number | null = null;
+    removeAttribute = vi.fn();
+    load = vi.fn();
+
+    private currentTimeValue = 0;
+
+    get currentTime(): number {
+        return this.currentTimeValue;
+    }
+
+    set currentTime(value: number) {
+        this.currentTimeValue = value;
+        this.seeks.push(value);
+        if (value > 1e50 && this.resolvedDuration !== null) {
+            this.duration = this.resolvedDuration;
+        }
+        queueMicrotask(() => this.onseeked?.());
+    }
+}
+
+let created: FakeVideo | null = null;
+
+beforeEach(() => {
+    created = null;
+    // The suite runs in a node environment (no jsdom), so stub the only two DOM
+    // globals readVideoMetadata touches rather than pulling in a full DOM.
+    vi.stubGlobal('document', {
+        createElement: (tag: string) => {
+            if (tag === 'video') {
+                created = new FakeVideo();
+
+                return created;
+            }
+
+            throw new Error(`unexpected createElement(${tag})`);
+        },
+    });
+    vi.stubGlobal('URL', {
+        createObjectURL: vi.fn(() => 'blob:fake'),
+        revokeObjectURL: vi.fn(),
+    });
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+function file(): File {
+    return new File([new Uint8Array(1024)], 'v.mp4', { type: 'video/mp4' });
+}
+
+it('resolves immediately when the first metadata read is already valid', async () => {
+    const promise = readVideoMetadata(file());
+    const el = created!;
+    el.duration = 12;
+    el.videoWidth = 1280;
+    el.videoHeight = 720;
+    el.onloadedmetadata?.();
+
+    await expect(promise).resolves.toEqual({
+        sizeBytes: 1024,
+        mime: 'video/mp4',
+        durationSeconds: 12,
+        width: 1280,
+        height: 720,
+    });
+    // A clean read must not pay for the seek nudge.
+    expect(el.seeks).toEqual([]);
+});
+
+it('nudges with a seek when duration comes back non-finite, then resolves', async () => {
+    const promise = readVideoMetadata(file());
+    const el = created!;
+    // The flaky case: metadata fires with Infinity duration but real dimensions.
+    el.duration = Number.POSITIVE_INFINITY;
+    el.videoWidth = 1920;
+    el.videoHeight = 1080;
+    el.resolvedDuration = 8; // what the browser settles on after the seek
+    el.onloadedmetadata?.();
+
+    await expect(promise).resolves.toEqual({
+        sizeBytes: 1024,
+        mime: 'video/mp4',
+        durationSeconds: 8,
+        width: 1920,
+        height: 1080,
+    });
+    expect(el.seeks.length).toBeGreaterThan(0);
+});
+
+it('nudges when dimensions are missing even if duration is known', async () => {
+    const promise = readVideoMetadata(file());
+    const el = created!;
+    el.duration = 30;
+    el.videoWidth = 0;
+    el.videoHeight = 0;
+    el.onloadedmetadata?.();
+    // Dimensions arrive after the frame-decode seek.
+    el.videoWidth = 640;
+    el.videoHeight = 480;
+    // Flush the queued onseeked.
+    await Promise.resolve();
+
+    await expect(promise).resolves.toMatchObject({
+        durationSeconds: 30,
+        width: 640,
+        height: 480,
+    });
+    expect(el.seeks).toContain(0);
+});
+
+it('rejects (rather than returning bad data) when the video errors', async () => {
+    const promise = readVideoMetadata(file());
+    created!.onerror?.();
+
+    await expect(promise).rejects.toThrow('Could not read video metadata');
+});
+
+it('rejects when a nudge still cannot produce valid metadata', async () => {
+    const promise = readVideoMetadata(file());
+    const el = created!;
+    el.duration = Number.NaN;
+    el.videoWidth = 0;
+    el.videoHeight = 0;
+    el.onloadedmetadata?.(); // triggers a seek; duration stays NaN
+
+    await expect(promise).rejects.toThrow('Could not read video metadata');
+});

--- a/resources/js/lib/compose/__tests__/read-video-metadata.test.ts
+++ b/resources/js/lib/compose/__tests__/read-video-metadata.test.ts
@@ -33,6 +33,11 @@ class FakeVideo {
     }
 
     set currentTime(value: number) {
+        // Real browsers don't fire `seeked` when the assigned value equals the
+        // current position — modelling that keeps the fake honest about no-op seeks.
+        if (value === this.currentTimeValue) {
+            return;
+        }
         this.currentTimeValue = value;
         this.seeks.push(value);
         if (value > 1e50 && this.resolvedDuration !== null) {
@@ -93,6 +98,25 @@ it('resolves immediately when the first metadata read is already valid', async (
     expect(el.seeks).toEqual([]);
 });
 
+it('clamps a sub-second duration to 1 so the confirm endpoint does not 422', async () => {
+    const promise = readVideoMetadata(file());
+    const el = created!;
+    // A short trim: a valid clip, but Math.floor(0.8) is 0, which fails the
+    // server's `min:1` rule and reintroduces the reported 422.
+    el.duration = 0.8;
+    el.videoWidth = 1080;
+    el.videoHeight = 1920;
+    el.onloadedmetadata?.();
+
+    await expect(promise).resolves.toMatchObject({
+        durationSeconds: 1,
+        width: 1080,
+        height: 1920,
+    });
+    // A clean (if short) read still must not pay for the seek nudge.
+    expect(el.seeks).toEqual([]);
+});
+
 it('nudges with a seek when duration comes back non-finite, then resolves', async () => {
     const promise = readVideoMetadata(file());
     const el = created!;
@@ -131,7 +155,9 @@ it('nudges when dimensions are missing even if duration is known', async () => {
         width: 640,
         height: 480,
     });
-    expect(el.seeks).toContain(0);
+    // A non-zero nudge is required: seeking to 0 (the current position) would be
+    // a no-op that never fires `seeked`, so the frame decode would never trigger.
+    expect(el.seeks.some((t) => t > 0)).toBe(true);
 });
 
 it('rejects (rather than returning bad data) when the video errors', async () => {

--- a/resources/js/lib/compose/video.ts
+++ b/resources/js/lib/compose/video.ts
@@ -149,21 +149,70 @@ export function readVideoMetadata(file: File): Promise<VideoMeta> {
         const url = URL.createObjectURL(file);
         const video = document.createElement('video');
         video.preload = 'metadata';
-        video.onloadedmetadata = () => {
+        video.muted = true;
+
+        let settled = false;
+        const finish = (run: () => void): void => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            clearTimeout(timer);
+            run();
             URL.revokeObjectURL(url);
-            resolve({
-                sizeBytes: file.size,
-                mime: file.type,
-                // Floor, not round: a 140.4s clip must not be rejected against a 140s cap.
-                durationSeconds: Math.floor(video.duration),
-                width: video.videoWidth,
-                height: video.videoHeight,
-            });
+            video.removeAttribute('src');
+            video.load();
         };
-        video.onerror = () => {
-            URL.revokeObjectURL(url);
-            reject(new Error('Could not read video metadata.'));
+
+        const hasDimensions = (): boolean =>
+            video.videoWidth > 0 && video.videoHeight > 0;
+        const hasDuration = (): boolean =>
+            Number.isFinite(video.duration) && video.duration > 0;
+
+        const succeed = (): void =>
+            finish(() =>
+                resolve({
+                    sizeBytes: file.size,
+                    mime: file.type,
+                    // Floor, not round: a 140.4s clip must not be rejected against a 140s cap.
+                    durationSeconds: Math.floor(video.duration),
+                    width: video.videoWidth,
+                    height: video.videoHeight,
+                }),
+            );
+        const bail = (): void =>
+            finish(() => reject(new Error('Could not read video metadata.')));
+
+        // A freshly-muxed MP4/WebM blob (e.g. the video editor's output) often
+        // fires `loadedmetadata` before the browser has resolved the real
+        // duration (reported as Infinity/NaN) or frame dimensions (0×0). Seeking
+        // past the end forces it to scan the file and settle both; `seeked` then
+        // carries trustworthy values. Only nudge when something is missing, so a
+        // normal file resolves immediately without the extra work.
+        const settle = (): void => {
+            if (hasDuration() && hasDimensions()) {
+                succeed();
+            } else if (Number.isFinite(video.duration) && !hasDimensions()) {
+                // Duration is known but dimensions aren't — decode one frame.
+                video.currentTime = 0;
+            } else {
+                video.currentTime = 1e101;
+            }
         };
+
+        video.onloadedmetadata = settle;
+        video.onseeked = () => {
+            if (hasDuration() && hasDimensions()) {
+                succeed();
+            } else {
+                bail();
+            }
+        };
+        video.onerror = bail;
+
+        // Never hang the upload flow on a video the browser can't parse.
+        const timer = setTimeout(bail, 15000);
+
         video.src = url;
     });
 }

--- a/resources/js/lib/compose/video.ts
+++ b/resources/js/lib/compose/video.ts
@@ -174,8 +174,11 @@ export function readVideoMetadata(file: File): Promise<VideoMeta> {
                 resolve({
                     sizeBytes: file.size,
                     mime: file.type,
-                    // Floor, not round: a 140.4s clip must not be rejected against a 140s cap.
-                    durationSeconds: Math.floor(video.duration),
+                    // Floor, not round: a 140.4s clip must not be rejected against a
+                    // 140s cap. Clamp to ≥1: a valid video always has some duration,
+                    // but a sub-second trim (e.g. 0.8s) floors to 0, which fails the
+                    // confirm endpoint's `min:1` rule and 422s the upload.
+                    durationSeconds: Math.max(1, Math.floor(video.duration)),
                     width: video.videoWidth,
                     height: video.videoHeight,
                 }),
@@ -193,8 +196,11 @@ export function readVideoMetadata(file: File): Promise<VideoMeta> {
             if (hasDuration() && hasDimensions()) {
                 succeed();
             } else if (Number.isFinite(video.duration) && !hasDimensions()) {
-                // Duration is known but dimensions aren't — decode one frame.
-                video.currentTime = 0;
+                // Duration is known but dimensions aren't — decode one frame. Seek
+                // to a small non-zero offset rather than 0: the element already
+                // sits at currentTime 0, and assigning the current value is a no-op
+                // that never fires `seeked`, so we'd hang to the timeout instead.
+                video.currentTime = 1e-3;
             } else {
                 video.currentTime = 1e101;
             }

--- a/tests/Feature/SecurityHeadersTest.php
+++ b/tests/Feature/SecurityHeadersTest.php
@@ -22,9 +22,49 @@ test('responses carry a nonce-based content security policy', function () {
         ->and($csp)->toContain("object-src 'none'")
         ->and($csp)->toContain("base-uri 'self'")
         ->and($csp)->toContain("img-src 'self' data: blob: https:")
+        ->and($csp)->toContain("media-src 'self' blob:")
         ->and($csp)->toContain("connect-src 'self' blob:")
         ->and($csp)->toMatch("/script-src [^;]*'nonce-[A-Za-z0-9+\/=]+'/")
         ->and($csp)->toContain("'strict-dynamic'");
+});
+
+test('a local/public-disk deployment keeps connect-src and media-src tight', function () {
+    config(['filesystems.default' => 'public']);
+
+    $csp = $this->get('/login')->headers->get('Content-Security-Policy');
+
+    // No remote storage host, so no origin is appended to either directive.
+    expect($csp)->toContain('connect-src \'self\' blob:;')
+        ->and($csp)->toContain('media-src \'self\' blob:;');
+});
+
+test('a remote s3 disk allowlists its configured endpoint origin for uploads and playback', function () {
+    config([
+        'filesystems.default' => 's3',
+        'filesystems.disks.s3.url' => null,
+        'filesystems.disks.s3.endpoint' => 'https://minio.example.com:9000',
+    ]);
+
+    $csp = $this->get('/login')->headers->get('Content-Security-Policy');
+
+    // The signed-upload PUT / editor GET and <video> playback both target this
+    // origin; it must appear in connect-src and media-src, and not leak to https:.
+    expect($csp)->toContain('connect-src \'self\' blob: https://minio.example.com:9000')
+        ->and($csp)->toContain('media-src \'self\' blob: https://minio.example.com:9000')
+        ->and($csp)->not->toContain('connect-src \'self\' blob: https:;');
+});
+
+test('a vanilla s3 disk with no endpoint falls back to https: so uploads still work', function () {
+    config([
+        'filesystems.default' => 's3',
+        'filesystems.disks.s3.url' => null,
+        'filesystems.disks.s3.endpoint' => null,
+    ]);
+
+    $csp = $this->get('/login')->headers->get('Content-Security-Policy');
+
+    expect($csp)->toContain('connect-src \'self\' blob: https:')
+        ->and($csp)->toContain('media-src \'self\' blob: https:');
 });
 
 test('the csp nonce is exposed to vite and differs per request', function () {


### PR DESCRIPTION
Two media-upload fixes that surfaced from a "422 on upload" report.

## 1. Edited-video 422 (the reported bug)

**Symptom:** uploading a video **after editing** (trim/crop) 422'd intermittently; uploading **without** editing always worked.

**Cause:** the video editor produces a freshly-muxed blob and hands it to `readVideoMetadata`, which trusted the first `loadedmetadata` event. For a just-encoded blob the browser frequently fires that event before it has resolved the real `duration` (comes back `Infinity`/`NaN`) or frame dimensions (`0×0`). On those reads the confirm request sent `duration_seconds`/`width`/`height` that fail the server's `min:1` rule → 422. Un-edited originals carry clean metadata, so they never tripped it. (Verified the server flow itself is fine end-to-end — sign → PUT → confirm all succeed with valid values.)

**Fix (`resources/js/lib/compose/video.ts`):** harden `readVideoMetadata` to
- detect a non-finite `duration` or `0×0` dimensions instead of trusting the first event,
- **nudge** the browser to settle them (seek past the end, read trustworthy values on `seeked`) — a clean file still resolves immediately with no seek,
- **reject** rather than return bad data if values still can't be read (callers already turn that into a clear toast, not a confusing 422),
- **time out** (15s) so an unparseable file fails gracefully instead of hanging the upload.

## 2. Media-storage CSP (prod-only, found en route)

The CSP is disabled in `local`, so this doesn't affect dev — but on a remote (s3) disk in staging/prod it breaks video media three ways: the direct-to-storage `PUT` (presigned URL), the editor's source `fetch()` (both `connect-src`), and playback of a signed remote video in a `<video>` element (`media-src`, which was missing entirely). 

**Fix (`app/Http/Middleware/SecurityHeaders.php`):** add `media-src` and append the configured storage origin (derived from `s3.url`/`s3.endpoint`, with an `https:` fallback for vanilla AWS whose virtual-hosted presign host can't be predicted) to both `connect-src` and `media-src`. Local/public-disk deployments append nothing and keep the tightest policy unchanged.

## Tests
- `read-video-metadata.test.ts` (new): immediate-valid, seek-nudge-on-non-finite-duration, nudge-on-missing-dimensions, error→reject, and nudge-still-invalid→reject.
- `SecurityHeadersTest.php`: local/public-disk (tight), s3-with-endpoint (exact origin), s3-without-endpoint (`https:` fallback), plus `media-src` assertion.

Gate: oxlint/oxfmt/tsc clean, 161 compose JS tests pass, Pint + Larastan clean, 19 SecurityHeaders/PostVideoUpload Pest tests pass.

## Note
The metadata fix is browser-runtime behavior that can't be exercised headless in CI (the new unit tests drive a controllable fake `<video>`); confirmed working in-app on repeated edited uploads.