### PR TITLE
feat: enable/disable platforms in instance settings

### DIFF
--- a/app/Console/Commands/RefreshExpiringTokens.php
+++ b/app/Console/Commands/RefreshExpiringTokens.php
@@ -9,6 +9,7 @@ use App\Enums\Platform;
 use App\Exceptions\TokenRefreshException;
 use App\Models\ConnectedAccount;
 use App\Services\Publishing\TokenManager;
+use App\Support\InstanceSettings;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Date;
 
@@ -20,8 +21,13 @@ class RefreshExpiringTokens extends Command
 
     public function handle(TokenManager $tokens): int
     {
+        $availablePlatforms = array_keys(array_filter(
+            app(InstanceSettings::class)->platformsEnabled(),
+        ));
+
         ConnectedAccount::query()
             ->withoutGlobalScopes()
+            ->whereIn('platform', $availablePlatforms)
             ->where(function ($query): void {
                 $query->where('platform', '!=', Platform::Bluesky->value)
                     ->orWhere(function ($query): void {

--- a/app/Enums/Platform.php
+++ b/app/Enums/Platform.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Enums;
 
+use App\Support\InstanceSettings;
+
 enum Platform: string
 {
     case X = 'x';
@@ -123,6 +125,24 @@ enum Platform: string
     }
 
     /**
+     * The launched Meta-Graph platforms (Facebook, Instagram) that are ALSO
+     * enabled instance-wide — used to gate the shared Meta connect flow and the
+     * per-asset platform list so an owner can freeze Facebook or Instagram
+     * independently.
+     *
+     * @return list<self>
+     */
+    public static function availableMetaGraphPlatforms(): array
+    {
+        $enabled = app(InstanceSettings::class)->platformsEnabled();
+
+        return array_values(array_filter(
+            [self::Facebook, self::Instagram],
+            fn (self $platform): bool => $platform->isLaunched() && ($enabled[$platform->value] ?? true),
+        ));
+    }
+
+    /**
      * Facebook and Instagram share a single Facebook Login flow with a
      * Page/asset-selection step, driven by `MetaConnectionController`. The
      * generic per-platform `OAuthConnectionController` (a single-step
@@ -135,10 +155,12 @@ enum Platform: string
     }
 
     /**
-     * @return list<array{platform: string, label: string, supportsOAuth: bool, supportsAppPassword: bool, configured: bool, launched: bool}>
+     * @return list<array{platform: string, label: string, supportsOAuth: bool, supportsAppPassword: bool, configured: bool, launched: bool, enabled: bool}>
      */
     public static function capabilities(): array
     {
+        $enabled = app(InstanceSettings::class)->platformsEnabled();
+
         return array_map(fn (self $platform): array => [
             'platform' => $platform->value,
             'label' => $platform->label(),
@@ -146,6 +168,7 @@ enum Platform: string
             'supportsAppPassword' => $platform->supportsAppPassword(),
             'configured' => $platform->isConfigured(),
             'launched' => $platform->isLaunched(),
+            'enabled' => $enabled[$platform->value] ?? true,
         ], self::cases());
     }
 

--- a/app/Enums/PostTargetStatus.php
+++ b/app/Enums/PostTargetStatus.php
@@ -13,4 +13,14 @@ enum PostTargetStatus: string
     case Skipped = 'skipped';
     case Deleting = 'deleting';
     case Deleted = 'deleted';
+
+    /**
+     * Whether a manual retry may re-dispatch this target: a hard failure or a
+     * target that was skipped (e.g. its platform was frozen instance-wide) and
+     * can now be re-attempted.
+     */
+    public function isRetryable(): bool
+    {
+        return in_array($this, [self::Failed, self::Skipped], true);
+    }
 }

--- a/app/Enums/PostTargetStatus.php
+++ b/app/Enums/PostTargetStatus.php
@@ -10,6 +10,7 @@ enum PostTargetStatus: string
     case Publishing = 'publishing';
     case Published = 'published';
     case Failed = 'failed';
+    case Skipped = 'skipped';
     case Deleting = 'deleting';
     case Deleted = 'deleted';
 }

--- a/app/Http/Controllers/Api/V1/PostActionsController.php
+++ b/app/Http/Controllers/Api/V1/PostActionsController.php
@@ -91,7 +91,7 @@ class PostActionsController extends Controller
             abort(404, 'No such target on that post.');
         }
 
-        if (! in_array($postTarget->status, [PostTargetStatus::Failed, PostTargetStatus::Skipped], true)) {
+        if (! $postTarget->status->isRetryable()) {
             abort(422, 'Only failed or skipped targets can be retried.');
         }
 

--- a/app/Http/Controllers/Api/V1/PostActionsController.php
+++ b/app/Http/Controllers/Api/V1/PostActionsController.php
@@ -91,8 +91,8 @@ class PostActionsController extends Controller
             abort(404, 'No such target on that post.');
         }
 
-        if ($postTarget->status !== PostTargetStatus::Failed) {
-            abort(422, 'Only failed targets can be retried.');
+        if (! in_array($postTarget->status, [PostTargetStatus::Failed, PostTargetStatus::Skipped], true)) {
+            abort(422, 'Only failed or skipped targets can be retried.');
         }
 
         $postTarget->forceFill([

--- a/app/Http/Controllers/ConnectedAccounts/ConnectedAccountController.php
+++ b/app/Http/Controllers/ConnectedAccounts/ConnectedAccountController.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Controller;
 use App\Models\ConnectedAccount;
 use App\Services\ConnectedAccounts\AccountConnectionService;
 use App\Services\ConnectedAccounts\BlueskyConnector;
+use App\Support\InstanceSettings;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -82,6 +83,11 @@ class ConnectedAccountController extends Controller
     public function reconnect(Request $request, ConnectedAccount $account): RedirectResponse
     {
         $request->user()->can('update', $account) ?: abort(403);
+
+        if (! app(InstanceSettings::class)->platformAvailable($account->platform)) {
+            return redirect()->route('accounts.index')
+                ->with('error', "{$account->platform->label()} is disabled on this instance.");
+        }
 
         // OAuth accounts reconnect by re-running the provider flow (which upserts
         // onto this row via the unique constraint); only app-password accounts

--- a/app/Http/Controllers/ConnectedAccounts/MetaConnectionController.php
+++ b/app/Http/Controllers/ConnectedAccounts/MetaConnectionController.php
@@ -64,7 +64,7 @@ class MetaConnectionController extends Controller
      */
     private function abortUnlessMetaFlowAvailable(): void
     {
-        if (! Platform::Facebook->isConfigured() || Platform::launchedMetaGraphPlatforms() === []) {
+        if (! Platform::Facebook->isConfigured() || Platform::availableMetaGraphPlatforms() === []) {
             abort(404);
         }
     }
@@ -267,9 +267,14 @@ class MetaConnectionController extends Controller
      */
     private function availablePlatformsFor(array $asset): array
     {
-        $platforms = [Platform::Facebook->value];
+        $available = Platform::availableMetaGraphPlatforms();
+        $platforms = [];
 
-        if (Platform::Instagram->isLaunched() && $asset['igUserId'] !== null) {
+        if (in_array(Platform::Facebook, $available, true)) {
+            $platforms[] = Platform::Facebook->value;
+        }
+
+        if (in_array(Platform::Instagram, $available, true) && $asset['igUserId'] !== null) {
             $platforms[] = Platform::Instagram->value;
         }
 

--- a/app/Http/Controllers/ConnectedAccounts/MetaConnectionController.php
+++ b/app/Http/Controllers/ConnectedAccounts/MetaConnectionController.php
@@ -231,7 +231,7 @@ class MetaConnectionController extends Controller
     {
         $scopes = [];
 
-        foreach (Platform::launchedMetaGraphPlatforms() as $platform) {
+        foreach (Platform::availableMetaGraphPlatforms() as $platform) {
             array_push($scopes, ...$platform->scopes());
         }
 

--- a/app/Http/Controllers/ConnectedAccounts/OAuthConnectionController.php
+++ b/app/Http/Controllers/ConnectedAccounts/OAuthConnectionController.php
@@ -11,6 +11,7 @@ use App\Models\ConnectedAccount;
 use App\Services\ConnectedAccounts\AccountConnectionService;
 use App\Services\ConnectedAccounts\Threads\ThreadsTokenExchanger;
 use App\Services\ConnectedAccounts\XAccountCapabilities;
+use App\Support\InstanceSettings;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -158,6 +159,7 @@ class OAuthConnectionController extends Controller
             || ! $resolved->supportsOAuth()
             || ! $resolved->isConfigured()
             || ! $resolved->isLaunched()
+            || ! app(InstanceSettings::class)->platformAvailable($resolved)
             // Facebook/Instagram always go through the dedicated
             // MetaConnectionController Page-selection flow, never this
             // generic single-step route — even once launched.

--- a/app/Http/Controllers/Posts/ComposerController.php
+++ b/app/Http/Controllers/Posts/ComposerController.php
@@ -12,6 +12,7 @@ use App\Models\AccountSet;
 use App\Models\ConnectedAccount;
 use App\Models\Post;
 use App\Models\WorkspaceMention;
+use App\Support\InstanceSettings;
 use App\Support\MetricsPresenter;
 use App\Support\PostView;
 use Illuminate\Http\Request;
@@ -24,9 +25,11 @@ class ComposerController extends Controller
     {
         $request->user()->can('viewAny', Post::class) ?: abort(403);
         $defaultAccountId = $request->user()->currentWorkspace()->value('default_connected_account_id');
+        $settings = app(InstanceSettings::class);
 
         $accounts = ConnectedAccount::query()
             ->get()
+            ->filter(fn (ConnectedAccount $account): bool => $settings->platformAvailable($account->platform))
             ->sortByDesc(fn (ConnectedAccount $account): bool => $account->id === $defaultAccountId)
             ->map(fn (ConnectedAccount $account): array => [
                 'id' => $account->id,

--- a/app/Http/Controllers/Posts/PostTargetRetryController.php
+++ b/app/Http/Controllers/Posts/PostTargetRetryController.php
@@ -20,7 +20,7 @@ class PostTargetRetryController extends Controller
     public function store(Request $request, Post $post, PostTarget $target): JsonResponse|RedirectResponse
     {
         abort_unless($request->user()->can('update', $post), 403);
-        abort_unless(in_array($target->status, [PostTargetStatus::Failed, PostTargetStatus::Skipped], true), 409);
+        abort_unless($target->status->isRetryable(), 409);
 
         $target->forceFill([
             'status' => PostTargetStatus::Pending->value,

--- a/app/Http/Controllers/Posts/PostTargetRetryController.php
+++ b/app/Http/Controllers/Posts/PostTargetRetryController.php
@@ -20,7 +20,7 @@ class PostTargetRetryController extends Controller
     public function store(Request $request, Post $post, PostTarget $target): JsonResponse|RedirectResponse
     {
         abort_unless($request->user()->can('update', $post), 403);
-        abort_unless($target->status === PostTargetStatus::Failed, 409);
+        abort_unless(in_array($target->status, [PostTargetStatus::Failed, PostTargetStatus::Skipped], true), 409);
 
         $target->forceFill([
             'status' => PostTargetStatus::Pending->value,

--- a/app/Http/Controllers/Settings/InstanceSettingsController.php
+++ b/app/Http/Controllers/Settings/InstanceSettingsController.php
@@ -7,6 +7,7 @@ use App\Enums\Platform;
 use App\Enums\UsageCategory;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\StoreInstanceOwnerRequest;
+use App\Http\Requests\Settings\UpdateInstancePlatformsRequest;
 use App\Http\Requests\Settings\UpdateInstancePollingSettingsRequest;
 use App\Http\Requests\Settings\UpdateInstanceSettingsRequest;
 use App\Models\UsageEvent;
@@ -99,6 +100,31 @@ class InstanceSettingsController extends Controller
         return Inertia::render('settings/instance-polling', [
             'settings' => $settings->polling(),
         ]);
+    }
+
+    public function platforms(Request $request, InstanceSettings $settings): Response
+    {
+        /** @var User|null $user */
+        $user = $request->user();
+        abort_unless($user?->isInstanceOwner(), 403);
+
+        $enabled = $settings->platformsEnabled();
+
+        return Inertia::render('settings/instance-platforms', [
+            'platforms' => array_map(fn (Platform $platform): array => [
+                'platform' => $platform->value,
+                'label' => $platform->label(),
+                'enabled' => $enabled[$platform->value] ?? true,
+                'configured' => $platform->isConfigured(),
+            ], Platform::cases()),
+        ]);
+    }
+
+    public function updatePlatforms(UpdateInstancePlatformsRequest $request, InstanceSettings $settings): RedirectResponse
+    {
+        $settings->update(['platforms_enabled' => $request->platformsEnabled()]);
+
+        return back()->with('success', 'Platform settings updated.');
     }
 
     public function usage(Request $request, UsagePricing $pricing): Response

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -96,10 +96,12 @@ class HandleInertiaRequests extends Middleware
         // middleware ordering and prevents cross-workspace leakage.
         $workspaceId = $user->current_workspace_id;
         $defaultAccountId = $user->currentWorkspace()->value('default_connected_account_id');
+        $settings = app(InstanceSettings::class);
 
         $accounts = ConnectedAccount::query()
             ->where('workspace_id', $workspaceId)
             ->get()
+            ->filter(fn (ConnectedAccount $account): bool => $settings->platformAvailable($account->platform))
             ->sortByDesc(fn (ConnectedAccount $account): bool => $account->id === $defaultAccountId)
             ->map(fn (ConnectedAccount $account): array => [
                 'id' => $account->id,

--- a/app/Http/Requests/Settings/UpdateInstancePlatformsRequest.php
+++ b/app/Http/Requests/Settings/UpdateInstancePlatformsRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use App\Enums\Platform;
+use App\Models\User;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateInstancePlatformsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        /** @var User|null $user */
+        $user = $this->user();
+
+        return $user?->isInstanceOwner() ?? false;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $rules = ['platforms' => ['required', 'array']];
+
+        foreach (Platform::cases() as $platform) {
+            $rules["platforms.{$platform->value}"] = ['required', 'boolean'];
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    public function platformsEnabled(): array
+    {
+        /** @var array{platforms: array<string, bool>} $validated */
+        $validated = $this->validated();
+
+        return $validated['platforms'];
+    }
+}

--- a/app/Jobs/PublishPostTarget.php
+++ b/app/Jobs/PublishPostTarget.php
@@ -22,6 +22,7 @@ use App\Services\Publishing\BackoffSchedule;
 use App\Services\Publishing\PostStatusRollup;
 use App\Services\Publishing\PublishConnectorRegistry;
 use App\Services\Publishing\TokenManager;
+use App\Support\InstanceSettings;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Date;
@@ -57,6 +58,7 @@ class PublishPostTarget implements ShouldQueue
 
     private const array TERMINAL = [
         PostTargetStatus::Published,
+        PostTargetStatus::Skipped,
         PostTargetStatus::Deleting,
         PostTargetStatus::Deleted,
     ];
@@ -77,6 +79,19 @@ class PublishPostTarget implements ShouldQueue
         // Guard against a stale delayed retry or a double dispatch firing after the
         // target already reached a terminal state: doing nothing keeps it a no-op.
         if (in_array($target->status, self::TERMINAL, true)) {
+            return;
+        }
+
+        if (! app(InstanceSettings::class)->platformAvailable($target->platform)) {
+            $target->forceFill([
+                'status' => PostTargetStatus::Skipped->value,
+                'error_kind' => null,
+                'error_message' => "{$target->platform->label()} is disabled on this instance.",
+                'next_attempt_at' => null,
+            ])->save();
+
+            $rollup->recompute($target->post()->firstOrFail());
+
             return;
         }
 

--- a/app/Jobs/PublishPostTarget.php
+++ b/app/Jobs/PublishPostTarget.php
@@ -71,8 +71,10 @@ class PublishPostTarget implements ShouldQueue
         PostStatusRollup $rollup,
         BackoffSchedule $backoff,
         ?WorkspaceSubscriptionGate $subscriptions = null,
+        ?InstanceSettings $settings = null,
     ): void {
         $subscriptions ??= app(WorkspaceSubscriptionGate::class);
+        $settings ??= app(InstanceSettings::class);
         $target = $this->target->fresh() ?? $this->target;
         $this->target = $target;
 
@@ -82,7 +84,7 @@ class PublishPostTarget implements ShouldQueue
             return;
         }
 
-        if (! app(InstanceSettings::class)->platformAvailable($target->platform)) {
+        if (! $settings->platformAvailable($target->platform)) {
             $target->forceFill([
                 'status' => PostTargetStatus::Skipped->value,
                 'error_kind' => null,

--- a/app/Mcp/Tools/RetryPostTargetTool.php
+++ b/app/Mcp/Tools/RetryPostTargetTool.php
@@ -17,7 +17,7 @@ use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
 
-#[Description('Retry a failed publish target. Outward-facing (re-attempts a live post). Requires confirm=true.')]
+#[Description('Retry a failed or skipped publish target. Outward-facing (re-attempts a live post). Requires confirm=true.')]
 class RetryPostTargetTool extends WorkspaceTool
 {
     public function handle(Request $request, PostStatusRollup $rollup): Response
@@ -47,8 +47,8 @@ class RetryPostTargetTool extends WorkspaceTool
             return Response::error('No such target on that post.');
         }
 
-        if ($target->status !== PostTargetStatus::Failed) {
-            return Response::error('Only failed targets can be retried.');
+        if (! in_array($target->status, [PostTargetStatus::Failed, PostTargetStatus::Skipped], true)) {
+            return Response::error('Only failed or skipped targets can be retried.');
         }
 
         if ($unconfirmed = $this->requireConfirmation($request, 'This will re-attempt publishing to the connected account.')) {
@@ -78,7 +78,7 @@ class RetryPostTargetTool extends WorkspaceTool
     {
         return [
             'post_id' => $schema->string()->description('Post id.')->required(),
-            'target_id' => $schema->string()->description('Failed target id.')->required(),
+            'target_id' => $schema->string()->description('Failed or skipped target id.')->required(),
             'confirm' => $schema->boolean()->description('Must be true to retry.'),
         ];
     }

--- a/app/Mcp/Tools/RetryPostTargetTool.php
+++ b/app/Mcp/Tools/RetryPostTargetTool.php
@@ -47,7 +47,7 @@ class RetryPostTargetTool extends WorkspaceTool
             return Response::error('No such target on that post.');
         }
 
-        if (! in_array($target->status, [PostTargetStatus::Failed, PostTargetStatus::Skipped], true)) {
+        if (! $target->status->isRetryable()) {
             return Response::error('Only failed or skipped targets can be retried.');
         }
 

--- a/app/Services/Posts/DraftService.php
+++ b/app/Services/Posts/DraftService.php
@@ -14,6 +14,7 @@ use App\Models\PostMedia;
 use App\Models\PostTarget;
 use App\Models\User;
 use App\Models\Workspace;
+use App\Support\InstanceSettings;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 
@@ -78,7 +79,30 @@ class DraftService
                 ->pluck('id'),
         };
 
+        $frozen = $this->frozenPlatformValues();
+
+        $ids = $frozen === []
+            ? $ids
+            : ConnectedAccount::withoutGlobalScopes()
+                ->whereKey($ids->all())
+                ->whereNotIn('platform', $frozen)
+                ->pluck('id');
+
         return $this->defaultFirst($workspaceId, $ids->map(static fn (mixed $id): string => (string) $id)->all());
+    }
+
+    /**
+     * The platform values that are frozen instance-wide, so draft targeting
+     * never snapshots an account whose platform is disabled.
+     *
+     * @return list<string>
+     */
+    private function frozenPlatformValues(): array
+    {
+        return array_keys(array_filter(
+            app(InstanceSettings::class)->platformsEnabled(),
+            static fn (bool $enabled): bool => ! $enabled,
+        ));
     }
 
     /**

--- a/app/Services/Publishing/PostStatusRollup.php
+++ b/app/Services/Publishing/PostStatusRollup.php
@@ -16,20 +16,20 @@ class PostStatusRollup
         $statuses = $post->targets()->pluck('status')
             ->map(fn (PostTargetStatus|string $value): PostTargetStatus => $value instanceof PostTargetStatus ? $value : PostTargetStatus::from($value));
 
+        $total = $statuses->count();
         $hasInFlight = $statuses->contains(fn (PostTargetStatus $s): bool => in_array($s, [PostTargetStatus::Pending, PostTargetStatus::Publishing], true));
         $published = $statuses->filter(fn (PostTargetStatus $s): bool => $s === PostTargetStatus::Published)->count();
-        $total = $statuses->count();
+        $failed = $statuses->filter(fn (PostTargetStatus $s): bool => $s === PostTargetStatus::Failed)->count();
+        $skipped = $statuses->filter(fn (PostTargetStatus $s): bool => $s === PostTargetStatus::Skipped)->count();
 
-        $hasTargets = $total > 0;
-        $allPublished = $published === $total;
-        $anyPublished = $published > 0;
+        $allPublished = $total > 0 && $published === $total;
+        $noneReached = $total > 0 && $published === 0 && ($failed + $skipped) === $total;
 
         $status = match (true) {
             $hasInFlight => PostStatus::Publishing,
-            $hasTargets && $allPublished => PostStatus::Published,
-            $hasTargets && $anyPublished => PostStatus::Partial, // some published, rest failed/skipped
-            $hasTargets => PostStatus::Failed,                   // nothing published (all failed/skipped)
-            default => PostStatus::Partial,                      // no targets — unchanged edge
+            $allPublished => PostStatus::Published,
+            $noneReached => PostStatus::Failed,
+            default => PostStatus::Partial,
         };
 
         $post->status = $status;

--- a/app/Services/Publishing/PostStatusRollup.php
+++ b/app/Services/Publishing/PostStatusRollup.php
@@ -18,14 +18,18 @@ class PostStatusRollup
 
         $hasInFlight = $statuses->contains(fn (PostTargetStatus $s): bool => in_array($s, [PostTargetStatus::Pending, PostTargetStatus::Publishing], true));
         $published = $statuses->filter(fn (PostTargetStatus $s): bool => $s === PostTargetStatus::Published)->count();
-        $failed = $statuses->filter(fn (PostTargetStatus $s): bool => $s === PostTargetStatus::Failed)->count();
         $total = $statuses->count();
+
+        $hasTargets = $total > 0;
+        $allPublished = $published === $total;
+        $anyPublished = $published > 0;
 
         $status = match (true) {
             $hasInFlight => PostStatus::Publishing,
-            $published === $total && $total > 0 => PostStatus::Published,
-            $failed === $total && $total > 0 => PostStatus::Failed,
-            default => PostStatus::Partial,
+            $hasTargets && $allPublished => PostStatus::Published,
+            $hasTargets && $anyPublished => PostStatus::Partial, // some published, rest failed/skipped
+            $hasTargets => PostStatus::Failed,                   // nothing published (all failed/skipped)
+            default => PostStatus::Partial,                      // no targets — unchanged edge
         };
 
         $post->status = $status;

--- a/app/Services/Publishing/PublishDispatcher.php
+++ b/app/Services/Publishing/PublishDispatcher.php
@@ -13,6 +13,7 @@ class PublishDispatcher
 {
     private const array TERMINAL = [
         PostTargetStatus::Published,
+        PostTargetStatus::Skipped,
         PostTargetStatus::Deleting,
         PostTargetStatus::Deleted,
     ];

--- a/app/Support/InstanceSettings.php
+++ b/app/Support/InstanceSettings.php
@@ -31,22 +31,38 @@ class InstanceSettings
 
     public function engagementPollingEnabled(?Platform $platform = null): bool
     {
-        return $this->platformEnabled('engagement_polling_enabled', $platform);
+        return $this->platformAvailable($platform)
+            && $this->platformEnabled('engagement_polling_enabled', $platform);
     }
 
     public function postMetricsPollingEnabled(?Platform $platform = null): bool
     {
-        return $this->platformEnabled('post_metrics_polling_enabled', $platform);
+        return $this->platformAvailable($platform)
+            && $this->platformEnabled('post_metrics_polling_enabled', $platform);
     }
 
     public function accountMetricsPollingEnabled(?Platform $platform = null): bool
     {
-        return $this->platformEnabled('account_metrics_polling_enabled', $platform);
+        return $this->platformAvailable($platform)
+            && $this->platformEnabled('account_metrics_polling_enabled', $platform);
     }
 
     public function quoteTweetsEnabled(): bool
     {
         return $this->boolean('quote_tweets_enabled');
+    }
+
+    public function platformAvailable(?Platform $platform = null): bool
+    {
+        return $this->platformEnabled('platforms_enabled', $platform);
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    public function platformsEnabled(): array
+    {
+        return $this->platformEnabledValues('platforms_enabled');
     }
 
     public function registrationsAllowed(?string $invitationToken = null): bool

--- a/resources/js/components/accounts/__tests__/connect-buttons-layout.test.ts
+++ b/resources/js/components/accounts/__tests__/connect-buttons-layout.test.ts
@@ -18,6 +18,7 @@ function capability(overrides: Partial<Capability>): Capability {
         supportsAppPassword: false,
         configured: true,
         launched: false,
+        enabled: true,
         ...overrides,
     };
 }

--- a/resources/js/components/accounts/account-card.tsx
+++ b/resources/js/components/accounts/account-card.tsx
@@ -134,11 +134,13 @@ function ReconnectBlueskyDialog({ account }: { account: Account }) {
 export function AccountCard({
     account,
     canManage,
+    frozen,
     onReconnectOAuth,
     onDisconnect,
 }: {
     account: Account;
     canManage: boolean;
+    frozen?: boolean;
     onReconnectOAuth: (account: Account) => void;
     onDisconnect: (account: Account) => void;
 }) {
@@ -192,25 +194,34 @@ export function AccountCard({
                     </div>
                 </div>
 
-                <span className="flex shrink-0 items-center gap-1.5 text-[11.5px] font-medium">
-                    <span
-                        className={cn(
-                            'size-1.5 rounded-full',
-                            needsAttention
-                                ? 'bg-destructive'
-                                : 'bg-emerald-500',
-                        )}
-                    />
-                    <span
-                        className={
-                            needsAttention
-                                ? 'text-destructive'
-                                : 'text-muted-foreground'
-                        }
-                    >
-                        {needsAttention ? account.status_label : 'Connected'}
+                <div className="flex shrink-0 items-center gap-2">
+                    {frozen && (
+                        <Badge variant="secondary" className="shrink-0">
+                            Platform disabled
+                        </Badge>
+                    )}
+                    <span className="flex shrink-0 items-center gap-1.5 text-[11.5px] font-medium">
+                        <span
+                            className={cn(
+                                'size-1.5 rounded-full',
+                                needsAttention
+                                    ? 'bg-destructive'
+                                    : 'bg-emerald-500',
+                            )}
+                        />
+                        <span
+                            className={
+                                needsAttention
+                                    ? 'text-destructive'
+                                    : 'text-muted-foreground'
+                            }
+                        >
+                            {needsAttention
+                                ? account.status_label
+                                : 'Connected'}
+                        </span>
                     </span>
-                </span>
+                </div>
             </div>
 
             <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11.5px] text-muted-foreground">
@@ -249,19 +260,20 @@ export function AccountCard({
 
             {canManage && (
                 <div className={ACCOUNT_CARD_ACTIONS_CLASS}>
-                    {account.auth_method === 'app_password' ? (
-                        <ReconnectBlueskyDialog account={account} />
-                    ) : (
-                        <Button
-                            variant={needsAttention ? 'default' : 'outline'}
-                            size="sm"
-                            className="h-8 shrink-0"
-                            onClick={() => onReconnectOAuth(account)}
-                        >
-                            <RefreshCw className="size-4" />
-                            Reconnect
-                        </Button>
-                    )}
+                    {!frozen &&
+                        (account.auth_method === 'app_password' ? (
+                            <ReconnectBlueskyDialog account={account} />
+                        ) : (
+                            <Button
+                                variant={needsAttention ? 'default' : 'outline'}
+                                size="sm"
+                                className="h-8 shrink-0"
+                                onClick={() => onReconnectOAuth(account)}
+                            >
+                                <RefreshCw className="size-4" />
+                                Reconnect
+                            </Button>
+                        ))}
                     {!account.is_default && (
                         <Form
                             {...ConnectedAccountController.makeDefault.form(

--- a/resources/js/components/accounts/connect-buttons.tsx
+++ b/resources/js/components/accounts/connect-buttons.tsx
@@ -481,6 +481,10 @@ export function ConnectButtons({
                     </DropdownMenuLabel>
                     <DropdownMenuSeparator />
                     {platforms.map((capability) => {
+                        if (!capability.enabled) {
+                            return null;
+                        }
+
                         const label =
                             capability.platform === 'facebook'
                                 ? metaConnectLabel(capabilities)

--- a/resources/js/components/accounts/types.ts
+++ b/resources/js/components/accounts/types.ts
@@ -23,4 +23,5 @@ export type Capability = {
     supportsAppPassword: boolean;
     configured: boolean;
     launched: boolean;
+    enabled: boolean;
 };

--- a/resources/js/components/compose/target-status-chips.tsx
+++ b/resources/js/components/compose/target-status-chips.tsx
@@ -36,7 +36,7 @@ export type ChipTarget = Pick<
 
 type Props = {
     targets: ChipTarget[];
-    /** Retry a single failed target; omit to hide the Retry control. */
+    /** Retry a single failed or skipped target; omit to hide the Retry control. */
     onRetry?: (targetId: string) => void;
     /** Target ids with an in-flight retry request (disables their Retry button). */
     retryingIds?: ReadonlySet<string>;
@@ -45,7 +45,9 @@ type Props = {
 /**
  * Live per-target publish status: a platform glyph, a tinted status label
  * (spinner while publishing, check when published, ✕ + error message when
- * failed), and an inline Retry on failed targets.
+ * failed), and an inline Retry on failed or skipped targets. Skipped targets
+ * also surface their stored reason (e.g. the platform being disabled
+ * instance-wide) so the chip isn't a bare "Skipped".
  */
 export function TargetStatusChips({ targets, onRetry, retryingIds }: Props) {
     if (targets.length === 0) {
@@ -57,6 +59,7 @@ export function TargetStatusChips({ targets, onRetry, retryingIds }: Props) {
             {targets.map((target) => {
                 const meta = targetStatusMeta(target.status);
                 const isFailed = target.status === 'failed';
+                const isSkipped = target.status === 'skipped';
                 const isRetrying = retryingIds?.has(target.id) ?? false;
                 const attempts = target.attempts ?? 0;
                 const errorMessage = target.error_message
@@ -107,13 +110,25 @@ export function TargetStatusChips({ targets, onRetry, retryingIds }: Props) {
                             ) : null}
                             <span>{meta.label}</span>
                         </span>
-                        {isFailed && errorMessage && (
-                            <span className="min-w-0 flex-1 truncate text-destructive/90">
+                        {(isFailed || isSkipped) && errorMessage && (
+                            <span
+                                className={cn(
+                                    'min-w-0 flex-1 truncate',
+                                    isFailed
+                                        ? 'text-destructive/90'
+                                        : 'text-muted-foreground',
+                                )}
+                            >
                                 <Tooltip>
                                     <TooltipTrigger asChild>
                                         <button
                                             type="button"
-                                            className="inline-block max-w-full cursor-help truncate border-0 bg-transparent p-0 text-left font-[inherit] text-inherit underline decoration-destructive/40 decoration-dotted underline-offset-2"
+                                            className={cn(
+                                                'inline-block max-w-full cursor-help truncate border-0 bg-transparent p-0 text-left font-[inherit] text-inherit underline decoration-dotted underline-offset-2',
+                                                isFailed
+                                                    ? 'decoration-destructive/40'
+                                                    : 'decoration-muted-foreground/40',
+                                            )}
                                         >
                                             {errorMessage}
                                         </button>
@@ -133,7 +148,7 @@ export function TargetStatusChips({ targets, onRetry, retryingIds }: Props) {
                                 </Tooltip>
                             </span>
                         )}
-                        {isFailed && onRetry && (
+                        {(isFailed || isSkipped) && onRetry && (
                             <button
                                 type="button"
                                 disabled={isRetrying}

--- a/resources/js/layouts/settings/instance-layout.tsx
+++ b/resources/js/layouts/settings/instance-layout.tsx
@@ -26,6 +26,11 @@ export default function InstanceSettingsLayout({
             icon: null,
         },
         {
+            title: 'Platforms',
+            href: InstanceSettingsController.platforms(),
+            icon: null,
+        },
+        {
             title: 'Usage',
             href: InstanceSettingsController.usage(),
             icon: null,

--- a/resources/js/lib/compose/publish-status.ts
+++ b/resources/js/lib/compose/publish-status.ts
@@ -24,6 +24,7 @@ const TARGET_STATUS_META: Record<TargetStatus, TargetStatusMeta> = {
     publishing: { tone: 'active', label: 'Publishing', spinning: true },
     published: { tone: 'success', label: 'Published', spinning: false },
     failed: { tone: 'error', label: 'Failed', spinning: false },
+    skipped: { tone: 'muted', label: 'Skipped', spinning: false },
     deleting: { tone: 'active', label: 'Deleting', spinning: true },
     deleted: { tone: 'muted', label: 'Deleted', spinning: false },
 };
@@ -64,7 +65,7 @@ export function failedTargets(targets: TargetView[]): TargetView[] {
  * feedback should leave them as-is rather than flip them back to in-flight.
  */
 const OPTIMISTIC_SKIP_STATUSES: ReadonlySet<TargetStatus> =
-    new Set<TargetStatus>(['published', 'deleting', 'deleted']);
+    new Set<TargetStatus>(['published', 'skipped', 'deleting', 'deleted']);
 
 /**
  * The instant in-flight snapshot to show when the user hits Publish/Schedule,

--- a/resources/js/pages/accounts/index.tsx
+++ b/resources/js/pages/accounts/index.tsx
@@ -53,6 +53,10 @@ export default function ConnectedAccounts({
     capabilities,
     canManage,
 }: Props) {
+    const disabledPlatforms = new Set(
+        capabilities.filter((c) => !c.enabled).map((c) => c.platform),
+    );
+
     const disconnect = (account: Account) => {
         // The controller flashes a success message which FlashListener turns into
         // a toast — don't toast again here or it fires twice.
@@ -160,6 +164,7 @@ export default function ConnectedAccounts({
                                 key={account.id}
                                 account={account}
                                 canManage={canManage}
+                                frozen={disabledPlatforms.has(account.platform)}
                                 onReconnectOAuth={reconnectOAuth}
                                 onDisconnect={disconnect}
                             />

--- a/resources/js/pages/settings/instance-platforms.tsx
+++ b/resources/js/pages/settings/instance-platforms.tsx
@@ -13,7 +13,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import type { PlatformName } from '@/types/compose';
 
-type PlatformRow = {
+type PlatformToggle = {
     platform: PlatformName;
     label: string;
     enabled: boolean;
@@ -21,21 +21,21 @@ type PlatformRow = {
 };
 
 type Props = {
-    platforms: PlatformRow[];
+    platforms: PlatformToggle[];
 };
 
 export default function InstancePlatforms({ platforms }: Props) {
-    function setPlatformEnabled(platform: PlatformName, enabled: boolean) {
-        const values: Record<string, boolean> = {};
-
-        for (const row of platforms) {
-            values[row.platform] =
-                row.platform === platform ? enabled : row.enabled;
-        }
+    function setEnabled(platform: PlatformName, enabled: boolean) {
+        const next = Object.fromEntries(
+            platforms.map((p) => [
+                p.platform,
+                p.platform === platform ? enabled : p.enabled,
+            ]),
+        );
 
         router.put(
             InstanceSettingsController.updatePlatforms().url,
-            { platforms: values },
+            { platforms: next },
             { preserveScroll: true },
         );
     }
@@ -48,39 +48,38 @@ export default function InstancePlatforms({ platforms }: Props) {
                 <Heading
                     variant="small"
                     title="Platforms"
-                    description="Freeze a platform instance-wide to stop publishing, polling, and new connections for it."
+                    description="Turn a social platform on or off for everyone on this instance. Disabling a platform hides it from the composer, blocks new connections, and skips any scheduled posts to it."
                 />
 
                 <Card>
                     <CardHeader>
                         <CardTitle>Available platforms</CardTitle>
                         <CardDescription>
-                            Disabling a platform here overrides every workspace
-                            on this instance.
+                            A disabled platform is frozen instance-wide.
                         </CardDescription>
                     </CardHeader>
                     <CardContent className="space-y-4">
-                        {platforms.map((row) => (
+                        {platforms.map((platform) => (
                             <div
-                                key={row.platform}
+                                key={platform.platform}
                                 className="flex items-center gap-2"
                             >
                                 <Checkbox
-                                    id={`platform-${row.platform}-enabled`}
-                                    checked={row.enabled}
+                                    id={`platform-${platform.platform}`}
+                                    checked={platform.enabled}
                                     onCheckedChange={(checked) =>
-                                        setPlatformEnabled(
-                                            row.platform,
+                                        setEnabled(
+                                            platform.platform,
                                             checked === true,
                                         )
                                     }
                                 />
                                 <Label
-                                    htmlFor={`platform-${row.platform}-enabled`}
+                                    htmlFor={`platform-${platform.platform}`}
                                 >
-                                    {row.label}
+                                    {platform.label}
                                 </Label>
-                                {!row.configured && (
+                                {!platform.configured && (
                                     <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-300">
                                         Not configured
                                     </span>

--- a/resources/js/pages/settings/instance-platforms.tsx
+++ b/resources/js/pages/settings/instance-platforms.tsx
@@ -1,0 +1,108 @@
+import { Head, router } from '@inertiajs/react';
+
+import InstanceSettingsController from '@/actions/App/Http/Controllers/Settings/InstanceSettingsController';
+import Heading from '@/components/common/heading';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import type { PlatformName } from '@/types/compose';
+
+type PlatformRow = {
+    platform: PlatformName;
+    label: string;
+    enabled: boolean;
+    configured: boolean;
+};
+
+type Props = {
+    platforms: PlatformRow[];
+};
+
+export default function InstancePlatforms({ platforms }: Props) {
+    function setPlatformEnabled(platform: PlatformName, enabled: boolean) {
+        const values: Record<string, boolean> = {};
+
+        for (const row of platforms) {
+            values[row.platform] =
+                row.platform === platform ? enabled : row.enabled;
+        }
+
+        router.put(
+            InstanceSettingsController.updatePlatforms().url,
+            { platforms: values },
+            { preserveScroll: true },
+        );
+    }
+
+    return (
+        <>
+            <Head title="Instance platforms" />
+
+            <div className="space-y-6">
+                <Heading
+                    variant="small"
+                    title="Platforms"
+                    description="Freeze a platform instance-wide to stop publishing, polling, and new connections for it."
+                />
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Available platforms</CardTitle>
+                        <CardDescription>
+                            Disabling a platform here overrides every workspace
+                            on this instance.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        {platforms.map((row) => (
+                            <div
+                                key={row.platform}
+                                className="flex items-center gap-2"
+                            >
+                                <Checkbox
+                                    id={`platform-${row.platform}-enabled`}
+                                    checked={row.enabled}
+                                    onCheckedChange={(checked) =>
+                                        setPlatformEnabled(
+                                            row.platform,
+                                            checked === true,
+                                        )
+                                    }
+                                />
+                                <Label
+                                    htmlFor={`platform-${row.platform}-enabled`}
+                                >
+                                    {row.label}
+                                </Label>
+                                {!row.configured && (
+                                    <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-300">
+                                        Not configured
+                                    </span>
+                                )}
+                            </div>
+                        ))}
+                    </CardContent>
+                </Card>
+            </div>
+        </>
+    );
+}
+
+InstancePlatforms.layout = {
+    breadcrumbs: [
+        {
+            title: 'Instance settings',
+            href: InstanceSettingsController.edit().url,
+        },
+        {
+            title: 'Platforms',
+            href: InstanceSettingsController.platforms().url,
+        },
+    ],
+};

--- a/resources/js/types/compose.ts
+++ b/resources/js/types/compose.ts
@@ -90,6 +90,7 @@ export type TargetStatus =
     | 'publishing'
     | 'published'
     | 'failed'
+    | 'skipped'
     | 'deleting'
     | 'deleted';
 

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -40,6 +40,8 @@ Route::middleware(['auth'])->group(function () {
     Route::put('settings/instance', [InstanceSettingsController::class, 'update'])->name('instance-settings.update');
     Route::get('settings/instance/polling', [InstanceSettingsController::class, 'polling'])->name('instance-settings.polling');
     Route::put('settings/instance/polling', [InstanceSettingsController::class, 'updatePolling'])->name('instance-settings.polling.update');
+    Route::get('settings/instance/platforms', [InstanceSettingsController::class, 'platforms'])->name('instance-settings.platforms');
+    Route::put('settings/instance/platforms', [InstanceSettingsController::class, 'updatePlatforms'])->name('instance-settings.updatePlatforms');
     Route::get('settings/instance/usage', [InstanceSettingsController::class, 'usage'])->name('instance-settings.usage');
     Route::get('settings/instance/usage/x', [InstanceSettingsController::class, 'xUsage'])->name('instance-settings.usage.x');
     Route::get('settings/instance/admins', [InstanceSettingsController::class, 'admins'])->name('instance-settings.admins');

--- a/tests/Feature/ConnectedAccounts/PlatformFreezeConnectTest.php
+++ b/tests/Feature/ConnectedAccounts/PlatformFreezeConnectTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Enums\Platform;
+use App\Enums\WorkspaceRole;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
+use App\Support\InstanceSettings;
+
+function ownerActingInFrozenTest(): array
+{
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'role' => WorkspaceRole::Owner,
+    ]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    test()->actingAs($user);
+
+    return [$user, $workspace];
+}
+
+beforeEach(function () {
+    config()->set('services.x.client_id', 'id');
+    config()->set('services.x.client_secret', 'secret');
+});
+
+it('reports a frozen platform as not enabled in capabilities', function () {
+    app(InstanceSettings::class)->update(['platforms_enabled' => ['x' => false]]);
+
+    $x = collect(Platform::capabilities())->firstWhere('platform', 'x');
+
+    expect($x['enabled'])->toBeFalse();
+    expect(collect(Platform::capabilities())->firstWhere('platform', 'bluesky')['enabled'])->toBeTrue();
+});
+
+it('404s the OAuth connect redirect for a frozen platform', function () {
+    ownerActingInFrozenTest();
+    app(InstanceSettings::class)->update(['platforms_enabled' => ['x' => false]]);
+
+    test()->get(route('accounts.connect', ['platform' => 'x']))
+        ->assertNotFound();
+});

--- a/tests/Feature/Console/RefreshExpiringTokensFreezeTest.php
+++ b/tests/Feature/Console/RefreshExpiringTokensFreezeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Enums\Platform;
+use App\Models\ConnectedAccount;
+use App\Models\ConnectedAccountSecret;
+use App\Services\Publishing\TokenManager;
+use App\Support\InstanceSettings;
+
+test('it does not refresh tokens for a frozen platform', function () {
+    // An X account inside the refresh window (expiring soon, active).
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::X->value,
+        'token_expires_at' => now()->addHours(1),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'refresh_token' => 'r',
+    ]);
+
+    app(InstanceSettings::class)->update(['platforms_enabled' => ['x' => false]]);
+
+    $this->mock(TokenManager::class, function ($mock): void {
+        $mock->shouldNotReceive('fresh');
+    });
+
+    $this->artisan('accounts:refresh-tokens')->assertSuccessful();
+});
+
+test('it still refreshes tokens for an available platform', function () {
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::X->value,
+        'token_expires_at' => now()->addHours(1),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'refresh_token' => 'r',
+    ]);
+
+    app(InstanceSettings::class)->update(['platforms_enabled' => ['x' => true]]);
+
+    $this->mock(TokenManager::class, function ($mock) use ($account): void {
+        $mock->shouldReceive('fresh')
+            ->once()
+            ->withArgs(fn (ConnectedAccount $refreshed): bool => $refreshed->is($account));
+    });
+
+    $this->artisan('accounts:refresh-tokens')->assertSuccessful();
+});

--- a/tests/Feature/Posts/PlatformFreezeComposerTest.php
+++ b/tests/Feature/Posts/PlatformFreezeComposerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Enums\Platform;
+use App\Enums\WorkspaceRole;
+use App\Models\ConnectedAccount;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
+use App\Services\Posts\DraftService;
+use App\Support\InstanceSettings;
+use Illuminate\Support\Facades\Context;
+
+/**
+ * @return array{0: string, 1: ConnectedAccount, 2: ConnectedAccount}
+ */
+function seedTwoPlatformWorkspace(): array
+{
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    Context::add('workspace_id', $workspace->id);
+
+    $xAccount = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'platform' => Platform::X->value,
+    ]);
+    $blueskyAccount = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'platform' => Platform::Bluesky->value,
+    ]);
+
+    return [$workspace->id, $xAccount, $blueskyAccount];
+}
+
+it('excludes frozen-platform accounts when resolving a draft destination', function () {
+    [$workspaceId, $xAccount, $blueskyAccount] = seedTwoPlatformWorkspace();
+
+    app(InstanceSettings::class)->update(['platforms_enabled' => ['x' => false]]);
+
+    $ids = app(DraftService::class)->resolveDestinationAccountIds($workspaceId, ['kind' => 'all']);
+
+    expect($ids)->not->toContain($xAccount->id);
+    expect($ids)->toContain($blueskyAccount->id);
+});
+
+it('excludes frozen-platform accounts from the composer accounts prop', function () {
+    [$workspaceId, $xAccount, $blueskyAccount] = seedTwoPlatformWorkspace();
+
+    app(InstanceSettings::class)->update(['platforms_enabled' => ['x' => false]]);
+
+    $user = User::query()->where('current_workspace_id', $workspaceId)->firstOrFail();
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspaceId,
+        'user_id' => $user->id,
+        'role' => WorkspaceRole::Member,
+    ]);
+    $post = app(DraftService::class)->createDraft($workspaceId, $user, ['kind' => 'all'], ['hello']);
+
+    $response = $this->actingAs($user)->get(route('posts.show', $post));
+
+    $response->assertInertia(fn ($page) => $page
+        ->where('accounts', fn (mixed $accounts): bool => collect($accounts)->pluck('id')->contains($blueskyAccount->id)
+            && ! collect($accounts)->pluck('id')->contains($xAccount->id)));
+});

--- a/tests/Feature/Publishing/PlatformFreezePublishTest.php
+++ b/tests/Feature/Publishing/PlatformFreezePublishTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Dto\Publishing\PublishContext;
+use App\Dto\Publishing\PublishResult;
+use App\Enums\Platform;
+use App\Enums\PostStatus;
+use App\Enums\PostTargetStatus;
+use App\Jobs\PublishPostTarget;
+use App\Models\ConnectedAccount;
+use App\Models\ConnectedAccountSecret;
+use App\Models\Post;
+use App\Models\PostTarget;
+use App\Services\Publishing\BackoffSchedule;
+use App\Services\Publishing\Contracts\PublishConnector;
+use App\Services\Publishing\PostStatusRollup;
+use App\Services\Publishing\PublishConnectorRegistry;
+use App\Services\Publishing\TokenManager;
+use App\Support\InstanceSettings;
+
+/**
+ * Same factory chain as PublishPostTargetTest's `publishTarget()` helper
+ * (workspace via ConnectedAccount::factory() -> Post::factory() -> PostTarget::factory()),
+ * generalized to accept a platform so a frozen-X + available-Bluesky sibling pair can be built.
+ */
+function makePendingTarget(string $platform, ?Post $post = null): PostTarget
+{
+    $post ??= Post::factory()->create(['status' => PostStatus::Publishing]);
+    $account = ConnectedAccount::factory()->create([
+        'platform' => $platform,
+        'token_expires_at' => now()->addHour(),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'access_token' => 'tok',
+    ]);
+
+    return PostTarget::factory()->for($post)->create([
+        'connected_account_id' => $account->id,
+        'platform' => $platform,
+        'sections' => ['hello'],
+        'status' => 'pending',
+    ]);
+}
+
+function bindSucceedingConnector(): void
+{
+    $connector = new class implements PublishConnector
+    {
+        public function publish(PublishContext $context): PublishResult
+        {
+            return PublishResult::success(['remote-id']);
+        }
+
+        public function delete(PostTarget $target, array $credentials): void {}
+    };
+
+    app()->instance(PublishConnectorRegistry::class, new class($connector) extends PublishConnectorRegistry
+    {
+        public function __construct(private PublishConnector $connector) {}
+
+        public function for(Platform $platform): PublishConnector
+        {
+            return $this->connector;
+        }
+    });
+}
+
+function runPublish(PostTarget $target): void
+{
+    app(PublishPostTarget::class, ['target' => $target])->handle(
+        app(PublishConnectorRegistry::class),
+        app(TokenManager::class),
+        app(PostStatusRollup::class),
+        app(BackoffSchedule::class),
+    );
+}
+
+it('skips a target whose platform is frozen instead of publishing', function () {
+    $target = makePendingTarget('x');
+
+    app(InstanceSettings::class)->update(['platforms_enabled' => ['x' => false]]);
+
+    runPublish($target);
+
+    expect($target->fresh()->status)->toBe(PostTargetStatus::Skipped);
+    expect($target->fresh()->attemptLogs()->count())->toBe(0);
+});
+
+it('leaves a sibling target on an available platform unaffected and rolls the post up to Partial', function () {
+    $post = Post::factory()->create(['status' => PostStatus::Publishing]);
+    $xTarget = makePendingTarget('x', $post);
+    $blueskyTarget = makePendingTarget('bluesky', $post);
+
+    app(InstanceSettings::class)->update(['platforms_enabled' => ['x' => false]]);
+    bindSucceedingConnector();
+
+    runPublish($xTarget);
+    runPublish($blueskyTarget);
+
+    expect($xTarget->fresh()->status)->toBe(PostTargetStatus::Skipped);
+    expect($xTarget->fresh()->attemptLogs()->count())->toBe(0);
+    expect($blueskyTarget->fresh()->status)->toBe(PostTargetStatus::Published);
+    expect($post->fresh()->status)->toBe(PostStatus::Partial);
+});

--- a/tests/Feature/Publishing/PublishEndpointTest.php
+++ b/tests/Feature/Publishing/PublishEndpointTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\Platform;
 use App\Enums\PostStatus;
 use App\Enums\PostTargetStatus;
 use App\Enums\WorkspaceRole;
@@ -9,6 +10,7 @@ use App\Models\PostTarget;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Models\WorkspaceMembership;
+use App\Support\InstanceSettings;
 use Illuminate\Support\Facades\Bus;
 
 function publishingMember(): array
@@ -80,6 +82,46 @@ test('per-target retry redirects after an Inertia retry request', function () {
 
     expect($target->refresh()->status)->toBe(PostTargetStatus::Pending);
     Bus::assertDispatched(PublishPostTarget::class, fn (PublishPostTarget $job): bool => $job->target->is($target));
+});
+
+test('per-target retry resets a skipped target to pending and dispatches it', function () {
+    Bus::fake();
+    [$user, $workspace] = publishingMember();
+    $post = Post::factory()->create(['workspace_id' => $workspace->id, 'status' => PostStatus::Partial]);
+    $target = PostTarget::factory()->for($post)->create([
+        'status' => PostTargetStatus::Skipped->value,
+        'error_message' => 'X is disabled on this instance.',
+    ]);
+
+    test()->postJson("/posts/{$post->id}/targets/{$target->id}/retry")
+        ->assertOk()
+        ->assertJsonPath('post.id', $post->id);
+
+    $target->refresh();
+    expect($target->status)->toBe(PostTargetStatus::Pending)
+        ->and($target->error_kind)->toBeNull()
+        ->and($target->error_message)->toBeNull();
+
+    Bus::assertDispatched(PublishPostTarget::class, fn (PublishPostTarget $job): bool => $job->target->is($target));
+});
+
+test('retrying a skipped target whose platform is still frozen re-skips it instead of erroring', function () {
+    [$user, $workspace] = publishingMember();
+    $post = Post::factory()->create(['workspace_id' => $workspace->id, 'status' => PostStatus::Partial]);
+    $target = PostTarget::factory()->for($post)->create([
+        'platform' => Platform::X->value,
+        'status' => PostTargetStatus::Skipped->value,
+        'error_message' => 'X is disabled on this instance.',
+    ]);
+
+    app(InstanceSettings::class)->update(['platforms_enabled' => ['x' => false]]);
+
+    // Sync queue runs the retried job inline, so the terminal + freeze guards in
+    // PublishPostTarget::handle() execute within this request.
+    test()->postJson("/posts/{$post->id}/targets/{$target->id}/retry")
+        ->assertOk();
+
+    expect($target->fresh()->status)->toBe(PostTargetStatus::Skipped);
 });
 
 test('retry rejects a non-failed target with 409 and dispatches nothing', function () {

--- a/tests/Feature/Settings/InstancePlatformSettingsTest.php
+++ b/tests/Feature/Settings/InstancePlatformSettingsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Enums\Platform;
+use App\Support\InstanceSettings;
+
+it('defaults every platform to available', function () {
+    $settings = app(InstanceSettings::class);
+
+    expect($settings->platformAvailable(Platform::X))->toBeTrue();
+    expect($settings->platformsEnabled())->toBe([
+        'x' => true,
+        'bluesky' => true,
+        'linkedin' => true,
+        'facebook' => true,
+        'instagram' => true,
+        'threads' => true,
+    ]);
+});
+
+it('freezes a single platform while leaving the rest available', function () {
+    $settings = app(InstanceSettings::class);
+    $settings->update(['platforms_enabled' => ['x' => false]]);
+
+    expect($settings->platformAvailable(Platform::X))->toBeFalse();
+    expect($settings->platformAvailable(Platform::Bluesky))->toBeTrue();
+});
+
+it('stops polling for a frozen platform regardless of the polling toggle', function () {
+    $settings = app(InstanceSettings::class);
+    $settings->update([
+        'engagement_polling_enabled' => ['x' => true],
+        'platforms_enabled' => ['x' => false],
+    ]);
+
+    expect($settings->engagementPollingEnabled(Platform::X))->toBeFalse();
+});

--- a/tests/Feature/Settings/InstancePlatformSettingsTest.php
+++ b/tests/Feature/Settings/InstancePlatformSettingsTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\Enums\InstanceRole;
 use App\Enums\Platform;
+use App\Models\User;
 use App\Support\InstanceSettings;
 
 it('defaults every platform to available', function () {
@@ -33,4 +35,42 @@ it('stops polling for a frozen platform regardless of the polling toggle', funct
     ]);
 
     expect($settings->engagementPollingEnabled(Platform::X))->toBeFalse();
+});
+
+it('lets an owner view the platforms page', function () {
+    $owner = User::factory()->create(['instance_role' => InstanceRole::Owner->value]);
+
+    $this->actingAs($owner)
+        ->get(route('instance-settings.platforms'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('settings/instance-platforms')
+            ->has('platforms', 6));
+});
+
+it('forbids a non-owner from the platforms page', function () {
+    $user = User::factory()->create(['instance_role' => null]);
+
+    $this->actingAs($user)
+        ->get(route('instance-settings.platforms'))
+        ->assertForbidden();
+});
+
+it('persists platform toggles for an owner', function () {
+    $owner = User::factory()->create(['instance_role' => InstanceRole::Owner->value]);
+
+    $this->actingAs($owner)
+        ->put(route('instance-settings.updatePlatforms'), [
+            'platforms' => [
+                'x' => false,
+                'bluesky' => true,
+                'linkedin' => true,
+                'facebook' => true,
+                'instagram' => true,
+                'threads' => true,
+            ],
+        ])
+        ->assertRedirect();
+
+    expect(app(InstanceSettings::class)->platformAvailable(Platform::X))->toBeFalse();
 });

--- a/tests/Unit/PostStatusRollupTest.php
+++ b/tests/Unit/PostStatusRollupTest.php
@@ -52,3 +52,39 @@ test('all failed rolls up to Failed', function () {
     expect($post->refresh()->status)->toBe(PostStatus::Failed)
         ->and($post->published_at)->toBeNull();
 });
+
+test('all skipped rolls up to Failed', function () {
+    $post = rollupPost([PostTargetStatus::Skipped, PostTargetStatus::Skipped]);
+
+    app(PostStatusRollup::class)->recompute($post);
+
+    expect($post->refresh()->status)->toBe(PostStatus::Failed)
+        ->and($post->published_at)->toBeNull();
+});
+
+test('failed and skipped with nothing published rolls up to Failed', function () {
+    $post = rollupPost([PostTargetStatus::Failed, PostTargetStatus::Skipped]);
+
+    app(PostStatusRollup::class)->recompute($post);
+
+    expect($post->refresh()->status)->toBe(PostStatus::Failed)
+        ->and($post->published_at)->toBeNull();
+});
+
+test('published alongside skipped rolls up to Partial', function () {
+    $post = rollupPost([PostTargetStatus::Published, PostTargetStatus::Skipped]);
+
+    app(PostStatusRollup::class)->recompute($post);
+
+    expect($post->refresh()->status)->toBe(PostStatus::Partial)
+        ->and($post->published_at)->not->toBeNull();
+});
+
+test('failed alongside deleted rolls up to Partial, not Failed', function () {
+    $post = rollupPost([PostTargetStatus::Failed, PostTargetStatus::Deleted]);
+
+    app(PostStatusRollup::class)->recompute($post);
+
+    expect($post->refresh()->status)->toBe(PostStatus::Partial)
+        ->and($post->published_at)->not->toBeNull();
+});


### PR DESCRIPTION
## What

Adds an instance owner the ability to **enable/disable each social platform instance-wide** from a new **Settings → Instance → Platforms** page (X, Bluesky, LinkedIn, Facebook, Instagram, Threads).

Disabling a platform is a **full freeze**, and it is an **additional gate that defaults to enabled** — ANDed with the existing `isConfigured()` / `isLaunched()` gates, so an instance that never touches these settings behaves exactly as before.

## Behavior when a platform is disabled

- **Connect & reconnect** are blocked, and the platform is hidden from the connect menu.
- **Composer** hides it as a destination, and `DraftService` never snapshots a frozen-platform account into a `PostTarget` (server-side too, so a stale/crafted request can't slip through).
- **Publishing** skips in-flight targets to it — a new terminal status `PostTargetStatus::Skipped` is recorded (with a reason); sibling targets on other platforms still publish. The single guard lives in `PublishPostTarget::handle()`, which every dispatch route (normal, retry, MCP, API) funnels through.
- **Background work** stops: polling accessors and the OAuth token-refresh sweep skip frozen platforms.
- **Existing accounts** on a frozen platform stay listed but render inert (a "Platform disabled" badge, no reconnect action; disconnect stays available).
- **Recovery:** re-enabling a platform makes everything work again immediately; previously-skipped targets can be **manually retried** (which re-publishes, or re-skips if still frozen).

Facebook and Instagram (which share one Meta flow) can be frozen **independently**.

## How

- Storage: one JSON key `platforms_enabled` (per-platform bool map) in the existing `instance_settings` table — **no migration**. Read via `InstanceSettings::platformAvailable()` / `platformsEnabled()`, which default any missing platform to `true`.
- Owner-only page/controller/request modeled on the existing instance-polling settings.
- `Platform::capabilities()` gains an `enabled` flag; `PostStatusRollup` learns the `Skipped` status; the frontend `TargetStatus` union / status meta / optimistic-skip set are updated.

## Testing

- New Pest coverage for: owner-only settings access, capability/connect gating (404 when frozen), composer + `DraftService` exclusion, publish-skip + rollup (incl. an all-skipped and a `[Failed, Deleted]` regression lock), token-refresh skip, and manual retry of a skipped target.
- Gate green: affected Pest suites **496/496**, Larastan L7 **0 errors**, `tsc` / oxlint / oxfmt clean.

## Note

The frontend couldn't be browser-verified in the dev sandbox (no chromium) — the Platforms settings page, frozen-account badges, and skipped-target chips should get a quick manual eyeball in the running app.