### PR TITLE
feat(x): opt-in quote tweets from a pasted status link

### DIFF
--- a/app/Http/Requests/Settings/UpdateInstanceSettingsRequest.php
+++ b/app/Http/Requests/Settings/UpdateInstanceSettingsRequest.php
@@ -30,15 +30,16 @@ class UpdateInstanceSettingsRequest extends FormRequest
             'registrations_enabled' => ['required', 'boolean'],
             'workspace_creation_enabled' => ['required', 'boolean'],
             'usage_tracking_enabled' => ['required', 'boolean'],
+            'quote_tweets_enabled' => ['required', 'boolean'],
         ];
     }
 
     /**
-     * @return array{registrations_enabled: bool, workspace_creation_enabled: bool, usage_tracking_enabled: bool}
+     * @return array{registrations_enabled: bool, workspace_creation_enabled: bool, usage_tracking_enabled: bool, quote_tweets_enabled: bool}
      */
     public function instanceSettings(): array
     {
-        /** @var array{registrations_enabled: bool, workspace_creation_enabled: bool, usage_tracking_enabled: bool} $settings */
+        /** @var array{registrations_enabled: bool, workspace_creation_enabled: bool, usage_tracking_enabled: bool, quote_tweets_enabled: bool} $settings */
         $settings = $this->validated();
 
         if (! (bool) config('kit.workspaces.enabled')) {

--- a/app/Services/Publishing/Connectors/XConnector.php
+++ b/app/Services/Publishing/Connectors/XConnector.php
@@ -79,13 +79,27 @@ class XConnector implements PublishConnector
                     continue;
                 }
 
-                // X rejects an empty `text` field; once media_ids are attached
+                $hasMedia = $index === 0 && $mediaIds !== [];
+
+                // quote_tweet_id is mutually exclusive with media on X, so only pull a
+                // quoted status link out of the copy when this segment carries no media.
+                // (When media is attached we leave the link inline as a plain URL.)
+                $quoteTweetId = null;
+                if (! $hasMedia) {
+                    [$text, $quoteTweetId] = $this->extractQuoteTweet($text);
+                }
+
+                // X rejects an empty `text` field; once media_ids or a quote are attached
                 // text is optional, so omit it entirely for a media-only post
                 // (otherwise the API returns a 400 "Invalid Request").
                 $body = $text === '' ? [] : ['text' => $text];
 
-                if ($index === 0 && $mediaIds !== []) {
+                if ($hasMedia) {
                     $body['media'] = ['media_ids' => $mediaIds];
+                }
+
+                if ($quoteTweetId !== null) {
+                    $body['quote_tweet_id'] = $quoteTweetId;
                 }
 
                 $previous = $remoteIds[$index - 1] ?? null;
@@ -121,6 +135,46 @@ class XConnector implements PublishConnector
         }
 
         return PublishResult::success(array_values($remoteIds));
+    }
+
+    /**
+     * Pull a quoted-post target out of a tweet's copy.
+     *
+     * A bare status link never renders as a quote on its own — X only shows a quote
+     * card when the request carries a separate `quote_tweet_id`. Mirroring X's native
+     * behaviour, the LAST status link in the text becomes the quote and is stripped
+     * from the visible copy so the reader sees a card, not a redundant t.co link.
+     *
+     * @return array{0: string, 1: ?string} the copy with the quoted link removed, and the quoted tweet id (or null)
+     */
+    private function extractQuoteTweet(string $text): array
+    {
+        $matched = preg_match_all(
+            '~https?://(?:www\.|mobile\.)?(?:twitter|x)\.com/\w+/status(?:es)?/(\d{1,19})(?:[/?#]\S*)?~i',
+            $text,
+            $matches,
+            PREG_OFFSET_CAPTURE,
+        );
+
+        if ($matched === 0 || $matched === false) {
+            return [$text, null];
+        }
+
+        $lastUrl = end($matches[0]);
+        $lastId = end($matches[1]);
+
+        if ($lastUrl === false || $lastId === false) {
+            return [$text, null];
+        }
+
+        [$url, $offset] = $lastUrl;
+        $quoteTweetId = $lastId[0];
+
+        // Remove the quoted link, then collapse the whitespace it left behind.
+        $stripped = substr_replace($text, '', $offset, strlen($url));
+        $stripped = trim((string) preg_replace('/\s{2,}/', ' ', $stripped));
+
+        return [$stripped, $quoteTweetId];
     }
 
     public function delete(PostTarget $target, array $credentials): void

