### PR TITLE
feat(compose): Shift+Enter soft newline + platform-accurate blank-line preview

### DIFF
--- a/resources/js/lib/compose/__tests__/platform-newlines.test.ts
+++ b/resources/js/lib/compose/__tests__/platform-newlines.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { collapsePlatformNewlines } from '../platform-newlines';
+
+describe('collapsePlatformNewlines', () => {
+    it('caps X at a single blank line', () => {
+        expect(collapsePlatformNewlines('a\n\n\n\nb', 'x')).toBe('a\n\nb');
+        expect(collapsePlatformNewlines('a\n\n\nb', 'x')).toBe('a\n\nb');
+    });
+
+    it('caps LinkedIn at a single blank line', () => {
+        expect(collapsePlatformNewlines('a\n\n\n\n\nb', 'linkedin')).toBe(
+            'a\n\nb',
+        );
+    });
+
+    it('leaves a single newline and a single blank line untouched', () => {
+        expect(collapsePlatformNewlines('a\nb', 'x')).toBe('a\nb');
+        expect(collapsePlatformNewlines('a\n\nb', 'x')).toBe('a\n\nb');
+        expect(collapsePlatformNewlines('a\nb', 'linkedin')).toBe('a\nb');
+    });
+
+    it('preserves every newline on Bluesky', () => {
+        expect(collapsePlatformNewlines('a\n\n\n\n\nb', 'bluesky')).toBe(
+            'a\n\n\n\n\nb',
+        );
+    });
+
+    it('collapses several separate runs in one post', () => {
+        expect(collapsePlatformNewlines('a\n\n\n\nb\n\n\n\nc', 'x')).toBe(
+            'a\n\nb\n\nc',
+        );
+    });
+});

--- a/resources/js/lib/compose/__tests__/platform-preview.test.ts
+++ b/resources/js/lib/compose/__tests__/platform-preview.test.ts
@@ -108,6 +108,37 @@ describe('buildPlatformPreview', () => {
         ]);
     });
 
