### PR TITLE
feat(compose): emoji browser (Frimousse picker + inline :shortcode typeahead)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /public/fonts-manifest.dev.json
 /public/hot
 /public/storage
+/public/emoji
 /storage/*.key
 /storage/pail
 /resources/js/actions

--- a/README.md
+++ b/README.md
@@ -164,7 +164,10 @@ The CSP is intentionally **not** sent in `local` (`APP_ENV=local`) because it is
 
 ## Connecting your accounts
 
-**Bluesky** needs nothing extra — users connect with a Bluesky [app password](https://bsky.app/settings/app-passwords).
+**Bluesky** connects two ways, and neither needs you to register a developer app:
+
+- **OAuth (recommended)** — users sign in on Bluesky and authorize Shoutrrr without handing over a password. It's zero-config: Shoutrrr publishes an [ATProto OAuth](https://atproto.com/specs/oauth) client-metadata document at `${APP_URL}/oauth/bluesky/client-metadata.json` (with keys at `${APP_URL}/oauth/bluesky/jwks.json`), and Bluesky's authorization server fetches those to identify your instance. The signing key is generated once and stored encrypted — there's nothing to add to `.env`. **The one requirement:** `APP_URL` must be a public HTTPS URL, because Bluesky has to reach those two documents over the internet. (In `local` dev, Shoutrrr falls back to a loopback client so OAuth still works on `localhost`.)
+- **App password** — users paste a Bluesky [app password](https://bsky.app/settings/app-passwords). No setup, and it works anywhere — including private or LAN deployments Bluesky can't reach for OAuth.
 
 **X** and **LinkedIn** publish through your own developer app, so you'll register one with each provider and add the credentials to `.env`. The redirect URIs must match what you register (they default to `${APP_URL}/...`):
 

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,8 @@
         "concurrently": "^9.0.1",
         "date-fns": "^4.4.0",
         "dayjs": "^1.11.21",
+        "emojibase-data": "^17.0.0",
+        "frimousse": "^0.3.0",
         "globals": "^15.14.0",
         "html-to-image": "^1.11.13",
         "input-otp": "^1.4.2",
@@ -781,6 +783,10 @@
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "emojibase": ["emojibase@17.0.0", "", {}, "sha512-bXdpf4HPY3p41zK5swVKZdC/VynsMZ4LoLxdYDE+GucqkFwzcM1GVc4ODfYAlwoKaf2U2oNNUoOO78N96ovpBA=="],
+
+    "emojibase-data": ["emojibase-data@17.0.0", "", { "peerDependencies": { "emojibase": "*" } }, "sha512-Yvgb5AWoHViHV/gq1qr5ZAarcBip+B27/ZLRsUJkbgAEaLlZ/fof9g882LTpmEpyhBNEC0m2SEmItljHsTygjA=="],
+
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.22.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag=="],
@@ -852,6 +858,8 @@
     "framer-motion": ["framer-motion@12.40.0", "", { "dependencies": { "motion-dom": "^12.40.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "frimousse": ["frimousse@0.3.0", "", { "peerDependencies": { "react": "^18 || ^19", "typescript": ">=5.1.0" }, "optionalPeers": ["typescript"] }, "sha512-kO6LMoKY/cLAYEhXXtqLRaLIE6L/DagpFPrUZaLv3LsUa1/8Iza3HhwZcgN8eZ+weXnhv69eoclNUPohcCa/IQ=="],
 
     "fs-extra": ["fs-extra@11.3.5", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
         "concurrently": "^9.0.1",
         "date-fns": "^4.4.0",
         "dayjs": "^1.11.21",
+        "emojibase-data": "^17.0.0",
+        "frimousse": "^0.3.0",
         "globals": "^15.14.0",
         "html-to-image": "^1.11.13",
         "input-otp": "^1.4.2",

--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -115,13 +115,6 @@ export function ComposerToolbar({
                         }}
                     />
 
-                    <EmojiPopover
-                        recents={emojiRecents}
-                        skinTone={emojiSkinTone}
-                        onSkinToneChange={onEmojiSkinToneChange}
-                        onSelect={onInsertEmoji}
-                    />
-
                     <EToolButton
                         title="Add media (⌘⇧M)"
                         onClick={() => input.current?.click()}
@@ -178,6 +171,15 @@ export function ComposerToolbar({
                         <span>Auto-split</span>
                     </EToolButton>
                 </>
+            )}
+
+            {!readOnly && (
+                <EmojiPopover
+                    recents={emojiRecents}
+                    skinTone={emojiSkinTone}
+                    onSkinToneChange={onEmojiSkinToneChange}
+                    onSelect={onInsertEmoji}
+                />
             )}
         </div>
     );
@@ -246,7 +248,7 @@ function EmojiPopover({
                 <PopoverPrimitive.Portal forceMount>
                     <PopoverPrimitive.Content
                         forceMount
-                        align="start"
+                        align="end"
                         side="top"
                         sideOffset={8}
                         onOpenAutoFocus={(event) => event.preventDefault()}

--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -252,12 +252,16 @@ function EmojiPopover({
                         onOpenAutoFocus={(event) => event.preventDefault()}
                         className={cn(
                             'z-50 w-[336px] overflow-hidden rounded-2xl bg-popover text-popover-foreground shadow-lg ring-1 ring-foreground/5 outline-hidden dark:ring-foreground/10',
-                            // No enter/exit animation: this popover wraps a heavy
-                            // virtualized emoji grid, and scale/opacity-animating that
-                            // subtree is what felt laggy. Kept mounted (forceMount) and
-                            // toggled with `invisible` (preserves Frimousse's measured
-                            // width) so open + select-to-close are both instant.
-                            'data-[state=closed]:pointer-events-none data-[state=closed]:invisible',
+                            // Same fade+zoom feel as the notification bell, but driven
+                            // by a CSS transition instead of Radix's keyframe animate-in/
+                            // -out. The picker is forceMounted (kept warm) and prewarmed
+                            // while closed, so a keyframe `animate-out` would flash it on
+                            // that first hidden mount; a transition only runs on real
+                            // state changes. opacity/transform are GPU-composited, so it
+                            // stays smooth on the heavy virtualized grid.
+                            'origin-(--radix-popover-content-transform-origin) transition-[opacity,transform] duration-100 ease-out',
+                            'data-[state=open]:scale-100 data-[state=open]:opacity-100',
+                            'data-[state=closed]:pointer-events-none data-[state=closed]:scale-95 data-[state=closed]:opacity-0',
                         )}
                     >
                         <EmojiPicker

--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -195,17 +195,35 @@ function EmojiPopover({
     onSelect: (emoji: string) => void;
 }) {
     const [open, setOpen] = useState(false);
-    // Mount the picker on first open and keep it alive afterward. Frimousse
-    // re-reads and re-parses the ~775KB emoji dataset and rebuilds its store on
-    // every fresh mount, so unmounting on close (Radix's default) made each
-    // reopen — and the selection that closes it — feel sluggish. `forceMount`
-    // keeps it warm; we hide it with `invisible` (not unmount) when closed.
+    // Mount the picker once and keep it alive. Frimousse re-reads and re-parses
+    // the ~775KB emoji dataset and rebuilds its store on every fresh mount, so
+    // unmounting on close (Radix's default) made each reopen — and the select
+    // that closes it — sluggish. We warm it during browser idle (never on the
+    // click, which the parse would block) and `forceMount` keeps it alive; when
+    // closed it's hidden with `invisible`, not unmounted.
     const [mounted, setMounted] = useState(false);
     useEffect(() => {
+        if (mounted) {
+            return;
+        }
         if (open) {
             setMounted(true);
+
+            return;
         }
-    }, [open]);
+        const idle = window as Window & {
+            requestIdleCallback?: (callback: () => void) => number;
+            cancelIdleCallback?: (handle: number) => void;
+        };
+        if (typeof idle.requestIdleCallback === 'function') {
+            const handle = idle.requestIdleCallback(() => setMounted(true));
+
+            return () => idle.cancelIdleCallback?.(handle);
+        }
+        const handle = window.setTimeout(() => setMounted(true), 500);
+
+        return () => window.clearTimeout(handle);
+    }, [mounted, open]);
 
     return (
         <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
@@ -214,10 +232,6 @@ function EmojiPopover({
                     type="button"
                     title="Emoji"
                     data-active={open}
-                    // Warm the picker the moment the user shows intent, so the
-                    // first open is instant instead of paying the mount cost then.
-                    onPointerEnter={() => setMounted(true)}
-                    onFocus={() => setMounted(true)}
                     className={cn(
                         'inline-flex h-8 items-center gap-1.5 rounded-md border border-transparent bg-transparent px-2.5 text-[12px] text-muted-foreground transition-colors sm:h-7',
                         'hover:border-border hover:bg-background hover:text-foreground',
@@ -237,12 +251,12 @@ function EmojiPopover({
                         sideOffset={8}
                         onOpenAutoFocus={(event) => event.preventDefault()}
                         className={cn(
-                            'z-50 w-[336px] origin-(--radix-popover-content-transform-origin) overflow-hidden rounded-2xl bg-popover text-popover-foreground shadow-lg ring-1 ring-foreground/5 outline-hidden dark:ring-foreground/10',
-                            'duration-100 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
-                            // Kept mounted: hide (not unmount) when closed.
-                            // `invisible` preserves the element's box so Frimousse
-                            // keeps its measured width, and the instant hide makes
-                            // selecting feel snappy.
+                            'z-50 w-[336px] overflow-hidden rounded-2xl bg-popover text-popover-foreground shadow-lg ring-1 ring-foreground/5 outline-hidden dark:ring-foreground/10',
+                            // No enter/exit animation: this popover wraps a heavy
+                            // virtualized emoji grid, and scale/opacity-animating that
+                            // subtree is what felt laggy. Kept mounted (forceMount) and
+                            // toggled with `invisible` (preserves Frimousse's measured
+                            // width) so open + select-to-close are both instant.
                             'data-[state=closed]:pointer-events-none data-[state=closed]:invisible',
                         )}
                     >

--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -1,13 +1,9 @@
 import { Image as ImageIcon, Shuffle, Smile, Split } from 'lucide-react';
+import { Popover as PopoverPrimitive } from 'radix-ui';
 import type { ReactNode } from 'react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import EmojiPicker from '@/components/compose/emoji-picker';
-import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-} from '@/components/ui/popover';
 import type { EmojiSkinTone } from '@/lib/compose/emoji/types';
 import { cn } from '@/lib/utils';
 import type { MediaView, PendingUpload, PlatformName } from '@/types/compose';
@@ -199,14 +195,29 @@ function EmojiPopover({
     onSelect: (emoji: string) => void;
 }) {
     const [open, setOpen] = useState(false);
+    // Mount the picker on first open and keep it alive afterward. Frimousse
+    // re-reads and re-parses the ~775KB emoji dataset and rebuilds its store on
+    // every fresh mount, so unmounting on close (Radix's default) made each
+    // reopen — and the selection that closes it — feel sluggish. `forceMount`
+    // keeps it warm; we hide it with `invisible` (not unmount) when closed.
+    const [mounted, setMounted] = useState(false);
+    useEffect(() => {
+        if (open) {
+            setMounted(true);
+        }
+    }, [open]);
 
     return (
-        <Popover open={open} onOpenChange={setOpen}>
-            <PopoverTrigger asChild>
+        <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+            <PopoverPrimitive.Trigger asChild>
                 <button
                     type="button"
                     title="Emoji"
                     data-active={open}
+                    // Warm the picker the moment the user shows intent, so the
+                    // first open is instant instead of paying the mount cost then.
+                    onPointerEnter={() => setMounted(true)}
+                    onFocus={() => setMounted(true)}
                     className={cn(
                         'inline-flex h-8 items-center gap-1.5 rounded-md border border-transparent bg-transparent px-2.5 text-[12px] text-muted-foreground transition-colors sm:h-7',
                         'hover:border-border hover:bg-background hover:text-foreground',
@@ -216,25 +227,38 @@ function EmojiPopover({
                     <Smile className="size-3.5" aria-hidden="true" />
                     <span>Emoji</span>
                 </button>
-            </PopoverTrigger>
-            <PopoverContent
-                align="start"
-                side="top"
-                sideOffset={8}
-                className="w-[336px] overflow-hidden rounded-2xl p-0"
-                onOpenAutoFocus={(event) => event.preventDefault()}
-            >
-                <EmojiPicker
-                    recents={recents}
-                    skinTone={skinTone}
-                    onSkinToneChange={onSkinToneChange}
-                    onSelect={(emoji) => {
-                        onSelect(emoji);
-                        setOpen(false);
-                    }}
-                />
-            </PopoverContent>
-        </Popover>
+            </PopoverPrimitive.Trigger>
+            {mounted && (
+                <PopoverPrimitive.Portal forceMount>
+                    <PopoverPrimitive.Content
+                        forceMount
+                        align="start"
+                        side="top"
+                        sideOffset={8}
+                        onOpenAutoFocus={(event) => event.preventDefault()}
+                        className={cn(
+                            'z-50 w-[336px] origin-(--radix-popover-content-transform-origin) overflow-hidden rounded-2xl bg-popover text-popover-foreground shadow-lg ring-1 ring-foreground/5 outline-hidden dark:ring-foreground/10',
+                            'duration-100 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+                            // Kept mounted: hide (not unmount) when closed.
+                            // `invisible` preserves the element's box so Frimousse
+                            // keeps its measured width, and the instant hide makes
+                            // selecting feel snappy.
+                            'data-[state=closed]:pointer-events-none data-[state=closed]:invisible',
+                        )}
+                    >
+                        <EmojiPicker
+                            recents={recents}
+                            skinTone={skinTone}
+                            onSkinToneChange={onSkinToneChange}
+                            onSelect={(emoji) => {
+                                onSelect(emoji);
+                                setOpen(false);
+                            }}
+                        />
+                    </PopoverPrimitive.Content>
+                </PopoverPrimitive.Portal>
+            )}
+        </PopoverPrimitive.Root>
     );
 }
 

--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -221,7 +221,7 @@ function EmojiPopover({
                 align="start"
                 side="top"
                 sideOffset={8}
-                className="w-auto overflow-hidden rounded-2xl p-0"
+                className="w-[336px] overflow-hidden rounded-2xl p-0"
                 onOpenAutoFocus={(event) => event.preventDefault()}
             >
                 <EmojiPicker

--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -237,7 +237,7 @@ function EmojiPopover({
                     className={cn(
                         'inline-flex h-8 items-center gap-1.5 rounded-md border border-transparent bg-transparent px-2.5 text-[12px] text-muted-foreground transition-colors sm:h-7',
                         'hover:border-border hover:bg-background hover:text-foreground',
-                        'data-[active=true]:border-border data-[active=true]:bg-background data-[active=true]:text-foreground',
+                        'data-[active=true]:border-border data-[active=true]:bg-background data-[active=true]:text-foreground data-[active=true]:shadow-[0_1px_2px_0_rgb(0_0_0/0.04)]',
                     )}
                 >
                     <Smile className="size-3.5" aria-hidden="true" />

--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -1,7 +1,14 @@
-import { Image as ImageIcon, Shuffle, Split } from 'lucide-react';
+import { Image as ImageIcon, Shuffle, Smile, Split } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
+import EmojiPicker from '@/components/compose/emoji-picker';
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover';
+import type { EmojiSkinTone } from '@/lib/compose/emoji/types';
 import { cn } from '@/lib/utils';
 import type { MediaView, PendingUpload, PlatformName } from '@/types/compose';
 
@@ -33,6 +40,12 @@ type Props = {
     onImageClick?: (mediaId: string) => void;
     /** Click a video chip's Edit button to open the video editor. */
     onVideoClick?: (mediaId: string) => void;