--- a/app/Services/Publishing/Connectors/XConnector.php
+++ b/app/Services/Publishing/Connectors/XConnector.php
@@ -17,6 +17,7 @@ use App\Services\Media\ImageCompressor;
 use App\Services\Publishing\Connectors\Concerns\MapsHttpErrors;
 use App\Services\Publishing\Contracts\PublishConnector;
 use App\Services\Usage\Concerns\TracksUsage;
+use App\Support\InstanceSettings;
 use App\Support\UsageOperation;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Factory as HttpFactory;
@@ -43,6 +44,7 @@ class XConnector implements PublishConnector
     public function __construct(
         private readonly HttpFactory $http,
         private readonly ImageCompressor $imageCompressor,
+        private readonly InstanceSettings $settings,
     ) {}
 
     public function publish(PublishContext $context): PublishResult
@@ -81,11 +83,12 @@ class XConnector implements PublishConnector
 
                 $hasMedia = $index === 0 && $mediaIds !== [];
 
-                // quote_tweet_id is mutually exclusive with media on X, so only pull a
-                // quoted status link out of the copy when this segment carries no media.
-                // (When media is attached we leave the link inline as a plain URL.)
+                // Quote-posting is opt-in per instance (it needs X Enterprise API access),
+                // and quote_tweet_id is mutually exclusive with media on X — so only pull a
+                // quoted status link out of the copy when the instance allows it and this
+                // segment carries no media. (Otherwise the link stays inline as a plain URL.)
                 $quoteTweetId = null;
-                if (! $hasMedia) {
+                if (! $hasMedia && $this->settings->quoteTweetsEnabled()) {
                     [$text, $quoteTweetId] = $this->extractQuoteTweet($text);
                 }
 

--- a/app/Support/InstanceSettings.php
+++ b/app/Support/InstanceSettings.php
@@ -28,6 +28,11 @@ class InstanceSettings
         return $this->boolean('usage_tracking_enabled');
     }
 
+    public function quoteTweetsEnabled(): bool
+    {
+        return $this->boolean('quote_tweets_enabled');
+    }
+
     public function registrationsAllowed(?string $invitationToken = null): bool
     {
         if (! $this->ownerExists()) {
@@ -56,7 +61,7 @@ class InstanceSettings
     }
 
     /**
-     * @return array{registrations_enabled: bool, workspace_creation_enabled: bool, usage_tracking_enabled: bool}
+     * @return array{registrations_enabled: bool, workspace_creation_enabled: bool, usage_tracking_enabled: bool, quote_tweets_enabled: bool}
      */
     public function all(): array
     {
@@ -64,11 +69,12 @@ class InstanceSettings
             'registrations_enabled' => $this->registrationsEnabled(),
             'workspace_creation_enabled' => $this->workspaceCreationEnabled(),
             'usage_tracking_enabled' => $this->usageTrackingEnabled(),
+            'quote_tweets_enabled' => $this->quoteTweetsEnabled(),
         ];
     }
 
     /**
-     * @param  array{registrations_enabled?: bool, workspace_creation_enabled?: bool, usage_tracking_enabled?: bool}  $values
+     * @param  array{registrations_enabled?: bool, workspace_creation_enabled?: bool, usage_tracking_enabled?: bool, quote_tweets_enabled?: bool}  $values
      */
     public function update(array $values): void
     {

--- a/config/instance.php
+++ b/config/instance.php
@@ -12,5 +12,6 @@ return [
             env('WORKSPACES_CAN_CREATE_WORKSPACE', true),
         ),
         'usage_tracking_enabled' => env('INSTANCE_USAGE_TRACKING_ENABLED', false),
+        'quote_tweets_enabled' => env('INSTANCE_QUOTE_TWEETS_ENABLED', false),
     ],
 ];