+    it('collapses extra blank lines to one in the X preview text but counts the raw body', () => {
+        const preview = buildPlatformPreview({
+            account: { ...account('x'), max_text_length: 280 },
+            segments: ['line one\n\n\n\nline two'],
+            mentions: [],
+            media: [],
+            excludedMediaIds: new Set(),
+            limit: 280,
+            autoSplit: true,
+        });
+
+        // Rendered spacing matches X (one blank line), while the count still
+        // reflects the four transmitted newlines.
+        expect(preview.items[0]?.text).toBe('line one\n\nline two');
+        expect(preview.items[0]?.count).toBe('line one\n\n\n\nline two'.length);
+    });
+
+    it('keeps every blank line in the Bluesky preview text', () => {
+        const preview = buildPlatformPreview({
+            account: { ...account('bluesky'), max_text_length: 300 },
+            segments: ['line one\n\n\n\nline two'],
+            mentions: [],
+            media: [],
+            excludedMediaIds: new Set(),
+            limit: 300,
+            autoSplit: false,
+        });
+
+        expect(preview.items[0]?.text).toBe('line one\n\n\n\nline two');
+    });
+
     it('marks LinkedIn mention display domains as link exclusions', () => {
         const preview = buildPlatformPreview({
             account: account('linkedin'),

--- a/resources/js/lib/compose/platform-newlines.ts
+++ b/resources/js/lib/compose/platform-newlines.ts
@@ -1,0 +1,38 @@
+import type { PlatformName } from '@/types/compose';
+
+/**
+ * The longest run of consecutive newlines each platform preserves when it
+ * *renders* a post. Longer runs are collapsed to this many, so a single blank
+ * line (`\n\n`) is the most vertical spacing X and LinkedIn will show, while
+ * Bluesky renders text verbatim.
+ *
+ * Behaviour confirmed 2026: X collapses runs of line breaks down to a single
+ * blank line; LinkedIn's feed keeps at most one blank line between paragraphs;
+ * Bluesky stores and renders standard newlines untouched. Tune a value here if
+ * a platform changes how it collapses spacing.
+ */
+const MAX_CONSECUTIVE_NEWLINES: Record<PlatformName, number> = {
+    x: 2,
+    linkedin: 2,
+    bluesky: Number.POSITIVE_INFINITY,
+};
+
+/**
+ * Collapse runs of newlines in `text` down to the most the given platform will
+ * actually render, so the composer preview shows the post's spacing as it will
+ * appear once published. Text is returned unchanged for platforms that preserve
+ * newlines verbatim (i.e. an infinite allowance).
+ */
+export function collapsePlatformNewlines(
+    text: string,
+    platform: PlatformName,
+): string {
+    const max = MAX_CONSECUTIVE_NEWLINES[platform];
+    if (!Number.isFinite(max)) {
+        return text;
+    }
+
+    const collapsibleRun = new RegExp(`\\n{${max + 1},}`, 'g');
+
+    return text.replace(collapsibleRun, '\n'.repeat(max));
+}

--- a/resources/js/lib/compose/platform-preview.ts
+++ b/resources/js/lib/compose/platform-preview.ts
@@ -2,6 +2,7 @@ import {
     mentionInputValue,
     replaceMentionTokens,
 } from '@/lib/compose/mentions';
+import { collapsePlatformNewlines } from '@/lib/compose/platform-newlines';
 import { measure, previewSections } from '@/lib/compose/section-split';
 import type {
     Account,
@@ -80,7 +81,9 @@ export function buildPlatformPreview({
         autoSplit,
         items: sections.map((section, index) => ({
             id: `${account.platform}-preview-${index + 1}`,
-            text: section,
+            // Show the spacing the platform will actually render; the character
+            // budget below still measures the raw text that gets transmitted.
+            text: collapsePlatformNewlines(section, account.platform),
             media: index === 0 ? visibleMedia : [],
             count: measure(section, account.platform),
             overLimit: limit > 0 && measure(section, account.platform) > limit,

--- a/resources/js/lib/compose/tiptap/__tests__/section-break.test.ts
+++ b/resources/js/lib/compose/tiptap/__tests__/section-break.test.ts
@@ -1,7 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { getSchema } from '@tiptap/core';
+import { splitBlock } from '@tiptap/pm/commands';
 import type { Node as PMNode } from '@tiptap/pm/model';
+import { EditorState, TextSelection } from '@tiptap/pm/state';
 import { describe, expect, it } from 'vitest';
 
+import { docToSegments } from '@/lib/compose/tiptap-doc';
 import { measureSectionAfterBreak } from '@/lib/compose/tiptap/section-break';
 import { composerExtensions } from '@/lib/compose/tiptap/setup';
 
@@ -54,5 +60,60 @@ describe('measureSectionAfterBreak', () => {
         expect(
             measureSectionAfterBreak(doc, posBeforeChild(doc, 1), 'bluesky'),
         ).toBe(0);
+    });
+});
+
+/** Run the command Shift+Enter is bound to and return the resulting segments. */
+function shiftEnterAt(blocks: object[], cursor: number): string[] {
+    const doc = docFrom(blocks);
+    let state = EditorState.create({
+        schema,
+        doc,
+        selection: TextSelection.create(doc, cursor),
+    });
+
+    splitBlock(state, (tr) => {
+        state = state.apply(tr);
+    });
+
+    return docToSegments(state.doc.toJSON());
+}
+
+describe('Shift+Enter soft newline', () => {
+    it('adds a newline within the post instead of a thread break', () => {
+        // Caret at end of "hello" (pos 6: 1 for doc open + "hello").
+        const segments = shiftEnterAt([para('hello')], 6);
+
+        // One post, a trailing newline — never a second segment.
+        expect(segments).toEqual(['hello\n']);
+    });
+
+    it('makes a blank line inside one post when pressed on an empty line', () => {
+        // "hello" then an empty paragraph; caret in the empty paragraph.
+        const blocks = [para('hello'), para('')];
+        const doc = docFrom(blocks);
+        // Position inside the second (empty) paragraph.
+        const cursor = posBeforeChild(doc, 1) + 1;
+
+        const segments = shiftEnterAt(blocks, cursor);
+
+        // A blank line within the single post — not two threaded posts.
+        expect(segments).toEqual(['hello\n\n']);
+    });
+});
+
+describe('keyboard bindings', () => {
+    it('binds Shift-Enter to a soft newline (splitBlock), not a section break', () => {
+        const source = readFileSync(
+            resolve(
+                process.cwd(),
+                'resources/js/lib/compose/tiptap/section-break.ts',
+            ),
+            'utf8',
+        );
+
+        expect(source).toContain(
+            "'Shift-Enter': () => this.editor.commands.splitBlock()",
+        );
     });
 });

--- a/resources/js/lib/compose/tiptap/section-break.ts
+++ b/resources/js/lib/compose/tiptap/section-break.ts
@@ -75,7 +75,8 @@ declare module '@tiptap/core' {
 
 /**
  * Manual thread-break atom node. Renders as a non-editable `<div data-section-break>`
- * and serializes to the canonical `---` boundary the server-side PostSplitter splits on.
+ * and marks a segment boundary — `docToSegments` ends the current segment here, so
+ * the server-side PostSplitter receives it as an array boundary, not an in-text marker.
  */
 export const SectionBreak = Node.create({
     name: 'sectionBreak',
@@ -241,6 +242,11 @@ export const SectionBreak = Node.create({
                     .focus()
                     .run();
             },
+            // Shift+Enter is the "soft" newline: split the paragraph so the
+            // caret moves to the next line within the same post, without ever
+            // converting to a section break the way an empty-line Enter does.
+            // Two Shift+Enters therefore make a blank line inside one post.
+            'Shift-Enter': () => this.editor.commands.splitBlock(),
             'Mod-Shift-Enter': () => this.editor.commands.insertSectionBreak(),
         };
     },


### PR DESCRIPTION
## What

Two related composer changes:

1. **Shift+Enter is a soft newline** that moves the caret to the next line within the same post and never creates a thread break. Only the empty-line Enter (double-Enter) threads. Two Shift+Enters make a blank line inside one post.
2. **The live preview now renders blank lines the way each platform actually will.** X and LinkedIn collapse runs of line breaks to a single blank line; Bluesky keeps them verbatim.

## Why

Change #1 lets authors add spacing without accidentally threading. But that immediately means they can create multi-blank-line runs — and the preview was showing those verbatim, which misrepresents the result: X and LinkedIn collapse them on render. The preview has to match what publishes.

## How

- `section-break.ts`: bind `Shift-Enter` to `splitBlock()` (a `\n` within the segment, never a `sectionBreak`).
- `platform-newlines.ts` (new): `collapsePlatformNewlines(text, platform)` with a per-platform cap — `x: 2`, `linkedin: 2` (one blank line), `bluesky: ∞` (verbatim). One table to tune if a platform changes.
- `platform-preview.ts`: collapse the **displayed** preview text only; the character `count`/`overLimit` still measures the raw transmitted body (newlines count against the limit even where the platform hides them).
- Fixed a stale doc comment claiming the `sectionBreak` node serializes to a `---` marker (breaks are segment-array boundaries).

## Platform behavior (researched 2026)

- **X** — collapses runs of line breaks down to a single blank line.
- **LinkedIn** — feed keeps at most one blank line between paragraphs (mobile is more aggressive; desktop is the reference here).
- **Bluesky** — stores/renders standard newlines untouched (the blank-line stripping people hit is a bug in *their* web composer's paste, not in rendering).

## Tests

- `platform-newlines.test.ts` — per-platform collapse rules, single newline / single blank line untouched, multiple runs, Bluesky verbatim.
- `platform-preview.test.ts` — X preview text collapses while count stays on the raw body; Bluesky preview keeps every blank line.
- `section-break.test.ts` — Shift+Enter yields a newline not a thread break; two of them make a blank line in one post; source-binding assertion.

Verified at the ProseMirror-state / pure-function level because the vitest env is `node` (no DOM).

## Notes / scope

- The collapse is applied to the **composer live preview** only. The public share page and published-post view render server-provided `sections` and aren't touched here — say the word if you want the same normalization pushed server-side (touches `PostSplitter` + parity fixtures).
- Blank lines still count toward the character limit (they are transmitted). If you'd rather also strip them before publish to reclaim budget, that's a separate follow-up.
- ⚠️ Needs a browser eyeball: Shift+Enter → new line with no thread chip, and an X/LinkedIn preview with 3+ blank lines showing only one.