+    /** Insert a chosen emoji at the editor caret. */
+    onInsertEmoji: (emoji: string) => void;
+    /** Recently-used emoji, newest first. */
+    emojiRecents: string[];
+    emojiSkinTone: EmojiSkinTone;
+    onEmojiSkinToneChange: (tone: EmojiSkinTone) => void;
 };
 
 export function ComposerToolbar({
@@ -53,6 +66,10 @@ export function ComposerToolbar({
     dismissPending,
     onImageClick,
     onVideoClick,
+    onInsertEmoji,
+    emojiRecents,
+    emojiSkinTone,
+    onEmojiSkinToneChange,
 }: Props) {
     const input = useRef<HTMLInputElement | null>(null);
 
@@ -114,6 +131,13 @@ export function ComposerToolbar({
                             </span>
                         )}
                     </EToolButton>
+
+                    <EmojiPopover
+                        recents={emojiRecents}
+                        skinTone={emojiSkinTone}
+                        onSkinToneChange={onEmojiSkinToneChange}
+                        onSelect={onInsertEmoji}
+                    />
                 </>
             )}
 
@@ -160,6 +184,57 @@ export function ComposerToolbar({
                 </>
             )}
         </div>
+    );
+}
+
+function EmojiPopover({
+    recents,
+    skinTone,
+    onSkinToneChange,
+    onSelect,
+}: {
+    recents: string[];
+    skinTone: EmojiSkinTone;
+    onSkinToneChange: (tone: EmojiSkinTone) => void;
+    onSelect: (emoji: string) => void;
+}) {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+                <button
+                    type="button"
+                    title="Emoji"
+                    data-active={open}
+                    className={cn(
+                        'inline-flex h-8 items-center gap-1.5 rounded-md border border-transparent bg-transparent px-2.5 text-[12px] text-muted-foreground transition-colors sm:h-7',
+                        'hover:border-border hover:bg-background hover:text-foreground',
+                        'data-[active=true]:border-border data-[active=true]:bg-background data-[active=true]:text-foreground',
+                    )}
+                >
+                    <Smile className="size-3.5" aria-hidden="true" />
+                    <span>Emoji</span>
+                </button>
+            </PopoverTrigger>
+            <PopoverContent
+                align="start"
+                side="top"
+                sideOffset={8}
+                className="w-auto overflow-hidden rounded-2xl p-0"
+                onOpenAutoFocus={(event) => event.preventDefault()}
+            >
+                <EmojiPicker
+                    recents={recents}
+                    skinTone={skinTone}
+                    onSkinToneChange={onSkinToneChange}
+                    onSelect={(emoji) => {
+                        onSelect(emoji);
+                        setOpen(false);
+                    }}
+                />
+            </PopoverContent>
+        </Popover>
     );
 }
 

--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -115,6 +115,13 @@ export function ComposerToolbar({
                         }}
                     />
 
+                    <EmojiPopover
+                        recents={emojiRecents}
+                        skinTone={emojiSkinTone}
+                        onSkinToneChange={onEmojiSkinToneChange}
+                        onSelect={onInsertEmoji}
+                    />
+
                     <EToolButton
                         title="Add media (⌘⇧M)"
                         onClick={() => input.current?.click()}
@@ -127,13 +134,6 @@ export function ComposerToolbar({
                             </span>
                         )}
                     </EToolButton>