--- a/resources/js/pages/settings/instance.tsx
+++ b/resources/js/pages/settings/instance.tsx
@@ -10,6 +10,7 @@ type InstanceSettings = {
     registrations_enabled: boolean;
     workspace_creation_enabled: boolean;
     usage_tracking_enabled: boolean;
+    quote_tweets_enabled: boolean;
 };
 
 type PageProps = {
@@ -23,6 +24,7 @@ export default function Instance({ settings, workspaces_enabled }: PageProps) {
         workspace_creation_enabled:
             workspaces_enabled && settings.workspace_creation_enabled,
         usage_tracking_enabled: settings.usage_tracking_enabled,
+        quote_tweets_enabled: settings.quote_tweets_enabled,
     });
 
     function handleSubmit(event: React.FormEvent) {
@@ -113,6 +115,30 @@ export default function Instance({ settings, workspaces_enabled }: PageProps) {
                                     When enabled, records per-workspace API
                                     usage (posts, reads, requests) for cost and
                                     abuse monitoring. Off by default.
+                                </p>
+                            </div>
+                        </div>
+
+                        <div className="flex items-start gap-3">
+                            <Checkbox
+                                id="quote_tweets_enabled"
+                                checked={data.quote_tweets_enabled}
+                                onCheckedChange={(checked) =>
+                                    setData(
+                                        'quote_tweets_enabled',
+                                        checked === true,
+                                    )
+                                }
+                            />
+                            <div className="space-y-1">
+                                <Label htmlFor="quote_tweets_enabled">
+                                    Quote tweets on X from pasted links
+                                </Label>
+                                <p className="text-sm text-muted-foreground">
+                                    When enabled, a post link in an X update
+                                    becomes a quote tweet instead of a plain
+                                    link. Requires X Enterprise API access;
+                                    leave off on other tiers. Off by default.
                                 </p>
                             </div>
                         </div>

--- a/tests/Feature/InstanceSettingsTest.php
+++ b/tests/Feature/InstanceSettingsTest.php
@@ -29,6 +29,7 @@ test('instance owner can update instance settings', function () {
             'registrations_enabled' => false,
             'workspace_creation_enabled' => false,
             'usage_tracking_enabled' => false,
+            'quote_tweets_enabled' => false,
         ])
         ->assertRedirect();
 
@@ -61,6 +62,7 @@ test('workspace creation setting cannot be enabled when workspaces are globally 
             'registrations_enabled' => true,
             'workspace_creation_enabled' => true,
             'usage_tracking_enabled' => false,
+            'quote_tweets_enabled' => false,
         ])
         ->assertRedirect();
 

--- a/tests/Feature/Publishing/QuoteTweetSettingUpdateTest.php
+++ b/tests/Feature/Publishing/QuoteTweetSettingUpdateTest.php
@@ -4,24 +4,29 @@ use App\Enums\InstanceRole;
 use App\Models\User;
 use App\Support\InstanceSettings;
 
-it('lets an instance owner enable usage tracking', function () {
-    $owner = User::factory()->create(['instance_role' => InstanceRole::Owner->value]);
-
-    $this->actingAs($owner)->put('/settings/instance', [
-        'registrations_enabled' => false,
-        'workspace_creation_enabled' => true,
-        'usage_tracking_enabled' => true,
-        'quote_tweets_enabled' => false,
-    ])->assertRedirect();
-
-    expect(app(InstanceSettings::class)->usageTrackingEnabled())->toBeTrue();
+it('is disabled by default', function () {
+    expect(app(InstanceSettings::class)->quoteTweetsEnabled())->toBeFalse();
 });
 
-it('rejects a missing usage_tracking_enabled field', function () {
+it('lets an instance owner enable quote tweets', function () {
     $owner = User::factory()->create(['instance_role' => InstanceRole::Owner->value]);
 
     $this->actingAs($owner)->put('/settings/instance', [
         'registrations_enabled' => false,
         'workspace_creation_enabled' => true,
-    ])->assertSessionHasErrors('usage_tracking_enabled');
+        'usage_tracking_enabled' => false,
+        'quote_tweets_enabled' => true,
+    ])->assertRedirect();
+
+    expect(app(InstanceSettings::class)->quoteTweetsEnabled())->toBeTrue();
+});
+
+it('rejects a missing quote_tweets_enabled field', function () {
+    $owner = User::factory()->create(['instance_role' => InstanceRole::Owner->value]);
+
+    $this->actingAs($owner)->put('/settings/instance', [
+        'registrations_enabled' => false,
+        'workspace_creation_enabled' => true,
+        'usage_tracking_enabled' => false,
+    ])->assertSessionHasErrors('quote_tweets_enabled');
 });

--- a/tests/Feature/Publishing/XConnectorTest.php
+++ b/tests/Feature/Publishing/XConnectorTest.php
@@ -302,6 +302,7 @@ test('x omits an empty text field for a media-only post', function () {
 });
 
 test('x quotes a pasted status link and strips it from the text', function () {
+    config(['instance.defaults.quote_tweets_enabled' => true]);
     Http::fake([
         'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => '111']]),
     ]);
@@ -318,6 +319,7 @@ test('x quotes a pasted status link and strips it from the text', function () {
 });
 
 test('x quotes twitter.com links and tolerates query strings', function () {
+    config(['instance.defaults.quote_tweets_enabled' => true]);
     Http::fake([
         'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => '111']]),
     ]);
@@ -331,6 +333,7 @@ test('x quotes twitter.com links and tolerates query strings', function () {
 });
 
 test('x quotes the last status link when several are present', function () {
+    config(['instance.defaults.quote_tweets_enabled' => true]);
     Http::fake([
         'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => '111']]),
     ]);
@@ -344,6 +347,7 @@ test('x quotes the last status link when several are present', function () {
 });
 
 test('x omits text entirely for a quote-only tweet', function () {
+    config(['instance.defaults.quote_tweets_enabled' => true]);
     Http::fake([
         'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => '111']]),
     ]);
@@ -355,6 +359,7 @@ test('x omits text entirely for a quote-only tweet', function () {
 });
 
 test('x does not treat a non-status x.com link as a quote', function () {
+    config(['instance.defaults.quote_tweets_enabled' => true]);
     Http::fake([
         'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => '111']]),
     ]);
@@ -365,7 +370,22 @@ test('x does not treat a non-status x.com link as a quote', function () {
         && ! array_key_exists('quote_tweet_id', $request->data()));
 });
 
+test('x leaves a status link inline when quote tweets are disabled (the default)', function () {
+    Http::fake([
+        'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => '111']]),
+    ]);
+
+    app(XConnector::class)->publish(xContext([
+        'great thread 👇 https://x.com/foo/status/1234567890',
+    ]));
+
+    // Off by default: the link is posted verbatim, no quote_tweet_id.
+    Http::assertSent(fn ($request) => $request['text'] === 'great thread 👇 https://x.com/foo/status/1234567890'
+        && ! array_key_exists('quote_tweet_id', $request->data()));
+});
+
 test('x leaves a status link inline and skips quoting when media is attached', function () {
+    config(['instance.defaults.quote_tweets_enabled' => true]);
     Storage::fake('public');
     Storage::disk('public')->put('media/cat.jpg', 'image-bytes');
 

--- a/tests/Feature/Publishing/XConnectorTest.php
+++ b/tests/Feature/Publishing/XConnectorTest.php
@@ -301,6 +301,96 @@ test('x omits an empty text field for a media-only post', function () {
         && ($request['media']['media_ids'] ?? null) === ['99001']);
 });
 
+test('x quotes a pasted status link and strips it from the text', function () {
+    Http::fake([
+        'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => '111']]),
+    ]);
+
+    $result = app(XConnector::class)->publish(xContext([
+        'great thread 👇 https://x.com/foo/status/1234567890',
+    ]));
+
+    expect($result->isSuccessful())->toBeTrue();
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://api.twitter.com/2/tweets'
+        && $request['text'] === 'great thread 👇'
+        && ($request['quote_tweet_id'] ?? null) === '1234567890');
+});
+
+test('x quotes twitter.com links and tolerates query strings', function () {
+    Http::fake([
+        'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => '111']]),
+    ]);
+
+    app(XConnector::class)->publish(xContext([
+        'look https://twitter.com/foo/status/999?s=20',
+    ]));
+
+    Http::assertSent(fn ($request) => $request['text'] === 'look'
+        && ($request['quote_tweet_id'] ?? null) === '999');
+});
+
+test('x quotes the last status link when several are present', function () {
+    Http::fake([
+        'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => '111']]),
+    ]);
+
+    app(XConnector::class)->publish(xContext([
+        'https://x.com/a/status/111 vs https://x.com/b/status/222',
+    ]));
+
+    Http::assertSent(fn ($request) => ($request['quote_tweet_id'] ?? null) === '222'
+        && $request['text'] === 'https://x.com/a/status/111 vs');
+});
+
+test('x omits text entirely for a quote-only tweet', function () {
+    Http::fake([
+        'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => '111']]),
+    ]);
+
+    app(XConnector::class)->publish(xContext(['https://x.com/foo/status/1234567890']));
+
+    Http::assertSent(fn ($request) => ! array_key_exists('text', $request->data())
+        && ($request['quote_tweet_id'] ?? null) === '1234567890');
+});
+
+test('x does not treat a non-status x.com link as a quote', function () {
+    Http::fake([
+        'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => '111']]),
+    ]);
+
+    app(XConnector::class)->publish(xContext(['follow me https://x.com/foo']));
+
+    Http::assertSent(fn ($request) => $request['text'] === 'follow me https://x.com/foo'
+        && ! array_key_exists('quote_tweet_id', $request->data()));
+});
+
+test('x leaves a status link inline and skips quoting when media is attached', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/cat.jpg', 'image-bytes');
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/cat.jpg',
+        'mime' => 'image/jpeg',
+    ]);
+
+    Http::fake([
+        'https://api.x.com/2/media/upload' => Http::response(['data' => ['id' => '99001']]),
+        'https://api.twitter.com/2/tweets' => Http::response(['data' => ['id' => '111']]),
+    ]);
+
+    app(XConnector::class)->publish(xContext([
+        'see https://x.com/foo/status/1234567890',
+    ], [$media]));
+
+    // quote_tweet_id is mutually exclusive with media, so the link stays in the copy.
+    Http::assertSent(fn ($request) => $request->url() === 'https://api.twitter.com/2/tweets'
+        && $request['text'] === 'see https://x.com/foo/status/1234567890'
+        && ! array_key_exists('quote_tweet_id', $request->data())
+        && ($request['media']['media_ids'] ?? null) === ['99001']);
+});
+
 test('x compresses oversized images via the compressor before upload', function () {
     Storage::fake('public');
     Storage::disk('public')->put('media/big.jpg', 'image-bytes');


### PR DESCRIPTION
## Problem

Posting to X with a tweet link in the copy just renders a plain t.co link, not a quote. X only shows a quote card when the request to `POST /2/tweets` carries a separate **`quote_tweet_id`** field — our `XConnector` never sent one.

## Fix

`XConnector` detects the **last** `x.com` / `twitter.com` `/status/<id>` link in each segment, sends its id as `quote_tweet_id`, and strips the link from the visible text (mirroring X's native "link at the end becomes the quote" behaviour).

### Opt-in per instance
Quote-posting requires **X Enterprise API access** (`quote_tweet_id` is not available on Free/Basic/Pro/pay-per-use tiers), so it's gated behind a new **`quote_tweets_enabled`** instance setting, **off by default**. It follows the existing instance-settings pattern:
- `config/instance.php` default (`INSTANCE_QUOTE_TWEETS_ENABLED`)
- `InstanceSettings::quoteTweetsEnabled()` getter (+ `all()`/`update()` shapes)
- `required|boolean` rule in `UpdateInstanceSettingsRequest`
- a toggle on the instance settings admin page, with an Enterprise-tier note

When the setting is **off** (default), a status link is posted verbatim exactly as before.

### Behaviour details
- **Scoped to X only** — extraction/stripping runs inside `XConnector` on its own segment copies, so LinkedIn / Bluesky / etc. keep the link inline.
- **Mutual exclusivity** — `quote_tweet_id` can't coexist with `media` on X, so a segment carrying media leaves the link untouched.
- **Quote-only tweets** — if stripping empties the text, the `text` key is omitted (X rejects `text: ""`).
- Tolerates `www.`/`mobile.` hosts, query strings, and trailing paths.
- Non-`/status/` links (e.g. a profile URL) are never treated as quotes.

## Tests
- `XConnectorTest`: quote+strip, `twitter.com`+query, last-of-many, quote-only omits text, non-status ignored, **disabled-by-default leaves link inline**, media-attached leaves link inline.
- `QuoteTweetSettingUpdateTest`: default off, owner can enable, missing field rejected.
- Existing instance-settings PUT payloads updated for the new required key.
- Full Publishing + instance-settings suites green; Pint, Larastan, tsc, oxlint, oxfmt clean.

## ⚠️ Tier note
On non-Enterprise tiers the API rejects `quote_tweet_id`, which is why this is opt-in. If it's ever enabled on the wrong tier, the request comes back 403 and `XConnector::mapFailure()` already surfaces it as a terminal `Validation` failure with X's own message.