-
-                    <EmojiPopover
-                        recents={emojiRecents}
-                        skinTone={emojiSkinTone}
-                        onSkinToneChange={onEmojiSkinToneChange}
-                        onSelect={onInsertEmoji}
-                    />
                 </>
             )}
 

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -859,6 +859,8 @@ export default function Composer({
                     onMentionsChange={(mentions) =>
                         dispatch({ type: 'setMentions', mentions })
                     }
+                    emojiSkinTone={emojiPrefs.skinTone}
+                    onEmojiInsert={emojiPrefs.addRecent}
                     markerState={
                         activeAccount
                             ? {

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 
 import WorkspaceMentionController from '@/actions/App/Http/Controllers/WorkspaceMentionController';
 import { useAutosave } from '@/hooks/compose/use-autosave';
+import { useEmojiPreferences } from '@/hooks/compose/use-emoji-preferences';
 import { useImageEditor } from '@/hooks/compose/use-image-editor';
 import { useMediaUploads } from '@/hooks/compose/use-media-uploads';
 import { useNextSlot } from '@/hooks/compose/use-next-slot';
@@ -54,7 +55,7 @@ import CharCounter from './char-counter';
 import { ComposerToolbar } from './composer-toolbar';
 import { ConflictDialog } from './conflict-dialog';
 import DestinationSelector from './destination-selector';
-import EditorBody from './editor-body';
+import EditorBody, { type EditorBodyHandle } from './editor-body';
 import { ImageEditor } from './image-editor';
 import { PlatformPreviewPanel } from './platform-preview-panel';
 import PlatformTabs from './platform-tabs';
@@ -245,6 +246,16 @@ export default function Composer({
             }
         },
     });
+
+    // The toolbar's Emoji picker inserts through this handle so it reaches the
+    // editor's live selection without lifting TipTap state into the reducer.
+    const editorRef = useRef<EditorBodyHandle>(null);
+    const emojiPrefs = useEmojiPreferences();
+
+    function insertEmoji(emoji: string) {
+        editorRef.current?.insertText(emoji);
+        emojiPrefs.addRecent(emoji);
+    }
 
     // The editor opens automatically when image(s) are added and when an attached
     // image is clicked. A multi-image add becomes a `batch` edited one item at a
@@ -822,6 +833,7 @@ export default function Composer({
 
                 {/* Override banner (inside EditorBody) + editor */}
                 <EditorBody
+                    ref={editorRef}
                     value={activeSegments}
                     onChange={handleSegments}
                     onBlur={flush}
@@ -899,6 +911,10 @@ export default function Composer({
                 {(!readOnly || state.media.length > 0) && (
                     <ComposerToolbar
                         readOnly={readOnly}
+                        onInsertEmoji={insertEmoji}
+                        emojiRecents={emojiPrefs.recents}
+                        emojiSkinTone={emojiPrefs.skinTone}
+                        onEmojiSkinToneChange={emojiPrefs.setSkinTone}
                         activePlatform={activeAccount?.platform}
                         autoSplit={
                             activeAccount

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -155,6 +155,10 @@ function EditorBodyInner(
     // below. A zero-size anchor (mirroring the mention pattern) floats the
     // typeahead popover beside the active `:query`.
     const emojiAnchorRef = useRef<HTMLDivElement>(null);
+    // Read live by the emojiSuggest plugin's handleKeyDown so key consumption
+    // (Enter/Tab/Arrows/Escape) is gated on the popover actually being open,
+    // not merely on a `:token` trigger being active — see emojiPopoverOpen.
+    const emojiPopoverOpenRef = useRef(false);
     const [emojiSuggest, setEmojiSuggest] = useState<EmojiSuggestState>({
         active: false,
         query: '',
@@ -181,7 +185,10 @@ function EditorBodyInner(
     const onPasteFilesRef = useRef(onPasteFiles);
     onPasteFilesRef.current = onPasteFiles;
     const editor = useEditor({
-        extensions: composerExtensions({ placeholder }),
+        extensions: composerExtensions({
+            placeholder,
+            emojiOpenRef: emojiPopoverOpenRef,
+        }),
         content: segmentsToDoc(value) as object,
         editable,
         editorProps: {
@@ -471,6 +478,16 @@ function EditorBodyInner(
             ? mentionPlatforms
             : ([markerPlatform ?? 'x'] as PlatformName[]);
 
+    // Mirrored into a ref (read live by the emojiSuggest plugin's
+    // handleKeyDown) so key consumption tracks the popover's actual open
+    // state, not just an active `:token` trigger.
+    const emojiPopoverOpen =
+        editable &&
+        emojiSuggest.active &&
+        !emojiDismissed.current &&
+        emojiMatches.length > 0;
+    emojiPopoverOpenRef.current = emojiPopoverOpen;
+
     // Place the floating anchor at the active `@` only on the open transition.
     // The `@` does not move as the name is typed into the picker, so positioning
     // once keeps the popover put; re-running on every keystroke would needlessly
@@ -638,14 +655,7 @@ function EditorBodyInner(
                     </PopoverContent>
                 )}
             </Popover>
-            <Popover
-                open={
-                    editable &&
-                    emojiSuggest.active &&
-                    !emojiDismissed.current &&
-                    emojiMatches.length > 0
-                }
-            >
+            <Popover open={emojiPopoverOpen}>
                 <PopoverAnchor asChild>
                     <div
                         ref={emojiAnchorRef}

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -9,25 +9,21 @@ import {
     useState,
 } from 'react';
 
-import EmojiSuggestList from '@/components/compose/emoji-suggest-list';
+import EmojiSuggestPopover from '@/components/compose/emoji-suggest-popover';
 import MentionPicker from '@/components/compose/mention-picker';
 import {
     Popover,
     PopoverAnchor,
     PopoverContent,
 } from '@/components/ui/popover';
-import { loadEmojiIndex, rankEmoji } from '@/lib/compose/emoji/shortcode-index';
-import type { EmojiMatch, EmojiSkinTone } from '@/lib/compose/emoji/types';
+import { useEmojiTypeahead } from '@/hooks/compose/use-emoji-typeahead';
+import type { EmojiSkinTone } from '@/lib/compose/emoji/types';
 import { mentionInputValue, updateMentionName } from '@/lib/compose/mentions';
 import {
     docToSegments,
     segmentsToDoc,
     type DocNode,
 } from '@/lib/compose/tiptap-doc';
-import {
-    emojiSuggestKey,
-    type EmojiSuggestState,
-} from '@/lib/compose/tiptap/emoji-suggest';
 import {
     editorContainsMentionLabel,
     findMentionLabelStart,
@@ -151,51 +147,20 @@ function EditorBodyInner(
     const mentionAnchorRef = useRef<HTMLDivElement>(null);
     const mentionWasActive = useRef(false);
     const [mentionAnchorReady, setMentionAnchorReady] = useState(false);
-    // Mirrors the emojiSuggest plugin's trigger state; see the `sync` effect
-    // below. A zero-size anchor (mirroring the mention pattern) floats the
-    // typeahead popover beside the active `:query`.
-    const emojiAnchorRef = useRef<HTMLDivElement>(null);
-    // Read live by the emojiSuggest plugin's handleKeyDown so key consumption
-    // (Enter/Tab/Arrows/Escape) is gated on the popover actually being open,
-    // not merely on a `:token` trigger being active — see emojiPopoverOpen.
-    const emojiPopoverOpenRef = useRef(false);
-    const [emojiSuggest, setEmojiSuggest] = useState<EmojiSuggestState>({
-        active: false,
-        query: '',
-        from: 0,
-        to: 0,
-    });
-    const [emojiMatches, setEmojiMatches] = useState<EmojiMatch[]>([]);
-    const [emojiActiveIndex, setEmojiActiveIndex] = useState(0);
-    // Whether the user dismissed the typeahead (Escape / clicked away) for the
-    // current `:query`. State (not a ref) so `emojiPopoverOpen` is derived from
-    // it without reading a mutable ref during render.
-    const [emojiDismissed, setEmojiDismissed] = useState(false);
-    // Read by the CustomEvent handlers, which capture stale state otherwise.
-    const emojiLatest = useRef({
-        suggest: emojiSuggest,
-        matches: emojiMatches,
-        index: emojiActiveIndex,
-    });
-    emojiLatest.current = {
-        suggest: emojiSuggest,
-        matches: emojiMatches,
-        index: emojiActiveIndex,
-    };
+    // Written live by useEmojiTypeahead and read by the emojiSuggest plugin's
+    // handleKeyDown so key consumption is gated on the popover actually being
+    // open. Created here because composerExtensions needs it before the editor
+    // exists, and the hook needs the editor after — one shared ref bridges them.
+    const emojiOpenRef = useRef(false);
     // editorProps is captured once at editor creation, but onPasteFiles is a
     // fresh closure each render (it reads the current media/limits). Route through
     // a ref so handlePaste always enforces the latest one-video / no-mixing rule.
     const onPasteFilesRef = useRef(onPasteFiles);
     onPasteFilesRef.current = onPasteFiles;
-    // Same reason as onPasteFilesRef: the CustomEvent commit handler is bound
-    // once per editor, so it must read the latest onEmojiInsert (addRecent
-    // changes identity across renders) through a ref, not a render closure.
-    const onEmojiInsertRef = useRef(onEmojiInsert);
-    onEmojiInsertRef.current = onEmojiInsert;
     const editor = useEditor({
         extensions: composerExtensions({
             placeholder,
-            emojiOpenRef: emojiPopoverOpenRef,
+            emojiOpenRef,
         }),
         content: segmentsToDoc(value) as object,
         editable,
@@ -214,6 +179,15 @@ function EditorBodyInner(
         onUpdate: ({ editor }) =>
             onChange(docToSegments(editor.getJSON() as DocNode)),
         onBlur,
+    });
+
+    const emoji = useEmojiTypeahead({
+        editor,
+        containerRef,
+        openRef: emojiOpenRef,
+        skinTone: emojiSkinTone,
+        editable,
+        onInsert: onEmojiInsert,
     });
 
     useImperativeHandle(
@@ -314,134 +288,6 @@ function EditorBodyInner(
         });
     }, [editor, markerPlatform, markerAutoSplit, markerLimit, markerThreadMax]);
 
-    // Mirror the emojiSuggest plugin's trigger state into React on every
-    // transaction (mirrors the section-markers → React bridge above).
-    useEffect(() => {
-        if (!editor) {
-            return;
-        }
-        function sync() {
-            setEmojiSuggest(
-                emojiSuggestKey.getState(editor.state) ?? {
-                    active: false,
-                    query: '',
-                    from: 0,
-                    to: 0,
-                },
-            );
-        }
-        editor.on('transaction', sync);
-        sync();
-
-        return () => {
-            editor.off('transaction', sync);
-        };
-    }, [editor]);
-
-    // Fetch + rank matches when the query changes. A new query always clears
-    // any prior dismissal, so re-typing after Escape reopens the popover.
-    useEffect(() => {
-        if (!emojiSuggest.active) {
-            setEmojiMatches([]);
-
-            return;
-        }
-        setEmojiDismissed(false);
-        let cancelled = false;
-        loadEmojiIndex()
-            .then((index) => {
-                if (cancelled) {
-                    return;
-                }
-                setEmojiMatches(
-                    rankEmoji(index, emojiSuggest.query, {
-                        skinTone: emojiSkinTone,
-                    }),
-                );
-                setEmojiActiveIndex(0);
-            })
-            .catch(() => {
-                if (!cancelled) {
-                    setEmojiMatches([]);
-                }
-            });
-
-        return () => {
-            cancelled = true;
-        };
-    }, [emojiSuggest.active, emojiSuggest.query, emojiSkinTone]);
-
-    // Replace the active `:query` with the chosen emoji and refocus.
-    function insertEmojiAt(match: EmojiMatch, from: number, to: number) {
-        if (!editor) {
-            return;
-        }
-        editor
-            .chain()
-            .focus()
-            .insertContentAt({ from, to }, `${match.emoji} `)
-            .run();
-        onEmojiInsertRef.current?.(match.emoji);
-    }
-
-    // Bridge the plugin's keyboard-forwarded CustomEvents to the typeahead's
-    // React state. Reads from `emojiLatest` (not the render's closed-over
-    // state) since these handlers are registered once per editor instance.
-    useEffect(() => {
-        const element = editor?.view.dom;
-        if (!element) {
-            return;
-        }
-
-        function onNav(event: Event) {
-            const delta = (event as CustomEvent<{ delta: number }>).detail
-                .delta;
-            const count = emojiLatest.current.matches.length;
-            if (count === 0) {
-                return;
-            }
-            setEmojiActiveIndex((index) => (index + delta + count) % count);
-        }
-
-        function onCommit() {
-            const { suggest, matches, index } = emojiLatest.current;
-            const match = matches[index];
-            if (match) {
-                insertEmojiAt(match, suggest.from, suggest.to);
-            }
-        }
-
-        function onDismiss() {
-            setEmojiDismissed(true);
-        }
-
-        element.addEventListener('composer:emoji-nav', onNav);
-        element.addEventListener('composer:emoji-commit', onCommit);
-        element.addEventListener('composer:emoji-dismiss', onDismiss);
-
-        return () => {
-            element.removeEventListener('composer:emoji-nav', onNav);
-            element.removeEventListener('composer:emoji-commit', onCommit);
-            element.removeEventListener('composer:emoji-dismiss', onDismiss);
-        };
-        // oxlint-disable-next-line react-hooks/exhaustive-deps
-    }, [editor]);
-
-    // Position the floating anchor at the start of the active `:query` so the
-    // popover tracks the caret (reuses positionMentionAnchor's coord logic).
-    useEffect(() => {
-        const container = containerRef.current;
-        const anchor = emojiAnchorRef.current;
-        if (!editor || !emojiSuggest.active || !container || !anchor) {
-            return;
-        }
-        const caret = editor.view.coordsAtPos(emojiSuggest.from);
-        const rect = container.getBoundingClientRect();
-        anchor.style.left = `${caret.left - rect.left}px`;
-        anchor.style.top = `${caret.top - rect.top}px`;
-        anchor.style.height = `${caret.bottom - caret.top}px`;
-    }, [editor, emojiSuggest.active, emojiSuggest.from]);
-
     useEffect(() => {
         const element = editor?.view.dom;
         if (!element) {
@@ -484,16 +330,6 @@ function EditorBodyInner(
         mentionPlatforms.length > 0
             ? mentionPlatforms
             : ([markerPlatform ?? 'x'] as PlatformName[]);
-
-    // Mirrored into a ref (read live by the emojiSuggest plugin's
-    // handleKeyDown) so key consumption tracks the popover's actual open
-    // state, not just an active `:token` trigger.
-    const emojiPopoverOpen =
-        editable &&
-        emojiSuggest.active &&
-        !emojiDismissed &&
-        emojiMatches.length > 0;
-    emojiPopoverOpenRef.current = emojiPopoverOpen;
 
     // Place the floating anchor at the active `@` only on the open transition.
     // The `@` does not move as the name is typed into the picker, so positioning
@@ -662,45 +498,14 @@ function EditorBodyInner(
                     </PopoverContent>
                 )}
             </Popover>
-            <Popover
-                open={emojiPopoverOpen}
-                onOpenChange={(open) => {
-                    if (!open) {
-                        setEmojiDismissed(true);
-                    }
-                }}
-            >
-                <PopoverAnchor asChild>
-                    <div
-                        ref={emojiAnchorRef}
-                        aria-hidden
-                        className="pointer-events-none absolute w-0"
-                    />
-                </PopoverAnchor>
-                <PopoverContent
-                    align="start"
-                    side="bottom"
-                    sideOffset={8}
-                    className="w-auto rounded-xl p-0"
-                    onOpenAutoFocus={(event) => event.preventDefault()}
-                    // Focus stays in the editor while the typeahead is open, so a
-                    // focus-outside must not dismiss it — only Escape or a pointer
-                    // click away (both routed through onOpenChange) should.
-                    onFocusOutside={(event) => event.preventDefault()}
-                >
-                    <EmojiSuggestList
-                        matches={emojiMatches}
-                        activeIndex={emojiActiveIndex}
-                        onSelect={(match) =>
-                            insertEmojiAt(
-                                match,
-                                emojiLatest.current.suggest.from,
-                                emojiLatest.current.suggest.to,
-                            )
-                        }
-                    />
-                </PopoverContent>
-            </Popover>
+            <EmojiSuggestPopover
+                open={emoji.open}
+                onDismiss={emoji.dismiss}
+                anchorRef={emoji.anchorRef}
+                matches={emoji.matches}
+                activeIndex={emoji.activeIndex}
+                onSelect={emoji.select}
+            />
             <div className="px-4 pt-[22px] pb-[18px] sm:px-[26px]">
                 <EditorContent
                     editor={editor}

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -167,7 +167,10 @@ function EditorBodyInner(
     });
     const [emojiMatches, setEmojiMatches] = useState<EmojiMatch[]>([]);
     const [emojiActiveIndex, setEmojiActiveIndex] = useState(0);
-    const emojiDismissed = useRef(false);
+    // Whether the user dismissed the typeahead (Escape / clicked away) for the
+    // current `:query`. State (not a ref) so `emojiPopoverOpen` is derived from
+    // it without reading a mutable ref during render.
+    const [emojiDismissed, setEmojiDismissed] = useState(false);
     // Read by the CustomEvent handlers, which capture stale state otherwise.
     const emojiLatest = useRef({
         suggest: emojiSuggest,
@@ -184,6 +187,11 @@ function EditorBodyInner(
     // a ref so handlePaste always enforces the latest one-video / no-mixing rule.
     const onPasteFilesRef = useRef(onPasteFiles);
     onPasteFilesRef.current = onPasteFiles;
+    // Same reason as onPasteFilesRef: the CustomEvent commit handler is bound
+    // once per editor, so it must read the latest onEmojiInsert (addRecent
+    // changes identity across renders) through a ref, not a render closure.
+    const onEmojiInsertRef = useRef(onEmojiInsert);
+    onEmojiInsertRef.current = onEmojiInsert;
     const editor = useEditor({
         extensions: composerExtensions({
             placeholder,
@@ -338,7 +346,7 @@ function EditorBodyInner(
 
             return;
         }
-        emojiDismissed.current = false;
+        setEmojiDismissed(false);
         let cancelled = false;
         loadEmojiIndex()
             .then((index) => {
@@ -373,7 +381,7 @@ function EditorBodyInner(
             .focus()
             .insertContentAt({ from, to }, `${match.emoji} `)
             .run();
-        onEmojiInsert?.(match.emoji);
+        onEmojiInsertRef.current?.(match.emoji);
     }
 
     // Bridge the plugin's keyboard-forwarded CustomEvents to the typeahead's
@@ -404,8 +412,7 @@ function EditorBodyInner(
         }
 
         function onDismiss() {
-            emojiDismissed.current = true;
-            setEmojiMatches([]);
+            setEmojiDismissed(true);
         }
 
         element.addEventListener('composer:emoji-nav', onNav);
@@ -484,7 +491,7 @@ function EditorBodyInner(
     const emojiPopoverOpen =
         editable &&
         emojiSuggest.active &&
-        !emojiDismissed.current &&
+        !emojiDismissed &&
         emojiMatches.length > 0;
     emojiPopoverOpenRef.current = emojiPopoverOpen;
 
@@ -655,7 +662,14 @@ function EditorBodyInner(
                     </PopoverContent>
                 )}
             </Popover>
-            <Popover open={emojiPopoverOpen}>
+            <Popover
+                open={emojiPopoverOpen}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setEmojiDismissed(true);
+                    }
+                }}
+            >
                 <PopoverAnchor asChild>
                     <div
                         ref={emojiAnchorRef}
@@ -669,6 +683,10 @@ function EditorBodyInner(
                     sideOffset={8}
                     className="w-auto rounded-xl p-0"
                     onOpenAutoFocus={(event) => event.preventDefault()}
+                    // Focus stays in the editor while the typeahead is open, so a
+                    // focus-outside must not dismiss it — only Escape or a pointer
+                    // click away (both routed through onOpenChange) should.
+                    onFocusOutside={(event) => event.preventDefault()}
                 >
                     <EmojiSuggestList
                         matches={emojiMatches}

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -1,6 +1,13 @@
 import { EditorContent, useEditor } from '@tiptap/react';
 import { Split } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import type { Ref } from 'react';
+import {
+    forwardRef,
+    useEffect,
+    useImperativeHandle,
+    useRef,
+    useState,
+} from 'react';
 
 import MentionPicker from '@/components/compose/mention-picker';
 import {
@@ -74,6 +81,11 @@ type EditorBodyProps = {
     };
 };
 
+export type EditorBodyHandle = {
+    /** Insert text (e.g. an emoji) at the current selection and refocus. */
+    insertText: (text: string) => void;
+};
+
 export function shouldFocusEditorOnMount(
     autoFocus: boolean,
     editable: boolean,
@@ -91,27 +103,30 @@ export function hasPasteableMedia(files: FileList | null | undefined): boolean {
     return !!files && Array.from(files).some(isPasteableMediaFile);
 }
 
-export default function EditorBody({
-    value,
-    onChange,
-    onBlur,
-    placeholder,
-    autoFocus = false,
-    onPasteFiles,
-    overrideBanner = false,
-    activePlatformLabel,
-    onResetOverride,
-    markerState,
-    mentions = [],
-    mentionPlatforms = [],
-    savedMentions = [],
-    onMentionsChange,
-    onMentionNameChange,
-    onApplySavedMention,
-    onSaveMention,
-    saveMentionProcessing = false,
-    editable = true,
-}: EditorBodyProps) {
+function EditorBodyInner(
+    {
+        value,
+        onChange,
+        onBlur,
+        placeholder,
+        autoFocus = false,
+        onPasteFiles,
+        overrideBanner = false,
+        activePlatformLabel,
+        onResetOverride,
+        markerState,
+        mentions = [],
+        mentionPlatforms = [],
+        savedMentions = [],
+        onMentionsChange,
+        onMentionNameChange,
+        onApplySavedMention,
+        onSaveMention,
+        saveMentionProcessing = false,
+        editable = true,
+    }: EditorBodyProps,
+    ref: Ref<EditorBodyHandle>,
+) {
     const [activeMentionId, setActiveMentionId] = useState<string | null>(null);
     const previousMentionCount = useRef(mentions.length);
     const pendingFocusLabel = useRef<string | null>(null);
@@ -148,6 +163,16 @@ export default function EditorBody({
             onChange(docToSegments(editor.getJSON() as DocNode)),
         onBlur,
     });
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            insertText: (text: string) => {
+                editor?.chain().focus().insertContent(text).run();
+            },
+        }),
+        [editor],
+    );
 
     useEffect(() => {
         if (!editor || !shouldFocusEditorOnMount(autoFocus, editable)) {
@@ -456,3 +481,6 @@ export default function EditorBody({
         </div>
     );
 }
+
+const EditorBody = forwardRef(EditorBodyInner);
+export default EditorBody;

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -9,18 +9,25 @@ import {
     useState,
 } from 'react';
 
+import EmojiSuggestList from '@/components/compose/emoji-suggest-list';
 import MentionPicker from '@/components/compose/mention-picker';
 import {
     Popover,
     PopoverAnchor,
     PopoverContent,
 } from '@/components/ui/popover';
+import { loadEmojiIndex, rankEmoji } from '@/lib/compose/emoji/shortcode-index';
+import type { EmojiMatch, EmojiSkinTone } from '@/lib/compose/emoji/types';
 import { mentionInputValue, updateMentionName } from '@/lib/compose/mentions';
 import {
     docToSegments,
     segmentsToDoc,
     type DocNode,
 } from '@/lib/compose/tiptap-doc';
+import {
+    emojiSuggestKey,
+    type EmojiSuggestState,
+} from '@/lib/compose/tiptap/emoji-suggest';
 import {
     editorContainsMentionLabel,
     findMentionLabelStart,
@@ -79,6 +86,10 @@ type EditorBodyProps = {
         limit: number;
         threadMax: number | null;
     };
+    /** Active skin tone for typeahead results. */
+    emojiSkinTone?: EmojiSkinTone;
+    /** Record a chosen emoji as recently used. */
+    onEmojiInsert?: (emoji: string) => void;
 };
 
 export type EditorBodyHandle = {
@@ -124,6 +135,8 @@ function EditorBodyInner(
         onSaveMention,
         saveMentionProcessing = false,
         editable = true,
+        emojiSkinTone = 'none',
+        onEmojiInsert,
     }: EditorBodyProps,
     ref: Ref<EditorBodyHandle>,
 ) {
@@ -138,6 +151,30 @@ function EditorBodyInner(
     const mentionAnchorRef = useRef<HTMLDivElement>(null);
     const mentionWasActive = useRef(false);
     const [mentionAnchorReady, setMentionAnchorReady] = useState(false);
+    // Mirrors the emojiSuggest plugin's trigger state; see the `sync` effect
+    // below. A zero-size anchor (mirroring the mention pattern) floats the
+    // typeahead popover beside the active `:query`.
+    const emojiAnchorRef = useRef<HTMLDivElement>(null);
+    const [emojiSuggest, setEmojiSuggest] = useState<EmojiSuggestState>({
+        active: false,
+        query: '',
+        from: 0,
+        to: 0,
+    });
+    const [emojiMatches, setEmojiMatches] = useState<EmojiMatch[]>([]);
+    const [emojiActiveIndex, setEmojiActiveIndex] = useState(0);
+    const emojiDismissed = useRef(false);
+    // Read by the CustomEvent handlers, which capture stale state otherwise.
+    const emojiLatest = useRef({
+        suggest: emojiSuggest,
+        matches: emojiMatches,
+        index: emojiActiveIndex,
+    });
+    emojiLatest.current = {
+        suggest: emojiSuggest,
+        matches: emojiMatches,
+        index: emojiActiveIndex,
+    };
     // editorProps is captured once at editor creation, but onPasteFiles is a
     // fresh closure each render (it reads the current media/limits). Route through
     // a ref so handlePaste always enforces the latest one-video / no-mixing rule.
@@ -261,6 +298,135 @@ function EditorBodyInner(
             threadMax: markerThreadMax,
         });
     }, [editor, markerPlatform, markerAutoSplit, markerLimit, markerThreadMax]);
+
+    // Mirror the emojiSuggest plugin's trigger state into React on every
+    // transaction (mirrors the section-markers → React bridge above).
+    useEffect(() => {
+        if (!editor) {
+            return;
+        }
+        function sync() {
+            setEmojiSuggest(
+                emojiSuggestKey.getState(editor.state) ?? {
+                    active: false,
+                    query: '',
+                    from: 0,
+                    to: 0,
+                },
+            );
+        }
+        editor.on('transaction', sync);
+        sync();
+
+        return () => {
+            editor.off('transaction', sync);
+        };
+    }, [editor]);
+
+    // Fetch + rank matches when the query changes. A new query always clears
+    // any prior dismissal, so re-typing after Escape reopens the popover.
+    useEffect(() => {
+        if (!emojiSuggest.active) {
+            setEmojiMatches([]);
+
+            return;
+        }
+        emojiDismissed.current = false;
+        let cancelled = false;
+        loadEmojiIndex()
+            .then((index) => {
+                if (cancelled) {
+                    return;
+                }
+                setEmojiMatches(
+                    rankEmoji(index, emojiSuggest.query, {
+                        skinTone: emojiSkinTone,
+                    }),
+                );
+                setEmojiActiveIndex(0);
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setEmojiMatches([]);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [emojiSuggest.active, emojiSuggest.query, emojiSkinTone]);
+
+    // Replace the active `:query` with the chosen emoji and refocus.
+    function insertEmojiAt(match: EmojiMatch, from: number, to: number) {
+        if (!editor) {
+            return;
+        }
+        editor
+            .chain()
+            .focus()
+            .insertContentAt({ from, to }, `${match.emoji} `)
+            .run();
+        onEmojiInsert?.(match.emoji);
+    }
+
+    // Bridge the plugin's keyboard-forwarded CustomEvents to the typeahead's
+    // React state. Reads from `emojiLatest` (not the render's closed-over
+    // state) since these handlers are registered once per editor instance.
+    useEffect(() => {
+        const element = editor?.view.dom;
+        if (!element) {
+            return;
+        }
+
+        function onNav(event: Event) {
+            const delta = (event as CustomEvent<{ delta: number }>).detail
+                .delta;
+            const count = emojiLatest.current.matches.length;
+            if (count === 0) {
+                return;
+            }
+            setEmojiActiveIndex((index) => (index + delta + count) % count);
+        }
+
+        function onCommit() {
+            const { suggest, matches, index } = emojiLatest.current;
+            const match = matches[index];
+            if (match) {
+                insertEmojiAt(match, suggest.from, suggest.to);
+            }
+        }
+
+        function onDismiss() {
+            emojiDismissed.current = true;
+            setEmojiMatches([]);
+        }
+
+        element.addEventListener('composer:emoji-nav', onNav);
+        element.addEventListener('composer:emoji-commit', onCommit);
+        element.addEventListener('composer:emoji-dismiss', onDismiss);
+
+        return () => {
+            element.removeEventListener('composer:emoji-nav', onNav);
+            element.removeEventListener('composer:emoji-commit', onCommit);
+            element.removeEventListener('composer:emoji-dismiss', onDismiss);
+        };
+        // oxlint-disable-next-line react-hooks/exhaustive-deps
+    }, [editor]);
+
+    // Position the floating anchor at the start of the active `:query` so the
+    // popover tracks the caret (reuses positionMentionAnchor's coord logic).
+    useEffect(() => {
+        const container = containerRef.current;
+        const anchor = emojiAnchorRef.current;
+        if (!editor || !emojiSuggest.active || !container || !anchor) {
+            return;
+        }
+        const caret = editor.view.coordsAtPos(emojiSuggest.from);
+        const rect = container.getBoundingClientRect();
+        anchor.style.left = `${caret.left - rect.left}px`;
+        anchor.style.top = `${caret.top - rect.top}px`;
+        anchor.style.height = `${caret.bottom - caret.top}px`;
+    }, [editor, emojiSuggest.active, emojiSuggest.from]);
 
     useEffect(() => {
         const element = editor?.view.dom;
@@ -471,6 +637,41 @@ function EditorBodyInner(
                         />
                     </PopoverContent>
                 )}
+            </Popover>
+            <Popover
+                open={
+                    editable &&
+                    emojiSuggest.active &&
+                    !emojiDismissed.current &&
+                    emojiMatches.length > 0
+                }
+            >
+                <PopoverAnchor asChild>
+                    <div
+                        ref={emojiAnchorRef}
+                        aria-hidden
+                        className="pointer-events-none absolute w-0"
+                    />
+                </PopoverAnchor>
+                <PopoverContent
+                    align="start"
+                    side="bottom"
+                    sideOffset={8}
+                    className="w-auto rounded-xl p-0"
+                    onOpenAutoFocus={(event) => event.preventDefault()}
+                >
+                    <EmojiSuggestList
+                        matches={emojiMatches}
+                        activeIndex={emojiActiveIndex}
+                        onSelect={(match) =>
+                            insertEmojiAt(
+                                match,
+                                emojiLatest.current.suggest.from,
+                                emojiLatest.current.suggest.to,
+                            )
+                        }
+                    />
+                </PopoverContent>
             </Popover>
             <div className="px-4 pt-[22px] pb-[18px] sm:px-[26px]">
                 <EditorContent

--- a/resources/js/components/compose/emoji-picker.tsx
+++ b/resources/js/components/compose/emoji-picker.tsx
@@ -23,7 +23,7 @@ export default function EmojiPicker({
 }: Props) {
     return (
         <Frimousse.Root
-            className="isolate flex h-[368px] w-[336px] flex-col bg-popover text-popover-foreground"
+            className="isolate flex h-[368px] w-full flex-col bg-popover text-popover-foreground"
             locale="en"
             columns={9}
             skinTone={skinTone}
@@ -44,13 +44,13 @@ export default function EmojiPicker({
                     <div className="px-1.5 pb-1 text-xs font-medium text-muted-foreground">
                         Recent
                     </div>
-                    <div className="flex flex-wrap">
+                    <div className="grid grid-cols-9">
                         {recents.map((emoji, position) => (
                             <button
                                 key={`${emoji}-${position}`}
                                 type="button"
                                 onClick={() => onSelect(emoji)}
-                                className="flex size-8 items-center justify-center rounded-md text-lg hover:bg-muted"
+                                className="flex h-8 w-full items-center justify-center rounded-md text-lg hover:bg-muted"
                             >
                                 {emoji}
                             </button>
@@ -77,14 +77,28 @@ export default function EmojiPicker({
                                 {category.label}
                             </div>
                         ),
-                        Row: ({ children, ...props }) => (
-                            <div className="scroll-my-1.5 px-1.5" {...props}>
+                        // Frimousse positions rows absolutely (virtualization) and
+                        // styles them `display:flex` inline; override to a full-width
+                        // grid so the emoji cells fill the picker instead of packing
+                        // left with dead space on the right.
+                        Row: ({ children, style, ...props }) => (
+                            <div
+                                {...props}
+                                style={{
+                                    ...style,
+                                    display: 'grid',
+                                    width: '100%',
+                                    gridTemplateColumns:
+                                        'repeat(9, minmax(0, 1fr))',
+                                }}
+                                className="scroll-my-1.5 px-1.5"
+                            >
                                 {children}
                             </div>
                         ),
                         Emoji: ({ emoji, ...props }) => (
                             <button
-                                className="flex size-8 items-center justify-center rounded-md text-lg data-[active]:bg-muted"
+                                className="flex h-8 w-full items-center justify-center rounded-md text-lg data-[active]:bg-muted"
                                 {...props}
                             >
                                 {emoji.emoji}

--- a/resources/js/components/compose/emoji-picker.tsx
+++ b/resources/js/components/compose/emoji-picker.tsx
@@ -1,0 +1,119 @@
+import { EmojiPicker as Frimousse, useSkinTone } from 'frimousse';
+import { useEffect } from 'react';
+
+import type { EmojiSkinTone } from '@/lib/compose/emoji/types';
+
+type Props = {
+    recents: string[];
+    skinTone: EmojiSkinTone;
+    onSkinToneChange: (tone: EmojiSkinTone) => void;
+    onSelect: (emoji: string) => void;
+};
+
+/**
+ * Styled Frimousse picker for the composer. Data is self-hosted under `/emoji`
+ * (CSP forbids the default CDN). Renders a recents row above the categorized
+ * list and persists skin-tone changes through `onSkinToneChange`.
+ */
+export default function EmojiPicker({
+    recents,
+    skinTone,
+    onSkinToneChange,
+    onSelect,
+}: Props) {
+    return (
+        <Frimousse.Root
+            className="isolate flex h-[368px] w-[336px] flex-col bg-popover text-popover-foreground"
+            locale="en"
+            columns={9}
+            skinTone={skinTone}
+            emojibaseUrl="/emoji"
+            onEmojiSelect={({ emoji }) => onSelect(emoji)}
+        >
+            <SkinTonePersistence onChange={onSkinToneChange} />
+            <div className="flex items-center gap-2 px-2 pt-2">
+                <Frimousse.Search
+                    className="h-8 flex-1 appearance-none rounded-md bg-muted px-2.5 text-sm outline-none placeholder:text-muted-foreground"
+                    placeholder="Search emoji…"
+                />
+                <Frimousse.SkinToneSelector className="flex size-8 items-center justify-center rounded-md text-lg hover:bg-muted" />
+            </div>
+
+            {recents.length > 0 && (
+                <div className="border-b border-border px-1.5 pt-2 pb-1.5">
+                    <div className="px-1.5 pb-1 text-xs font-medium text-muted-foreground">
+                        Recent
+                    </div>
+                    <div className="flex flex-wrap">
+                        {recents.map((emoji, position) => (
+                            <button
+                                key={`${emoji}-${position}`}
+                                type="button"
+                                onClick={() => onSelect(emoji)}
+                                className="flex size-8 items-center justify-center rounded-md text-lg hover:bg-muted"
+                            >
+                                {emoji}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            <Frimousse.Viewport className="relative flex-1 outline-hidden">
+                <Frimousse.Loading className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+                    Loading…
+                </Frimousse.Loading>
+                <Frimousse.Empty className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+                    No emoji found.
+                </Frimousse.Empty>
+                <Frimousse.List
+                    className="pb-1.5 select-none"
+                    components={{
+                        CategoryHeader: ({ category, ...props }) => (
+                            <div
+                                className="bg-popover px-3 pt-3 pb-1.5 text-xs font-medium text-muted-foreground"
+                                {...props}
+                            >
+                                {category.label}
+                            </div>
+                        ),
+                        Row: ({ children, ...props }) => (
+                            <div className="scroll-my-1.5 px-1.5" {...props}>
+                                {children}
+                            </div>
+                        ),
+                        Emoji: ({ emoji, ...props }) => (
+                            <button
+                                className="flex size-8 items-center justify-center rounded-md text-lg data-[active]:bg-muted"
+                                {...props}
+                            >
+                                {emoji.emoji}
+                            </button>
+                        ),
+                    }}
+                />
+            </Frimousse.Viewport>
+        </Frimousse.Root>
+    );
+}
+
+/**
+ * Mirrors Frimousse's live skin tone (changed via the in-picker selector) back
+ * to the caller so it can be persisted. Must render inside `Frimousse.Root` —
+ * `useSkinTone` reads from its store. The sync happens in an effect (not
+ * during render) so it never updates the parent while this subtree is
+ * rendering.
+ */
+function SkinTonePersistence({
+    onChange,
+}: {
+    onChange: (tone: EmojiSkinTone) => void;
+}) {
+    const [skinTone] = useSkinTone();
+
+    useEffect(() => {
+        onChange(skinTone);
+    }, [skinTone, onChange]);
+
+    return null;
+}

--- a/resources/js/components/compose/emoji-picker.tsx
+++ b/resources/js/components/compose/emoji-picker.tsx
@@ -98,6 +98,7 @@ export default function EmojiPicker({
                         ),
                         Emoji: ({ emoji, ...props }) => (
                             <button
+                                type="button"
                                 className="flex h-8 w-full items-center justify-center rounded-md text-lg data-[active]:bg-muted"
                                 {...props}
                             >

--- a/resources/js/components/compose/emoji-suggest-list.tsx
+++ b/resources/js/components/compose/emoji-suggest-list.tsx
@@ -1,0 +1,40 @@
+import type { EmojiMatch } from '@/lib/compose/emoji/types';
+import { cn } from '@/lib/utils';
+
+type Props = {
+    matches: EmojiMatch[];
+    activeIndex: number;
+    onSelect: (match: EmojiMatch) => void;
+};
+
+/** Presentational `:shortcode` results. Focus stays in the editor; the plugin
+ *  drives keyboard nav, so items use onMouseDown to avoid stealing focus. */
+export default function EmojiSuggestList({
+    matches,
+    activeIndex,
+    onSelect,
+}: Props) {
+    return (
+        <div className="max-h-64 w-64 overflow-y-auto p-1">
+            {matches.map((match, index) => (
+                <button
+                    key={`${match.shortcode}-${index}`}
+                    type="button"
+                    onMouseDown={(event) => {
+                        event.preventDefault();
+                        onSelect(match);
+                    }}
+                    className={cn(
+                        'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm',
+                        index === activeIndex
+                            ? 'bg-muted text-foreground'
+                            : 'text-muted-foreground',
+                    )}
+                >
+                    <span className="text-lg">{match.emoji}</span>
+                    <span className="truncate">:{match.shortcode}:</span>
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/resources/js/components/compose/emoji-suggest-list.tsx
+++ b/resources/js/components/compose/emoji-suggest-list.tsx
@@ -20,6 +20,7 @@ export default function EmojiSuggestList({
                 <button
                     key={`${match.shortcode}-${index}`}
                     type="button"
+                    aria-label={match.label}
                     onMouseDown={(event) => {
                         event.preventDefault();
                         onSelect(match);

--- a/resources/js/components/compose/emoji-suggest-popover.tsx
+++ b/resources/js/components/compose/emoji-suggest-popover.tsx
@@ -1,0 +1,69 @@
+import { type RefObject } from 'react';
+
+import {
+    Popover,
+    PopoverAnchor,
+    PopoverContent,
+} from '@/components/ui/popover';
+import type { EmojiMatch } from '@/lib/compose/emoji/types';
+
+import EmojiSuggestList from './emoji-suggest-list';
+
+type Props = {
+    open: boolean;
+    /** Called by Radix on dismissal (Escape / pointer click away). */
+    onDismiss: () => void;
+    /** Zero-size element the popover floats beside (pinned to the `:query`). */
+    anchorRef: RefObject<HTMLDivElement | null>;
+    matches: EmojiMatch[];
+    activeIndex: number;
+    onSelect: (match: EmojiMatch) => void;
+};
+
+/**
+ * The inline `:shortcode` typeahead popover. Presentational: all state and
+ * keyboard handling live in `useEmojiTypeahead`. Focus stays in the editor
+ * (`onOpenAutoFocus` / `onFocusOutside` prevented), so only Escape or a pointer
+ * click away — routed through `onOpenChange` — dismisses it.
+ */
+export default function EmojiSuggestPopover({
+    open,
+    onDismiss,
+    anchorRef,
+    matches,
+    activeIndex,
+    onSelect,
+}: Props) {
+    return (
+        <Popover
+            open={open}
+            onOpenChange={(next) => {
+                if (!next) {
+                    onDismiss();
+                }
+            }}
+        >
+            <PopoverAnchor asChild>
+                <div
+                    ref={anchorRef}
+                    aria-hidden
+                    className="pointer-events-none absolute w-0"
+                />
+            </PopoverAnchor>
+            <PopoverContent
+                align="start"
+                side="bottom"
+                sideOffset={8}
+                className="w-auto rounded-xl p-0"
+                onOpenAutoFocus={(event) => event.preventDefault()}
+                onFocusOutside={(event) => event.preventDefault()}
+            >
+                <EmojiSuggestList
+                    matches={matches}
+                    activeIndex={activeIndex}
+                    onSelect={onSelect}
+                />
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/resources/js/hooks/compose/use-emoji-preferences.ts
+++ b/resources/js/hooks/compose/use-emoji-preferences.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+import {
+    parseRecents,
+    parseSkinTone,
+    pushRecent,
+    RECENTS_KEY,
+    SKIN_TONE_KEY,
+} from '@/lib/compose/emoji/preferences';
+import type { EmojiSkinTone } from '@/lib/compose/emoji/types';
+
+export type EmojiPreferences = {
+    recents: string[];
+    addRecent: (emoji: string) => void;
+    skinTone: EmojiSkinTone;
+    setSkinTone: (tone: EmojiSkinTone) => void;
+};
+
+/** localStorage-backed emoji preferences (per browser): recents + skin tone. */
+export function useEmojiPreferences(): EmojiPreferences {
+    const [recents, setRecents] = useState<string[]>([]);
+    const [skinTone, setSkinToneState] = useState<EmojiSkinTone>('none');
+
+    // Hydrate once on mount (SSR-safe: localStorage is unavailable server-side).
+    useEffect(() => {
+        setRecents(parseRecents(localStorage.getItem(RECENTS_KEY)));
+        setSkinToneState(parseSkinTone(localStorage.getItem(SKIN_TONE_KEY)));
+    }, []);
+
+    function addRecent(emoji: string): void {
+        setRecents((current) => {
+            const next = pushRecent(current, emoji);
+            localStorage.setItem(RECENTS_KEY, JSON.stringify(next));
+
+            return next;
+        });
+    }
+
+    function setSkinTone(tone: EmojiSkinTone): void {
+        setSkinToneState(tone);
+        localStorage.setItem(SKIN_TONE_KEY, tone);
+    }
+
+    return { recents, addRecent, skinTone, setSkinTone };
+}

--- a/resources/js/hooks/compose/use-emoji-preferences.ts
+++ b/resources/js/hooks/compose/use-emoji-preferences.ts
@@ -21,16 +21,23 @@ export function useEmojiPreferences(): EmojiPreferences {
     const [recents, setRecents] = useState<string[]>([]);
     const [skinTone, setSkinToneState] = useState<EmojiSkinTone>('none');
 
-    // Hydrate once on mount (SSR-safe: localStorage is unavailable server-side).
+    // Hydrate once on mount. Guarded because localStorage access throws in
+    // some environments (private mode, disabled storage) as well as SSR.
     useEffect(() => {
-        setRecents(parseRecents(localStorage.getItem(RECENTS_KEY)));
-        setSkinToneState(parseSkinTone(localStorage.getItem(SKIN_TONE_KEY)));
+        try {
+            setRecents(parseRecents(localStorage.getItem(RECENTS_KEY)));
+            setSkinToneState(
+                parseSkinTone(localStorage.getItem(SKIN_TONE_KEY)),
+            );
+        } catch {
+            // Keep the in-memory defaults when storage is unavailable.
+        }
     }, []);
 
     function addRecent(emoji: string): void {
         setRecents((current) => {
             const next = pushRecent(current, emoji);
-            localStorage.setItem(RECENTS_KEY, JSON.stringify(next));
+            persist(RECENTS_KEY, JSON.stringify(next));
 
             return next;
         });
@@ -38,8 +45,17 @@ export function useEmojiPreferences(): EmojiPreferences {
 
     function setSkinTone(tone: EmojiSkinTone): void {
         setSkinToneState(tone);
-        localStorage.setItem(SKIN_TONE_KEY, tone);
+        persist(SKIN_TONE_KEY, tone);
     }
 
     return { recents, addRecent, skinTone, setSkinTone };
+}
+
+/** Write to localStorage, swallowing errors (quota/private-mode/disabled). */
+function persist(key: string, value: string): void {
+    try {
+        localStorage.setItem(key, value);
+    } catch {
+        // Preference just won't persist this session; not worth surfacing.
+    }
 }

--- a/resources/js/hooks/compose/use-emoji-typeahead.ts
+++ b/resources/js/hooks/compose/use-emoji-typeahead.ts
@@ -1,0 +1,215 @@
+import { type Editor } from '@tiptap/react';
+import { type RefObject, useEffect, useRef, useState } from 'react';
+
+import { loadEmojiIndex, rankEmoji } from '@/lib/compose/emoji/shortcode-index';
+import type { EmojiMatch, EmojiSkinTone } from '@/lib/compose/emoji/types';
+import {
+    emojiSuggestKey,
+    type EmojiSuggestState,
+} from '@/lib/compose/tiptap/emoji-suggest';
+
+const INACTIVE: EmojiSuggestState = {
+    active: false,
+    query: '',
+    from: 0,
+    to: 0,
+};
+
+type Options = {
+    /** The TipTap editor (null until it mounts). */
+    editor: Editor | null;
+    /** The editor's relatively-positioned wrapper, for caret-anchoring. */
+    containerRef: RefObject<HTMLDivElement | null>;
+    /**
+     * Written live so the emojiSuggest plugin's handleKeyDown gates key
+     * consumption on the popover actually being open. Created by the caller and
+     * also handed to `composerExtensions`, so both sides share one ref.
+     */
+    openRef: RefObject<boolean>;
+    /** Active skin tone applied to ranked results. */
+    skinTone: EmojiSkinTone;
+    /** False on a read-only post — suppresses the popover entirely. */
+    editable: boolean;
+    /** Record a chosen emoji as recently used. */
+    onInsert?: (emoji: string) => void;
+};
+
+export type EmojiTypeahead = {
+    /** Whether the typeahead popover should be shown. */
+    open: boolean;
+    matches: EmojiMatch[];
+    activeIndex: number;
+    /** Zero-size element pinned to the active `:query` for the popover anchor. */
+    anchorRef: RefObject<HTMLDivElement | null>;
+    /** Dismiss for the current query (Escape / click-away). */
+    dismiss: () => void;
+    /** Commit a match, replacing the active `:query`. */
+    select: (match: EmojiMatch) => void;
+};
+
+/**
+ * Owns the inline `:shortcode` emoji typeahead: it mirrors the emojiSuggest
+ * ProseMirror plugin's trigger state into React, fetches + ranks matches, bridges
+ * the plugin's keyboard-forwarded CustomEvents (nav / commit / dismiss) back into
+ * React, and keeps a caret-anchored element positioned for the popover. The
+ * rendering lives in `EmojiSuggestPopover`; this hook is the behaviour.
+ */
+export function useEmojiTypeahead({
+    editor,
+    containerRef,
+    openRef,
+    skinTone,
+    editable,
+    onInsert,
+}: Options): EmojiTypeahead {
+    const anchorRef = useRef<HTMLDivElement>(null);
+    const [suggest, setSuggest] = useState<EmojiSuggestState>(INACTIVE);
+    const [matches, setMatches] = useState<EmojiMatch[]>([]);
+    const [activeIndex, setActiveIndex] = useState(0);
+    // State (not a ref) so `open` derives from it without reading a mutable ref
+    // during render.
+    const [dismissed, setDismissed] = useState(false);
+
+    // The CustomEvent handlers below are bound once per editor, so they read the
+    // latest state (and onInsert, whose identity changes across renders) through
+    // refs rather than a stale render closure.
+    const onInsertRef = useRef(onInsert);
+    onInsertRef.current = onInsert;
+    const latest = useRef({ suggest, matches, activeIndex });
+    latest.current = { suggest, matches, activeIndex };
+
+    const open = editable && suggest.active && !dismissed && matches.length > 0;
+    openRef.current = open;
+
+    // Mirror the plugin's trigger state into React on every transaction.
+    useEffect(() => {
+        if (!editor) {
+            return;
+        }
+        const view = editor;
+        function sync() {
+            setSuggest(emojiSuggestKey.getState(view.state) ?? INACTIVE);
+        }
+        view.on('transaction', sync);
+        sync();
+
+        return () => {
+            view.off('transaction', sync);
+        };
+    }, [editor]);
+
+    // Fetch + rank matches when the query changes. A new query clears any prior
+    // dismissal, so re-typing after Escape reopens the popover.
+    useEffect(() => {
+        if (!suggest.active) {
+            setMatches([]);
+
+            return;
+        }
+        setDismissed(false);
+        let cancelled = false;
+        loadEmojiIndex()
+            .then((index) => {
+                if (cancelled) {
+                    return;
+                }
+                setMatches(rankEmoji(index, suggest.query, { skinTone }));
+                setActiveIndex(0);
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setMatches([]);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [suggest.active, suggest.query, skinTone]);
+
+    // Replace the active `:query` with the chosen emoji and refocus.
+    function insertAt(match: EmojiMatch, from: number, to: number) {
+        if (!editor) {
+            return;
+        }
+        editor
+            .chain()
+            .focus()
+            .insertContentAt({ from, to }, `${match.emoji} `)
+            .run();
+        onInsertRef.current?.(match.emoji);
+    }
+
+    // Bridge the plugin's keyboard-forwarded CustomEvents to React state.
+    useEffect(() => {
+        const element = editor?.view.dom;
+        if (!element) {
+            return;
+        }
+
+        function onNav(event: Event) {
+            const delta = (event as CustomEvent<{ delta: number }>).detail
+                .delta;
+            const count = latest.current.matches.length;
+            if (count === 0) {
+                return;
+            }
+            setActiveIndex((index) => (index + delta + count) % count);
+        }
+
+        function onCommit() {
+            const {
+                suggest: active,
+                matches: current,
+                activeIndex: index,
+            } = latest.current;
+            const match = current[index];
+            if (match) {
+                insertAt(match, active.from, active.to);
+            }
+        }
+
+        function onDismiss() {
+            setDismissed(true);
+        }
+
+        element.addEventListener('composer:emoji-nav', onNav);
+        element.addEventListener('composer:emoji-commit', onCommit);
+        element.addEventListener('composer:emoji-dismiss', onDismiss);
+
+        return () => {
+            element.removeEventListener('composer:emoji-nav', onNav);
+            element.removeEventListener('composer:emoji-commit', onCommit);
+            element.removeEventListener('composer:emoji-dismiss', onDismiss);
+        };
+        // oxlint-disable-next-line react-hooks/exhaustive-deps
+    }, [editor]);
+
+    // Pin the floating anchor to the start of the active `:query`.
+    useEffect(() => {
+        const container = containerRef.current;
+        const anchor = anchorRef.current;
+        if (!editor || !suggest.active || !container || !anchor) {
+            return;
+        }
+        const caret = editor.view.coordsAtPos(suggest.from);
+        const rect = container.getBoundingClientRect();
+        anchor.style.left = `${caret.left - rect.left}px`;
+        anchor.style.top = `${caret.top - rect.top}px`;
+        anchor.style.height = `${caret.bottom - caret.top}px`;
+    }, [editor, containerRef, suggest.active, suggest.from]);
+
+    return {
+        open,
+        matches,
+        activeIndex,
+        anchorRef,
+        dismiss: () => setDismissed(true),
+        select: (match) =>
+            insertAt(
+                match,
+                latest.current.suggest.from,
+                latest.current.suggest.to,
+            ),
+    };
+}

--- a/resources/js/lib/compose/emoji/__tests__/preferences.test.ts
+++ b/resources/js/lib/compose/emoji/__tests__/preferences.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseRecents, parseSkinTone, pushRecent } from '../preferences';
+
+describe('pushRecent', () => {
+    it('prepends a new emoji', () => {
+        expect(pushRecent(['😀'], '🔥')).toEqual(['🔥', '😀']);
+    });
+
+    it('moves an existing emoji to the front (dedupe)', () => {
+        expect(pushRecent(['😀', '🔥', '❤️'], '❤️')).toEqual(['❤️', '😀', '🔥']);
+    });
+
+    it('caps the list length', () => {
+        const list = Array.from({ length: 16 }, (_, i) => String(i));
+        expect(pushRecent(list, 'new', 16)).toHaveLength(16);
+        expect(pushRecent(list, 'new', 16)[0]).toBe('new');
+    });
+});
+
+describe('parseRecents', () => {
+    it('parses a valid array', () => {
+        expect(parseRecents('["😀","🔥"]')).toEqual(['😀', '🔥']);
+    });
+
+    it('falls back to [] on null', () => {
+        expect(parseRecents(null)).toEqual([]);
+    });
+
+    it('falls back to [] on corrupt JSON', () => {
+        expect(parseRecents('{not json')).toEqual([]);
+    });
+
+    it('falls back to [] on a non-string array', () => {
+        expect(parseRecents('[1,2,3]')).toEqual([]);
+    });
+});
+
+describe('parseSkinTone', () => {
+    it('accepts a valid tone', () => {
+        expect(parseSkinTone('dark')).toBe('dark');
+    });
+
+    it('falls back to none on garbage', () => {
+        expect(parseSkinTone('purple')).toBe('none');
+        expect(parseSkinTone(null)).toBe('none');
+    });
+});

--- a/resources/js/lib/compose/emoji/__tests__/preferences.test.ts
+++ b/resources/js/lib/compose/emoji/__tests__/preferences.test.ts
@@ -8,7 +8,11 @@ describe('pushRecent', () => {
     });
 
     it('moves an existing emoji to the front (dedupe)', () => {
-        expect(pushRecent(['😀', '🔥', '❤️'], '❤️')).toEqual(['❤️', '😀', '🔥']);
+        expect(pushRecent(['😀', '🔥', '❤️'], '❤️')).toEqual([
+            '❤️',
+            '😀',
+            '🔥',
+        ]);
     });
 
     it('caps the list length', () => {

--- a/resources/js/lib/compose/emoji/__tests__/shortcode-index.test.ts
+++ b/resources/js/lib/compose/emoji/__tests__/shortcode-index.test.ts
@@ -24,11 +24,35 @@ const RAW: RawEmoji[] = [
             { hexcode: '1F44B-1F3FF', emoji: '👋🏿', tone: 5 },
         ],
     },
+    {
+        hexcode: '1F60A',
+        emoji: '☺️',
+        label: 'smiling face',
+        tags: ['smile'],
+        skins: [
+            // Couple/multi-person emoji with array tone (should be filtered)
+            {
+                hexcode: '1F9DD-couple',
+                emoji: '🧑‍🤝‍🧑🏻',
+                tone: [1, 1] as unknown as number,
+            },
+            // Normal single-tone skin (should be kept)
+            { hexcode: '1F60A-1F3FB', emoji: '☺️🏻', tone: 1 },
+        ],
+    },
+    {
+        hexcode: '1F60F',
+        emoji: '😏',
+        label: 'smirking face',
+        tags: ['playful'],
+    },
 ];
 
 const SHORTCODES: Record<string, string | string[]> = {
     '1F604': 'smile',
     '1F44B': ['wave', 'waving_hand'],
+    '1F60A': 'smiling_face',
+    '1F60F': 'smirk',
 };
 
 const index = buildEmojiIndex(RAW, SHORTCODES);
@@ -39,12 +63,27 @@ describe('buildEmojiIndex', () => {
         expect(smile?.shortcodes).toEqual(['smile']);
         expect(smile?.tags).toEqual(['happy', 'smile']);
     });
+
+    it('filters couple-emoji skins with array tones', () => {
+        const smilingFace = index.find((e) => e.hexcode === '1F60A');
+        // Should have exactly 1 skin (the normal tone), the array-tone one is filtered
+        expect(smilingFace?.skins).toHaveLength(1);
+        // The kept skin should be the single-number-tone one
+        expect(smilingFace?.skins[0]).toEqual({ tone: 1, emoji: '☺️🏻' });
+        // Verify the array-tone couple skin is absent
+        expect(smilingFace?.skins.some((s) => s.emoji === '🧑‍🤝‍🧑🏻')).toBe(false);
+    });
 });
 
 describe('rankEmoji', () => {
     it('ranks an exact shortcode above a substring match', () => {
         const results = rankEmoji(index, 'smile', { skinTone: 'none' });
+        // Should match both 'smile' (exact) and 'smiling_face' (substring)
+        expect(results.map((r) => r.emoji)).toContain('😄');
+        expect(results.map((r) => r.emoji)).toContain('☺️');
+        // Exact match must come first
         expect(results[0]?.emoji).toBe('😄');
+        expect(results[1]?.emoji).toBe('☺️');
     });
 
     it('matches on shortcode prefix', () => {
@@ -61,8 +100,19 @@ describe('rankEmoji', () => {
         expect(rankEmoji(index, '', { skinTone: 'none' })).toEqual([]);
     });
 
-    it('respects the limit', () => {
-        expect(rankEmoji(index, 'a', { skinTone: 'none', limit: 1 }).length).toBeLessThanOrEqual(1);
+    it('respects the limit and returns higher-scored result', () => {
+        // Query 'smile' matches both 'smile' (score 4) and 'smiling_face' (score 2)
+        const allResults = rankEmoji(index, 'smile', { skinTone: 'none' });
+        expect(allResults.length).toBeGreaterThanOrEqual(2);
+
+        // With limit:1, only the highest-scored one should be returned
+        const limitedResults = rankEmoji(index, 'smile', {
+            skinTone: 'none',
+            limit: 1,
+        });
+        expect(limitedResults).toHaveLength(1);
+        // Should be the exact match ('smile'), not the substring match ('smiling_face')
+        expect(limitedResults[0]?.emoji).toBe('😄');
     });
 
     it('applies the selected skin tone', () => {

--- a/resources/js/lib/compose/emoji/__tests__/shortcode-index.test.ts
+++ b/resources/js/lib/compose/emoji/__tests__/shortcode-index.test.ts
@@ -51,7 +51,7 @@ const RAW: RawEmoji[] = [
 const SHORTCODES: Record<string, string | string[]> = {
     '1F604': 'smile',
     '1F44B': ['wave', 'waving_hand'],
-    '1F60A': 'smiling_face',
+    '1F60A': 'big_smile',
     '1F60F': 'smirk',
 };
 
@@ -78,12 +78,14 @@ describe('buildEmojiIndex', () => {
 describe('rankEmoji', () => {
     it('ranks an exact shortcode above a substring match', () => {
         const results = rankEmoji(index, 'smile', { skinTone: 'none' });
-        // Should match both 'smile' (exact) and 'smiling_face' (substring)
-        expect(results.map((r) => r.emoji)).toContain('😄');
-        expect(results.map((r) => r.emoji)).toContain('☺️');
+        // Should match both 'smile' (exact score 4) and 'big_smile' (substring score 2)
+        const emojis = results.map((r) => r.emoji);
+        expect(emojis).toContain('😄'); // exact match
+        expect(emojis).toContain('☺️'); // substring match
         // Exact match must come first
         expect(results[0]?.emoji).toBe('😄');
-        expect(results[1]?.emoji).toBe('☺️');
+        // Substring match should appear later
+        expect(emojis.indexOf('☺️')).toBeGreaterThan(0);
     });
 
     it('matches on shortcode prefix', () => {
@@ -101,7 +103,7 @@ describe('rankEmoji', () => {
     });
 
     it('respects the limit and returns higher-scored result', () => {
-        // Query 'smile' matches both 'smile' (score 4) and 'smiling_face' (score 2)
+        // Query 'smile' matches both 'smile' (score 4, exact) and 'big_smile' (score 2, substring)
         const allResults = rankEmoji(index, 'smile', { skinTone: 'none' });
         expect(allResults.length).toBeGreaterThanOrEqual(2);
 
@@ -111,7 +113,7 @@ describe('rankEmoji', () => {
             limit: 1,
         });
         expect(limitedResults).toHaveLength(1);
-        // Should be the exact match ('smile'), not the substring match ('smiling_face')
+        // Should be the exact match ('smile'), not the substring match ('big_smile')
         expect(limitedResults[0]?.emoji).toBe('😄');
     });
 

--- a/resources/js/lib/compose/emoji/__tests__/shortcode-index.test.ts
+++ b/resources/js/lib/compose/emoji/__tests__/shortcode-index.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-    applySkinTone,
-    buildEmojiIndex,
-    rankEmoji,
-} from '../shortcode-index';
+import { applySkinTone, buildEmojiIndex, rankEmoji } from '../shortcode-index';
 import type { RawEmoji } from '../types';
 
 const RAW: RawEmoji[] = [
@@ -119,7 +115,9 @@ describe('rankEmoji', () => {
 
     it('applies the selected skin tone', () => {
         const results = rankEmoji(index, 'wave', { skinTone: 'dark' });
-        expect(results.find((r) => r.label === 'waving hand')?.emoji).toBe('👋🏿');
+        expect(results.find((r) => r.label === 'waving hand')?.emoji).toBe(
+            '👋🏿',
+        );
     });
 });
 

--- a/resources/js/lib/compose/emoji/__tests__/shortcode-index.test.ts
+++ b/resources/js/lib/compose/emoji/__tests__/shortcode-index.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    applySkinTone,
+    buildEmojiIndex,
+    rankEmoji,
+} from '../shortcode-index';
+import type { RawEmoji } from '../types';
+
+const RAW: RawEmoji[] = [
+    {
+        hexcode: '1F604',
+        emoji: '😄',
+        label: 'grinning face with smiling eyes',
+        tags: ['happy', 'smile'],
+    },
+    {
+        hexcode: '1F44B',
+        emoji: '👋',
+        label: 'waving hand',
+        tags: ['wave', 'hello'],
+        skins: [
+            { hexcode: '1F44B-1F3FB', emoji: '👋🏻', tone: 1 },
+            { hexcode: '1F44B-1F3FF', emoji: '👋🏿', tone: 5 },
+        ],
+    },
+];
+
+const SHORTCODES: Record<string, string | string[]> = {
+    '1F604': 'smile',
+    '1F44B': ['wave', 'waving_hand'],
+};
+
+const index = buildEmojiIndex(RAW, SHORTCODES);
+
+describe('buildEmojiIndex', () => {
+    it('joins data and shortcodes by hexcode', () => {
+        const smile = index.find((e) => e.hexcode === '1F604');
+        expect(smile?.shortcodes).toEqual(['smile']);
+        expect(smile?.tags).toEqual(['happy', 'smile']);
+    });
+});
+
+describe('rankEmoji', () => {
+    it('ranks an exact shortcode above a substring match', () => {
+        const results = rankEmoji(index, 'smile', { skinTone: 'none' });
+        expect(results[0]?.emoji).toBe('😄');
+    });
+
+    it('matches on shortcode prefix', () => {
+        const results = rankEmoji(index, 'wav', { skinTone: 'none' });
+        expect(results.map((r) => r.emoji)).toContain('👋');
+    });
+
+    it('matches on tag', () => {
+        const results = rankEmoji(index, 'hello', { skinTone: 'none' });
+        expect(results.map((r) => r.emoji)).toContain('👋');
+    });
+
+    it('returns nothing for an empty query', () => {
+        expect(rankEmoji(index, '', { skinTone: 'none' })).toEqual([]);
+    });
+
+    it('respects the limit', () => {
+        expect(rankEmoji(index, 'a', { skinTone: 'none', limit: 1 }).length).toBeLessThanOrEqual(1);
+    });
+
+    it('applies the selected skin tone', () => {
+        const results = rankEmoji(index, 'wave', { skinTone: 'dark' });
+        expect(results.find((r) => r.label === 'waving hand')?.emoji).toBe('👋🏿');
+    });
+});
+
+describe('applySkinTone', () => {
+    it('returns the base emoji for none', () => {
+        expect(applySkinTone(index[1]!, 'none')).toBe('👋');
+    });
+
+    it('returns the base emoji when the tone variant is missing', () => {
+        expect(applySkinTone(index[0]!, 'dark')).toBe('😄');
+    });
+});

--- a/resources/js/lib/compose/emoji/__tests__/trigger.test.ts
+++ b/resources/js/lib/compose/emoji/__tests__/trigger.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { matchEmojiTrigger } from '../trigger';
+
+describe('matchEmojiTrigger', () => {
+    it('matches a colon token after whitespace', () => {
+        // "hello :sm" — caret at doc pos 20, ":sm" is 3 chars → from = 17
+        expect(matchEmojiTrigger('hello :sm', 20)).toEqual({ query: 'sm', from: 17 });
+    });
+
+    it('matches a colon token at the start of a block', () => {
+        expect(matchEmojiTrigger(':smile', 6)).toEqual({ query: 'smile', from: 0 });
+    });
+
+    it('ignores a colon glued to a word (URLs)', () => {
+        expect(matchEmojiTrigger('http://', 7)).toBeNull();
+        expect(matchEmojiTrigger('see http://x', 12)).toBeNull();
+    });
+
+    it('ignores times like 12:30', () => {
+        expect(matchEmojiTrigger('12:30', 5)).toBeNull();
+    });
+
+    it('ignores text emoticons like :)', () => {
+        expect(matchEmojiTrigger('hey :)', 6)).toBeNull();
+    });
+
+    it('requires at least two query characters', () => {
+        expect(matchEmojiTrigger('hey :a', 6)).toBeNull();
+    });
+
+    it('returns null with no colon', () => {
+        expect(matchEmojiTrigger('just typing', 11)).toBeNull();
+    });
+});

--- a/resources/js/lib/compose/emoji/__tests__/trigger.test.ts
+++ b/resources/js/lib/compose/emoji/__tests__/trigger.test.ts
@@ -5,11 +5,17 @@ import { matchEmojiTrigger } from '../trigger';
 describe('matchEmojiTrigger', () => {
     it('matches a colon token after whitespace', () => {
         // "hello :sm" — caret at doc pos 20, ":sm" is 3 chars → from = 17
-        expect(matchEmojiTrigger('hello :sm', 20)).toEqual({ query: 'sm', from: 17 });
+        expect(matchEmojiTrigger('hello :sm', 20)).toEqual({
+            query: 'sm',
+            from: 17,
+        });
     });
 
     it('matches a colon token at the start of a block', () => {
-        expect(matchEmojiTrigger(':smile', 6)).toEqual({ query: 'smile', from: 0 });
+        expect(matchEmojiTrigger(':smile', 6)).toEqual({
+            query: 'smile',
+            from: 0,
+        });
     });
 
     it('ignores a colon glued to a word (URLs)', () => {

--- a/resources/js/lib/compose/emoji/preferences.ts
+++ b/resources/js/lib/compose/emoji/preferences.ts
@@ -1,0 +1,51 @@
+import type { EmojiSkinTone } from './types';
+
+export const MAX_RECENTS = 16;
+export const RECENTS_KEY = 'shoutrrr:emoji:recents';
+export const SKIN_TONE_KEY = 'shoutrrr:emoji:skin-tone';
+
+const SKIN_TONES: EmojiSkinTone[] = [
+    'none',
+    'light',
+    'medium-light',
+    'medium',
+    'medium-dark',
+    'dark',
+];
+
+/** Most-recently-used list: dedupe to front, cap at `max`. */
+export function pushRecent(
+    list: string[],
+    emoji: string,
+    max: number = MAX_RECENTS,
+): string[] {
+    return [emoji, ...list.filter((item) => item !== emoji)].slice(0, max);
+}
+
+/** Parse a stored recents list, tolerating null/corrupt/wrong-typed values. */
+export function parseRecents(raw: string | null): string[] {
+    if (!raw) {
+        return [];
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (
+            Array.isArray(parsed) &&
+            parsed.every((item) => typeof item === 'string')
+        ) {
+            return parsed;
+        }
+    } catch {
+        // fall through
+    }
+
+    return [];
+}
+
+/** Parse a stored skin tone, falling back to 'none'. */
+export function parseSkinTone(raw: string | null): EmojiSkinTone {
+    return SKIN_TONES.includes(raw as EmojiSkinTone)
+        ? (raw as EmojiSkinTone)
+        : 'none';
+}

--- a/resources/js/lib/compose/emoji/shortcode-index.ts
+++ b/resources/js/lib/compose/emoji/shortcode-index.ts
@@ -107,43 +107,63 @@ export function rankEmoji(
         }));
 }
 
-let indexPromise: Promise<EmojiEntry[]> | null = null;
+/** Abort emoji fetches that stall past this, so the promise rejects instead of
+ *  hanging forever (which would wedge the cache and never retry). */
+const FETCH_TIMEOUT_MS = 10_000;
+
+/** In-flight/resolved indexes keyed by source, so a different baseUrl/locale
+ *  doesn't reuse the first fetch. */
+const indexCache = new Map<string, Promise<EmojiEntry[]>>();
+
+async function fetchJson(url: string, signal: AbortSignal): Promise<unknown> {
+    const response = await fetch(url, { signal });
+    if (!response.ok) {
+        throw new Error(`emoji fetch failed (${response.status}): ${url}`);
+    }
+
+    return response.json();
+}
 
 /**
- * Fetch and build the emoji index once (memoized). Data is self-hosted under
- * `${baseUrl}/${locale}/…` to satisfy the app CSP. Rejects on network failure;
- * callers must treat a rejection as "no matches" and never surface it to the editor.
+ * Fetch and build the emoji index once per source (memoized). Data is
+ * self-hosted under `${baseUrl}/${locale}/…` to satisfy the app CSP. Rejects on
+ * network failure or timeout — callers must treat a rejection as "no matches"
+ * and never surface it to the editor. A rejected/aborted attempt is evicted so
+ * a later open can retry.
  */
 export function loadEmojiIndex(
     baseUrl = '/emoji',
     locale = 'en',
 ): Promise<EmojiEntry[]> {
-    if (!indexPromise) {
-        indexPromise = Promise.all([
-            fetch(`${baseUrl}/${locale}/data.json`).then((r) => {
-                if (!r.ok) {
-                    throw new Error(`emoji data fetch failed: ${r.status}`);
-                }
-                return r.json();
-            }),
-            fetch(`${baseUrl}/${locale}/shortcodes/emojibase.json`).then(
-                (r) => {
-                    if (!r.ok) {
-                        throw new Error(
-                            `emoji shortcodes fetch failed: ${r.status}`,
-                        );
-                    }
-                    return r.json();
-                },
-            ),
-        ])
-            .then(([data, shortcodes]) => buildEmojiIndex(data, shortcodes))
-            .catch((error) => {
-                // Allow a later open to retry rather than caching the failure.
-                indexPromise = null;
-                throw error;
-            });
+    const key = `${baseUrl}\n${locale}`;
+    const cached = indexCache.get(key);
+    if (cached) {
+        return cached;
     }
 
-    return indexPromise;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    const promise = Promise.all([
+        fetchJson(`${baseUrl}/${locale}/data.json`, controller.signal),
+        fetchJson(
+            `${baseUrl}/${locale}/shortcodes/emojibase.json`,
+            controller.signal,
+        ),
+    ])
+        .then(([data, shortcodes]) =>
+            buildEmojiIndex(
+                data as RawEmoji[],
+                shortcodes as Record<string, string | string[]>,
+            ),
+        )
+        .catch((error: unknown) => {
+            indexCache.delete(key);
+            throw error;
+        })
+        .finally(() => clearTimeout(timeout));
+
+    indexCache.set(key, promise);
+
+    return promise;
 }

--- a/resources/js/lib/compose/emoji/shortcode-index.ts
+++ b/resources/js/lib/compose/emoji/shortcode-index.ts
@@ -115,10 +115,18 @@ export function loadEmojiIndex(
 ): Promise<EmojiEntry[]> {
     if (!indexPromise) {
         indexPromise = Promise.all([
-            fetch(`${baseUrl}/${locale}/data.json`).then((r) => r.json()),
-            fetch(`${baseUrl}/${locale}/shortcodes/emojibase.json`).then((r) =>
-                r.json(),
-            ),
+            fetch(`${baseUrl}/${locale}/data.json`).then((r) => {
+                if (!r.ok) {
+                    throw new Error(`emoji data fetch failed: ${r.status}`);
+                }
+                return r.json();
+            }),
+            fetch(`${baseUrl}/${locale}/shortcodes/emojibase.json`).then((r) => {
+                if (!r.ok) {
+                    throw new Error(`emoji shortcodes fetch failed: ${r.status}`);
+                }
+                return r.json();
+            }),
         ])
             .then(([data, shortcodes]) => buildEmojiIndex(data, shortcodes))
             .catch((error) => {

--- a/resources/js/lib/compose/emoji/shortcode-index.ts
+++ b/resources/js/lib/compose/emoji/shortcode-index.ts
@@ -33,7 +33,9 @@ export function buildEmojiIndex(
         shortcodes: toShortcodes(shortcodes[row.hexcode]),
         skins: (row.skins ?? [])
             .filter(
-                (skin): skin is { hexcode: string; emoji: string; tone: number } =>
+                (
+                    skin,
+                ): skin is { hexcode: string; emoji: string; tone: number } =>
                     typeof skin.tone === 'number',
             )
             .map((skin) => ({ tone: skin.tone, emoji: skin.emoji })),
@@ -47,7 +49,10 @@ export function applySkinTone(entry: EmojiEntry, tone: EmojiSkinTone): string {
         return entry.emoji;
     }
 
-    return entry.skins.find((skin) => skin.tone === toneNumber)?.emoji ?? entry.emoji;
+    return (
+        entry.skins.find((skin) => skin.tone === toneNumber)?.emoji ??
+        entry.emoji
+    );
 }
 
 /** Best match score for an entry against a lowercased needle (0 = no match). */
@@ -121,12 +126,16 @@ export function loadEmojiIndex(
                 }
                 return r.json();
             }),
-            fetch(`${baseUrl}/${locale}/shortcodes/emojibase.json`).then((r) => {
-                if (!r.ok) {
-                    throw new Error(`emoji shortcodes fetch failed: ${r.status}`);
-                }
-                return r.json();
-            }),
+            fetch(`${baseUrl}/${locale}/shortcodes/emojibase.json`).then(
+                (r) => {
+                    if (!r.ok) {
+                        throw new Error(
+                            `emoji shortcodes fetch failed: ${r.status}`,
+                        );
+                    }
+                    return r.json();
+                },
+            ),
         ])
             .then(([data, shortcodes]) => buildEmojiIndex(data, shortcodes))
             .catch((error) => {

--- a/resources/js/lib/compose/emoji/shortcode-index.ts
+++ b/resources/js/lib/compose/emoji/shortcode-index.ts
@@ -1,0 +1,132 @@
+import type { EmojiEntry, EmojiMatch, EmojiSkinTone, RawEmoji } from './types';
+
+const TONE_NUMBER: Record<EmojiSkinTone, number> = {
+    none: 0,
+    light: 1,
+    'medium-light': 2,
+    medium: 3,
+    'medium-dark': 4,
+    dark: 5,
+};
+
+/** Normalize a shortcodes entry (string | string[]) into a flat list. */
+function toShortcodes(value: string | string[] | undefined): string[] {
+    if (!value) {
+        return [];
+    }
+
+    return (Array.isArray(value) ? value : [value]).map((code) =>
+        code.toLowerCase(),
+    );
+}
+
+/** Join emojibase `data.json` rows with a shortcodes preset, keyed by hexcode. */
+export function buildEmojiIndex(
+    data: RawEmoji[],
+    shortcodes: Record<string, string | string[]>,
+): EmojiEntry[] {
+    return data.map((row) => ({
+        emoji: row.emoji,
+        label: row.label,
+        hexcode: row.hexcode,
+        tags: row.tags ?? [],
+        shortcodes: toShortcodes(shortcodes[row.hexcode]),
+        skins: (row.skins ?? [])
+            .filter(
+                (skin): skin is { hexcode: string; emoji: string; tone: number } =>
+                    typeof skin.tone === 'number',
+            )
+            .map((skin) => ({ tone: skin.tone, emoji: skin.emoji })),
+    }));
+}
+
+/** The base emoji rendered in the selected skin tone, or the base if unavailable. */
+export function applySkinTone(entry: EmojiEntry, tone: EmojiSkinTone): string {
+    const toneNumber = TONE_NUMBER[tone];
+    if (toneNumber === 0) {
+        return entry.emoji;
+    }
+
+    return entry.skins.find((skin) => skin.tone === toneNumber)?.emoji ?? entry.emoji;
+}
+
+/** Best match score for an entry against a lowercased needle (0 = no match). */
+function scoreEntry(entry: EmojiEntry, needle: string): number {
+    let best = 0;
+
+    for (const shortcode of entry.shortcodes) {
+        if (shortcode === needle) {
+            return 4;
+        }
+        if (shortcode.startsWith(needle)) {
+            best = Math.max(best, 3);
+        } else if (shortcode.includes(needle)) {
+            best = Math.max(best, 2);
+        }
+    }
+
+    for (const token of [entry.label, ...entry.tags]) {
+        if (token.toLowerCase().includes(needle)) {
+            best = Math.max(best, 1);
+        }
+    }
+
+    return best;
+}
+
+/** Rank emoji for the typeahead: shortcode hits first, then label/tag hits. */
+export function rankEmoji(
+    index: EmojiEntry[],
+    query: string,
+    opts: { skinTone: EmojiSkinTone; limit?: number },
+): EmojiMatch[] {
+    const needle = query.trim().toLowerCase();
+    if (needle === '') {
+        return [];
+    }
+
+    return index
+        .map((entry) => ({ entry, score: scoreEntry(entry, needle) }))
+        .filter(({ score }) => score > 0)
+        .sort(
+            (a, b) =>
+                b.score - a.score ||
+                (a.entry.shortcodes[0]?.length ?? 99) -
+                    (b.entry.shortcodes[0]?.length ?? 99),
+        )
+        .slice(0, opts.limit ?? 8)
+        .map(({ entry }) => ({
+            emoji: applySkinTone(entry, opts.skinTone),
+            label: entry.label,
+            shortcode: entry.shortcodes[0] ?? entry.label,
+        }));
+}
+
+let indexPromise: Promise<EmojiEntry[]> | null = null;
+
+/**
+ * Fetch and build the emoji index once (memoized). Data is self-hosted under
+ * `${baseUrl}/${locale}/…` to satisfy the app CSP. Rejects on network failure;
+ * callers must treat a rejection as "no matches" and never surface it to the editor.
+ */
+export function loadEmojiIndex(
+    baseUrl = '/emoji',
+    locale = 'en',
+): Promise<EmojiEntry[]> {
+    if (!indexPromise) {
+        indexPromise = Promise.all([
+            fetch(`${baseUrl}/${locale}/data.json`).then((r) => r.json()),
+            fetch(`${baseUrl}/${locale}/shortcodes/emojibase.json`).then((r) =>
+                r.json(),
+            ),
+        ])
+            .then(([data, shortcodes]) => buildEmojiIndex(data, shortcodes))
+            .catch((error) => {
+                // Allow a later open to retry rather than caching the failure.
+                indexPromise = null;
+                throw error;
+            });
+    }
+
+    return indexPromise;
+}

--- a/resources/js/lib/compose/emoji/trigger.ts
+++ b/resources/js/lib/compose/emoji/trigger.ts
@@ -1,0 +1,19 @@
+/**
+ * Detect an active emoji shortcode trigger at the caret: a `:` that begins a
+ * word (start of block or after whitespace) followed by at least two of
+ * `[a-z0-9_+-]`. The boundary rule keeps URLs (`http://`), times (`12:30`),
+ * and emoticons (`:)`) from opening the picker.
+ */
+export function matchEmojiTrigger(
+    textBefore: string,
+    caretPos: number,
+): { query: string; from: number } | null {
+    const match = /(?:^|\s)(:[a-z0-9_+-]{2,})$/i.exec(textBefore);
+    if (!match) {
+        return null;
+    }
+
+    const token = match[1]; // ":smile"
+
+    return { query: token.slice(1), from: caretPos - token.length };
+}

--- a/resources/js/lib/compose/emoji/types.ts
+++ b/resources/js/lib/compose/emoji/types.ts
@@ -1,0 +1,34 @@
+/** Frimousse skin-tone identifiers, persisted verbatim and reused for the typeahead. */
+export type EmojiSkinTone =
+    | 'none'
+    | 'light'
+    | 'medium-light'
+    | 'medium'
+    | 'medium-dark'
+    | 'dark';
+
+/** A normalized emoji ready for search and skin-tone application. */
+export type EmojiEntry = {
+    emoji: string;
+    label: string;
+    hexcode: string;
+    tags: string[];
+    shortcodes: string[];
+    skins: { tone: number; emoji: string }[];
+};
+
+/** A single ranked typeahead result. */
+export type EmojiMatch = {
+    emoji: string;
+    label: string;
+    shortcode: string;
+};
+
+/** emojibase `data.json` row shape (only the fields we use). */
+export type RawEmoji = {
+    hexcode: string;
+    emoji: string;
+    label: string;
+    tags?: string[];
+    skins?: { hexcode: string; emoji: string; tone?: number | number[] }[];
+};

--- a/resources/js/lib/compose/tiptap/emoji-suggest.ts
+++ b/resources/js/lib/compose/tiptap/emoji-suggest.ts
@@ -1,0 +1,112 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey, type EditorState } from '@tiptap/pm/state';
+import { Decoration, DecorationSet } from '@tiptap/pm/view';
+
+import { matchEmojiTrigger } from '@/lib/compose/emoji/trigger';
+
+export type EmojiSuggestState = {
+    active: boolean;
+    query: string;
+    from: number;
+    to: number;
+};
+
+export const emojiSuggestKey = new PluginKey<EmojiSuggestState>('emojiSuggest');
+
+const INACTIVE: EmojiSuggestState = {
+    active: false,
+    query: '',
+    from: 0,
+    to: 0,
+};
+
+/** Derive the trigger state from the text before an empty caret. */
+function computeState(state: EditorState): EmojiSuggestState {
+    const { selection } = state;
+    if (!selection.empty) {
+        return INACTIVE;
+    }
+
+    const { $from } = selection;
+    const textBefore = $from.parent.textBetween(
+        0,
+        $from.parentOffset,
+        undefined,
+        '￼',
+    );
+    const match = matchEmojiTrigger(textBefore, selection.from);
+    if (!match) {
+        return INACTIVE;
+    }
+
+    return {
+        active: true,
+        query: match.query,
+        from: match.from,
+        to: selection.from,
+    };
+}
+
+const NAV_EVENTS: Record<string, { type: string; delta?: number }> = {
+    ArrowDown: { type: 'composer:emoji-nav', delta: 1 },
+    ArrowUp: { type: 'composer:emoji-nav', delta: -1 },
+    Enter: { type: 'composer:emoji-commit' },
+    Tab: { type: 'composer:emoji-commit' },
+    Escape: { type: 'composer:emoji-dismiss' },
+};
+
+/**
+ * Tracks an active `:shortcode` trigger and, while active, forwards navigation
+ * keys to React via DOM CustomEvents (mirrors `composer:mention-click`). The
+ * popover UI lives in EditorBody; this plugin owns only trigger state + keys.
+ */
+export const EmojiSuggest = Extension.create({
+    name: 'emojiSuggest',
+
+    addProseMirrorPlugins() {
+        return [
+            new Plugin<EmojiSuggestState>({
+                key: emojiSuggestKey,
+                state: {
+                    init: () => INACTIVE,
+                    apply: (_tr, _value, _old, newState) =>
+                        computeState(newState),
+                },
+                props: {
+                    decorations(state) {
+                        const current = emojiSuggestKey.getState(state);
+                        if (!current?.active) {
+                            return null;
+                        }
+
+                        return DecorationSet.create(state.doc, [
+                            Decoration.inline(current.from, current.to, {
+                                class: 'rounded bg-primary/10 text-primary',
+                            }),
+                        ]);
+                    },
+                    handleKeyDown(view, event) {
+                        const current = emojiSuggestKey.getState(view.state);
+                        if (!current?.active) {
+                            return false;
+                        }
+
+                        const mapping = NAV_EVENTS[event.key];
+                        if (!mapping) {
+                            return false;
+                        }
+
+                        view.dom.dispatchEvent(
+                            new CustomEvent(mapping.type, {
+                                bubbles: true,
+                                detail: { delta: mapping.delta ?? 0 },
+                            }),
+                        );
+
+                        return true;
+                    },
+                },
+            }),
+        ];
+    },
+});

--- a/resources/js/lib/compose/tiptap/emoji-suggest.ts
+++ b/resources/js/lib/compose/tiptap/emoji-suggest.ts
@@ -63,7 +63,15 @@ const NAV_EVENTS: Record<string, { type: string; delta?: number }> = {
 export const EmojiSuggest = Extension.create({
     name: 'emojiSuggest',
 
+    addOptions() {
+        return {
+            openRef: null as { current: boolean } | null,
+        };
+    },
+
     addProseMirrorPlugins() {
+        const openRef = this.options.openRef;
+
         return [
             new Plugin<EmojiSuggestState>({
                 key: emojiSuggestKey,
@@ -87,7 +95,7 @@ export const EmojiSuggest = Extension.create({
                     },
                     handleKeyDown(view, event) {
                         const current = emojiSuggestKey.getState(view.state);
-                        if (!current?.active) {
+                        if (!current?.active || !openRef?.current) {
                             return false;
                         }
 

--- a/resources/js/lib/compose/tiptap/setup.ts
+++ b/resources/js/lib/compose/tiptap/setup.ts
@@ -5,6 +5,7 @@ import Paragraph from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
 import { Placeholder, UndoRedo } from '@tiptap/extensions';
 
+import { EmojiSuggest } from './emoji-suggest';
 import { MentionPlaceholders } from './mention-placeholders';
 import { SectionBreak } from './section-break';
 import { SectionMarkers } from './section-markers';
@@ -33,6 +34,7 @@ export function composerExtensions(
         }),
         SectionBreak,
         MentionPlaceholders,
+        EmojiSuggest,
         SectionMarkers,
     ];
 }

--- a/resources/js/lib/compose/tiptap/setup.ts
+++ b/resources/js/lib/compose/tiptap/setup.ts
@@ -17,7 +17,10 @@ import { SectionMarkers } from './section-markers';
  * Mention/Hashtag extensions are intentionally dropped (out of scope).
  */
 export function composerExtensions(
-    opts: { placeholder?: string } = {},
+    opts: {
+        placeholder?: string;
+        emojiOpenRef?: { current: boolean } | null;
+    } = {},
 ): Extensions {
     return [
         Document,
@@ -34,7 +37,7 @@ export function composerExtensions(
         }),
         SectionBreak,
         MentionPlaceholders,
-        EmojiSuggest,
+        EmojiSuggest.configure({ openRef: opts.emojiOpenRef ?? null }),
         SectionMarkers,
     ];
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { networkInterfaces } from 'node:os';
+import { cpSync } from 'node:fs';
 
 import inertia from '@inertiajs/vite';
 import { wayfinder } from '@laravel/vite-plugin-wayfinder';
@@ -27,6 +28,22 @@ const tailscaleHost = (): string | undefined => {
 
 const hmrHost = process.env.VITE_HMR_HOST ?? tailscaleHost() ?? 'localhost';
 
+// Copy the emojibase `en` locale into public/ so Frimousse and the emoji
+// typeahead fetch it same-origin. The app's CSP (connect-src 'self') blocks
+// Frimousse's default jsdelivr CDN, so the data must be served from our origin.
+function copyEmojiData() {
+    const copy = () =>
+        cpSync('node_modules/emojibase-data/en', 'public/emoji/en', {
+            recursive: true,
+        });
+
+    return {
+        name: 'copy-emoji-data',
+        buildStart: copy,
+        configureServer: copy,
+    };
+}
+
 export default defineConfig({
     server: {
         host: process.env.VITE_HOST ?? '0.0.0.0',
@@ -40,6 +57,7 @@ export default defineConfig({
             : undefined,
     },
     plugins: [
+        copyEmojiData(),
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.tsx'],
             refresh: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-import { networkInterfaces } from 'node:os';
 import { cpSync } from 'node:fs';
+import { networkInterfaces } from 'node:os';
 
 import inertia from '@inertiajs/vite';
 import { wayfinder } from '@laravel/vite-plugin-wayfinder';
@@ -32,10 +32,19 @@ const hmrHost = process.env.VITE_HMR_HOST ?? tailscaleHost() ?? 'localhost';
 // typeahead fetch it same-origin. The app's CSP (connect-src 'self') blocks
 // Frimousse's default jsdelivr CDN, so the data must be served from our origin.
 function copyEmojiData() {
-    const copy = () =>
-        cpSync('node_modules/emojibase-data/en', 'public/emoji/en', {
-            recursive: true,
-        });
+    const copy = () => {
+        try {
+            cpSync('node_modules/emojibase-data/en', 'public/emoji/en', {
+                recursive: true,
+            });
+        } catch (error) {
+            throw new Error(
+                'copy-emoji-data: could not copy node_modules/emojibase-data/en ' +
+                    'to public/emoji/en. Run `bun install` to restore the ' +
+                    `emojibase-data dependency. (${(error as Error).message})`,
+            );
+        }
+    };
 
     return {
         name: 'copy-emoji-data',


### PR DESCRIPTION
## Emoji browser for the composer

Adds a first-class emoji browser to the composer with **two entry points**:

- **Toolbar “Emoji” button** → a styled [Frimousse](https://frimousse.liveblocks.io/) headless picker in a Radix popover: search, categories, a recently-used row, and a skin-tone selector. Selecting inserts a native-unicode emoji at the caret.
- **Inline `:shortcode` typeahead** → type `:fire` in the editor and a popover offers matches; ↑/↓ navigate, Enter/Tab commit, Esc dismisses. Built as a custom ProseMirror plugin mirroring the existing `@`-mention `composer:mention-click` CustomEvent bridge, so focus never leaves the editor.

Recently-used and skin-tone are persisted per-browser (localStorage) and shared by both surfaces.

### How it’s built
- **CSP-safe data hosting.** The app’s `connect-src` is `'self' blob:`, which blocks Frimousse’s default jsdelivr CDN. A small Vite plugin copies `emojibase-data/en` → `public/emoji/en` (gitignored) on `buildStart`/`configureServer`, and both the picker (`emojibaseUrl="/emoji"`) and the typeahead index fetch it same-origin. Emoji render as native unicode (no sprite images).
- **Pure, unit-tested core** (`resources/js/lib/compose/emoji/`): the `:`-trigger matcher, the shortcode search index + ranking + skin-tone application, and the preferences helpers — 26 Vitest cases.
- **Thin React/editor wiring** verified by `tsc` + `build` (Vitest runs node-env here, so component/editor wiring is browser-verified, not unit-tested).
- New deps: `frimousse`, `emojibase-data`.

### Testing
- ✅ 26 emoji unit tests, `types:check`, `lint:check`, `oxfmt`, and `bun run build` all clean.
- ℹ️ The full JS suite shows 3 failures (`reconnect-oauth-route` ×2, `pick-time` ×1) that **also fail on `main`** — pre-existing and unrelated to this branch.
- ⏳ **Pending in-browser verification** (no browser in the build env): picker open/select, recents row, skin-tone round-trip + persistence, typeahead trigger firing, negatives (`http://`, `12:30` don’t open it), arrow wraparound, Enter/Tab/Esc, skin-toned typeahead results, and recents updating from the typeahead.

### Follow-ups (deferred, non-blocking — from review)
- Add `onOpenChange`/interact-outside dismissal to the typeahead popover (parity with the mention popover) so it can’t linger if you click away mid-`:query`.
- `EmojiPopover` trigger button duplicates `EToolButton` styling and misses its active-state shadow — cosmetic; reuse would need `EToolButton` to forward props/ref.