### PR TITLE
feat: disable connected accounts per workspace

### DIFF
--- a/app/Http/Controllers/ConnectedAccounts/ConnectedAccountController.php
+++ b/app/Http/Controllers/ConnectedAccounts/ConnectedAccountController.php
@@ -12,6 +12,8 @@ use App\Services\ConnectedAccounts\BlueskyConnector;
 use App\Support\InstanceSettings;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 use RuntimeException;
@@ -48,6 +50,7 @@ class ConnectedAccountController extends Controller
                 'max_text_length' => $account->maxTextLength(),
                 'x_premium' => $account->hasXPremium(),
                 'is_default' => $account->id === $defaultAccountId,
+                'disabled' => $account->isDisabled(),
                 'pds_url' => $this->customPdsUrl($account),
             ])
             ->values()
@@ -154,6 +157,32 @@ class ConnectedAccountController extends Controller
         ])->save();
 
         return redirect()->route('accounts.index')->with('success', "{$account->handle} is now the default account.");
+    }
+
+    public function toggle(Request $request, ConnectedAccount $account): RedirectResponse
+    {
+        $request->user()->can('update', $account) ?: abort(403);
+
+        DB::transaction(function () use ($request, $account): void {
+            $disabling = ! $account->isDisabled();
+
+            $account->forceFill([
+                'disabled_at' => $disabling ? Date::now() : null,
+            ])->save();
+
+            if ($disabling) {
+                $workspace = $request->user()->currentWorkspace()->first();
+                if ($workspace?->default_connected_account_id === $account->id) {
+                    $workspace->forceFill(['default_connected_account_id' => null])->save();
+                }
+            }
+        });
+
+        $message = $account->isDisabled()
+            ? "{$account->handle} is disabled."
+            : "{$account->handle} is enabled.";
+
+        return redirect()->route('accounts.index')->with('success', $message);
     }
 
     public function destroy(Request $request, ConnectedAccount $account): RedirectResponse

--- a/app/Http/Controllers/Posts/ComposerController.php
+++ b/app/Http/Controllers/Posts/ComposerController.php
@@ -28,6 +28,7 @@ class ComposerController extends Controller
         $settings = app(InstanceSettings::class);
 
         $accounts = ConnectedAccount::query()
+            ->enabled()
             ->get()
             ->filter(fn (ConnectedAccount $account): bool => $settings->platformAvailable($account->platform))
             ->sortByDesc(fn (ConnectedAccount $account): bool => $account->id === $defaultAccountId)

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -100,6 +100,7 @@ class HandleInertiaRequests extends Middleware
 
         $accounts = ConnectedAccount::query()
             ->where('workspace_id', $workspaceId)
+            ->enabled()
             ->get()
             ->filter(fn (ConnectedAccount $account): bool => $settings->platformAvailable($account->platform))
             ->sortByDesc(fn (ConnectedAccount $account): bool => $account->id === $defaultAccountId)

--- a/app/Jobs/PublishPostTarget.php
+++ b/app/Jobs/PublishPostTarget.php
@@ -97,6 +97,19 @@ class PublishPostTarget implements ShouldQueue
             return;
         }
 
+        if ($target->account()->first()?->isDisabled()) {
+            $target->forceFill([
+                'status' => PostTargetStatus::Skipped->value,
+                'error_kind' => null,
+                'error_message' => 'This account is disabled in the workspace.',
+                'next_attempt_at' => null,
+            ])->save();
+
+            $rollup->recompute($target->post()->firstOrFail());
+
+            return;
+        }
+
         $attempt = DB::transaction(function () use ($target): PostTargetAttempt {
             $target->forceFill([
                 'status' => PostTargetStatus::Publishing->value,

--- a/app/Models/ConnectedAccount.php
+++ b/app/Models/ConnectedAccount.php
@@ -11,6 +11,7 @@ use App\Enums\Platform;
 use Carbon\CarbonImmutable;
 use Database\Factories\ConnectedAccountFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -30,6 +31,7 @@ use Override;
  * @property string $auth_method
  * @property string|null $connected_by_user_id
  * @property ConnectedAccountStatus $status
+ * @property CarbonImmutable|null $disabled_at
  * @property array<string, mixed>|null $capabilities
  * @property CarbonImmutable|null $token_expires_at
  * @property CarbonImmutable|null $last_refreshed_at
@@ -48,6 +50,7 @@ use Override;
     'auth_method',
     'connected_by_user_id',
     'status',
+    'disabled_at',
     'capabilities',
     'token_expires_at',
     'last_refreshed_at',
@@ -70,6 +73,7 @@ class ConnectedAccount extends Model
         return [
             'platform' => Platform::class,
             'status' => ConnectedAccountStatus::class,
+            'disabled_at' => 'immutable_datetime',
             'capabilities' => 'array',
             'token_expires_at' => 'immutable_datetime',
             'last_refreshed_at' => 'immutable_datetime',
@@ -88,6 +92,19 @@ class ConnectedAccount extends Model
     {
         return $this->platform === Platform::X
             && (bool) ($this->capabilities['x_premium'] ?? false);
+    }
+
+    public function isDisabled(): bool
+    {
+        return $this->disabled_at !== null;
+    }
+
+    /**
+     * @param  Builder<ConnectedAccount>  $query
+     */
+    public function scopeEnabled(Builder $query): void
+    {
+        $query->whereNull('disabled_at');
     }
 
     /**

--- a/app/Services/Posts/DraftService.php
+++ b/app/Services/Posts/DraftService.php
@@ -15,6 +15,7 @@ use App\Models\PostTarget;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Support\InstanceSettings;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 
@@ -81,12 +82,11 @@ class DraftService
 
         $frozen = $this->frozenPlatformValues();
 
-        $ids = $frozen === []
-            ? $ids
-            : ConnectedAccount::withoutGlobalScopes()
-                ->whereKey($ids->all())
-                ->whereNotIn('platform', $frozen)
-                ->pluck('id');
+        $ids = ConnectedAccount::withoutGlobalScopes()
+            ->whereKey($ids->all())
+            ->enabled()
+            ->when($frozen !== [], fn (Builder $query): Builder => $query->whereNotIn('platform', $frozen))
+            ->pluck('id');
 
         return $this->defaultFirst($workspaceId, $ids->map(static fn (mixed $id): string => (string) $id)->all());
     }

--- a/database/factories/ConnectedAccountFactory.php
+++ b/database/factories/ConnectedAccountFactory.php
@@ -51,4 +51,11 @@ class ConnectedAccountFactory extends Factory
             'status' => ConnectedAccountStatus::NeedsAttention->value,
         ]);
     }
+
+    public function disabled(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'disabled_at' => now()->subDay(),
+        ]);
+    }
 }

--- a/database/migrations/2026_07_10_092821_add_disabled_at_to_connected_accounts_table.php
+++ b/database/migrations/2026_07_10_092821_add_disabled_at_to_connected_accounts_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('connected_accounts', function (Blueprint $table): void {
+            $table->timestamp('disabled_at')->nullable()->after('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('connected_accounts', function (Blueprint $table): void {
+            $table->dropColumn('disabled_at');
+        });
+    }
+};

--- a/resources/js/components/accounts/account-card.tsx
+++ b/resources/js/components/accounts/account-card.tsx
@@ -24,6 +24,7 @@ import {
     InputGroupInput,
 } from '@/components/ui/input-group';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 import type { PlatformName } from '@/types/compose';
 
@@ -137,15 +138,18 @@ export function AccountCard({
     frozen,
     onReconnectOAuth,
     onDisconnect,
+    onToggle,
 }: {
     account: Account;
     canManage: boolean;
     frozen?: boolean;
     onReconnectOAuth: (account: Account) => void;
     onDisconnect: (account: Account) => void;
+    onToggle: (account: Account, enabled: boolean) => void;
 }) {
     const brand = PLATFORM_BRAND[account.platform] ?? PLATFORM_FALLBACK;
     const needsAttention = account.status !== 'active';
+    const disabled = account.disabled;
     const name = account.display_name ?? account.handle;
 
     return (
@@ -153,6 +157,7 @@ export function AccountCard({
             className={cn(
                 'flex flex-col gap-4 rounded-xl border bg-card p-5 transition-colors',
                 needsAttention ? 'border-destructive/40' : 'border-border',
+                disabled && 'opacity-60',
             )}
         >
             <div className="flex items-start justify-between gap-2">
@@ -200,6 +205,11 @@ export function AccountCard({
                             Platform disabled
                         </Badge>
                     )}
+                    {disabled && !frozen && (
+                        <Badge variant="secondary" className="shrink-0">
+                            Disabled
+                        </Badge>
+                    )}
                     <span className="flex shrink-0 items-center gap-1.5 text-[11.5px] font-medium">
                         <span
                             className={cn(
@@ -221,6 +231,20 @@ export function AccountCard({
                                 : 'Connected'}
                         </span>
                     </span>
+                    {canManage && (
+                        <Switch
+                            checked={!disabled}
+                            onCheckedChange={(checked) =>
+                                onToggle(account, checked)
+                            }
+                            aria-label={
+                                disabled
+                                    ? `Enable ${account.handle}`
+                                    : `Disable ${account.handle}`
+                            }
+                            className="ml-1"
+                        />
+                    )}
                 </div>
             </div>
 

--- a/resources/js/components/accounts/types.ts
+++ b/resources/js/components/accounts/types.ts
@@ -13,6 +13,7 @@ export type Account = {
     max_text_length: number;
     x_premium: boolean;
     is_default: boolean;
+    disabled: boolean;
     pds_url: string | null;
 };
 

--- a/resources/js/components/ui/switch.tsx
+++ b/resources/js/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 data-checked:bg-primary data-unchecked:bg-input",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block size-4 rounded-full bg-background shadow-sm ring-0 transition-transform data-checked:translate-x-4 data-unchecked:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/resources/js/pages/accounts/__tests__/reconnect-oauth-route.test.ts
+++ b/resources/js/pages/accounts/__tests__/reconnect-oauth-route.test.ts
@@ -21,6 +21,7 @@ function account(overrides: Partial<Account>): Account {
         max_text_length: 300,
         x_premium: false,
         is_default: false,
+        disabled: false,
         pds_url: null,
         ...overrides,
     };

--- a/resources/js/pages/accounts/index.tsx
+++ b/resources/js/pages/accounts/index.tsx
@@ -75,6 +75,30 @@ export default function ConnectedAccounts({
         window.location.href = reconnectOAuthUrl(account);
     };
 
+    const toggleEnabled = (account: Account, enabled: boolean) => {
+        router.patch(
+            ConnectedAccountController.toggle.url(account.id),
+            {},
+            {
+                preserveScroll: true,
+                optimistic: (props) => ({
+                    accounts: (props as { accounts?: Account[] }).accounts?.map(
+                        (a) =>
+                            a.id === account.id
+                                ? {
+                                      ...a,
+                                      disabled: !enabled,
+                                      is_default: enabled
+                                          ? a.is_default
+                                          : false,
+                                  }
+                                : a,
+                    ),
+                }),
+            },
+        );
+    };
+
     const { flash } = usePage().props;
     const [dismissedError, setDismissedError] = useState<string | null>(null);
     // Connect/reconnect failures for every platform flash an `error`; surface it
@@ -167,6 +191,7 @@ export default function ConnectedAccounts({
                                 frozen={disabledPlatforms.has(account.platform)}
                                 onReconnectOAuth={reconnectOAuth}
                                 onDisconnect={disconnect}
+                                onToggle={toggleEnabled}
                             />
                         ))}
                     </div>

--- a/resources/js/pages/accounts/index.tsx
+++ b/resources/js/pages/accounts/index.tsx
@@ -106,8 +106,15 @@ export default function ConnectedAccounts({
     const connectError =
         flash?.error && flash.error !== dismissedError ? flash.error : null;
 
-    const connectedCount = accounts.filter((a) => a.status === 'active').length;
-    const attentionCount = accounts.length - connectedCount;
+    // A disabled account is neither "connected" nor "needs attention" — it's a
+    // third, dormant bucket, so each account lands in exactly one count.
+    const connectedCount = accounts.filter(
+        (a) => a.status === 'active' && !a.disabled,
+    ).length;
+    const attentionCount = accounts.filter(
+        (a) => a.status !== 'active' && !a.disabled,
+    ).length;
+    const disabledCount = accounts.filter((a) => a.disabled).length;
 
     return (
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pt-6 pb-16 sm:px-6">
@@ -177,6 +184,17 @@ export default function ConnectedAccounts({
                                 <span className="text-muted-foreground">
                                     need{attentionCount === 1 ? 's' : ''}{' '}
                                     attention
+                                </span>
+                            </span>
+                        )}
+                        {disabledCount > 0 && (
+                            <span className="flex items-center gap-1.5">
+                                <span className="size-1.5 rounded-full bg-muted-foreground/60" />
+                                <span className="font-medium tabular-nums">
+                                    {disabledCount}
+                                </span>
+                                <span className="text-muted-foreground">
+                                    disabled
                                 </span>
                             </span>
                         )}

--- a/routes/accounts.php
+++ b/routes/accounts.php
@@ -72,6 +72,9 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::post('accounts/{account}/default', [ConnectedAccountController::class, 'makeDefault'])
         ->name('accounts.default');
 
+    Route::patch('accounts/{account}/toggle', [ConnectedAccountController::class, 'toggle'])
+        ->name('accounts.toggle');
+
     Route::delete('accounts/{account}', [ConnectedAccountController::class, 'destroy'])
         ->name('accounts.destroy');
 });

--- a/routes/accounts.php
+++ b/routes/accounts.php
@@ -73,6 +73,7 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
         ->name('accounts.default');
 
     Route::patch('accounts/{account}/toggle', [ConnectedAccountController::class, 'toggle'])
+        ->middleware('throttle:30,1')
         ->name('accounts.toggle');
 
     Route::delete('accounts/{account}', [ConnectedAccountController::class, 'destroy'])

--- a/tests/Feature/ConnectedAccounts/AccountDisableToggleTest.php
+++ b/tests/Feature/ConnectedAccounts/AccountDisableToggleTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Enums\WorkspaceRole;
+use App\Models\ConnectedAccount;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
+use Inertia\Testing\AssertableInertia as Assert;
+
+function toggleOwner(): array
+{
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'role' => WorkspaceRole::Owner,
+    ]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+
+    return [$user, $workspace];
+}
+
+test('toggling disables then re-enables an account', function () {
+    [$user, $workspace] = toggleOwner();
+    $account = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'connected_by_user_id' => $user->id,
+    ]);
+
+    test()->actingAs($user)->patch("/accounts/{$account->id}/toggle")
+        ->assertRedirect(route('accounts.index'));
+    expect($account->fresh()->isDisabled())->toBeTrue();
+
+    test()->actingAs($user)->patch("/accounts/{$account->id}/toggle")
+        ->assertRedirect(route('accounts.index'));
+    expect($account->fresh()->isDisabled())->toBeFalse();
+});
+
+test('disabling the workspace default clears the default', function () {
+    [$user, $workspace] = toggleOwner();
+    $account = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'connected_by_user_id' => $user->id,
+    ]);
+    $workspace->forceFill(['default_connected_account_id' => $account->id])->save();
+
+    test()->actingAs($user)->patch("/accounts/{$account->id}/toggle");
+
+    expect($account->fresh()->isDisabled())->toBeTrue()
+        ->and($workspace->fresh()->default_connected_account_id)->toBeNull();
+});
+
+test('a member without account-manage permission cannot toggle', function () {
+    [$owner, $workspace] = toggleOwner();
+    $account = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'connected_by_user_id' => $owner->id,
+    ]);
+
+    $member = User::factory()->create();
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $member->id,
+        'role' => WorkspaceRole::Member,
+    ]);
+    $member->forceFill(['current_workspace_id' => $workspace->id])->save();
+
+    test()->actingAs($member)->patch("/accounts/{$account->id}/toggle")
+        ->assertForbidden();
+    expect($account->fresh()->isDisabled())->toBeFalse();
+});
+
+test('the accounts page exposes the disabled flag', function () {
+    [$user, $workspace] = toggleOwner();
+    ConnectedAccount::factory()->disabled()->create([
+        'workspace_id' => $workspace->id,
+        'handle' => '@off',
+        'connected_by_user_id' => $user->id,
+    ]);
+
+    test()->actingAs($user)->get('/accounts')
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('accounts/index')
+            ->where('accounts.0.handle', '@off')
+            ->where('accounts.0.disabled', true),
+        );
+});

--- a/tests/Feature/ConnectedAccounts/AccountDisabledStateTest.php
+++ b/tests/Feature/ConnectedAccounts/AccountDisabledStateTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Models\ConnectedAccount;
+
+test('isDisabled reflects the disabled_at timestamp', function () {
+    $enabled = ConnectedAccount::factory()->create();
+    $disabled = ConnectedAccount::factory()->disabled()->create();
+
+    expect($enabled->isDisabled())->toBeFalse()
+        ->and($disabled->isDisabled())->toBeTrue();
+});
+
+test('the enabled scope excludes disabled accounts', function () {
+    $enabled = ConnectedAccount::factory()->create();
+    ConnectedAccount::factory()->disabled()->create();
+
+    $ids = ConnectedAccount::withoutGlobalScopes()->enabled()->pluck('id');
+
+    expect($ids->all())->toBe([$enabled->id]);
+});

--- a/tests/Feature/Posts/DisabledAccountTargetingTest.php
+++ b/tests/Feature/Posts/DisabledAccountTargetingTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Enums\WorkspaceRole;
+use App\Models\ConnectedAccount;
+use App\Models\Post;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
+use App\Services\Posts\DraftService;
+use Illuminate\Support\Facades\Context;
+use Inertia\Testing\AssertableInertia as Assert;
+
+function ownerWithDisabledAccount(): array
+{
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'role' => WorkspaceRole::Owner,
+    ]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+
+    $enabled = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'handle' => '@enabled',
+        'connected_by_user_id' => $user->id,
+    ]);
+    $disabled = ConnectedAccount::factory()->disabled()->create([
+        'workspace_id' => $workspace->id,
+        'handle' => '@disabled',
+        'connected_by_user_id' => $user->id,
+    ]);
+
+    return [$user, $workspace, $enabled, $disabled];
+}
+
+test('draft targeting never snapshots a disabled account', function () {
+    [$user, $workspace, $enabled, $disabled] = ownerWithDisabledAccount();
+
+    Context::add('workspace_id', $workspace->id);
+
+    $ids = app(DraftService::class)->resolveDestinationAccountIds(
+        $workspace->id,
+        ['kind' => 'all'],
+    );
+
+    expect($ids)->toBe([$enabled->id]);
+});
+
+test('the composer and shell exclude disabled accounts', function () {
+    [$user, $workspace, $enabled, $disabled] = ownerWithDisabledAccount();
+
+    $post = Post::factory()->create([
+        'workspace_id' => $workspace->id,
+        'author_id' => $user->id,
+    ]);
+
+    test()->actingAs($user)->get("/posts/{$post->id}")
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('compose/index')
+            ->has('accounts', 1)
+            ->where('accounts.0.handle', '@enabled')
+            ->has('shell.accounts', 1)
+            ->where('shell.accounts.0.handle', '@enabled'),
+        );
+});

--- a/tests/Feature/Publishing/AccountDisabledPublishTest.php
+++ b/tests/Feature/Publishing/AccountDisabledPublishTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Enums\PostStatus;
+use App\Enums\PostTargetStatus;
+use App\Jobs\PublishPostTarget;
+use App\Models\ConnectedAccount;
+use App\Models\ConnectedAccountSecret;
+use App\Models\Post;
+use App\Models\PostTarget;
+use App\Services\Publishing\BackoffSchedule;
+use App\Services\Publishing\PostStatusRollup;
+use App\Services\Publishing\PublishConnectorRegistry;
+use App\Services\Publishing\TokenManager;
+
+function disabledPublishTarget(): PostTarget
+{
+    $post = Post::factory()->create(['status' => PostStatus::Publishing]);
+    $account = ConnectedAccount::factory()->disabled()->create([
+        'platform' => 'x',
+        'token_expires_at' => now()->addHour(),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'access_token' => 'tok',
+    ]);
+
+    return PostTarget::factory()->for($post)->create([
+        'connected_account_id' => $account->id,
+        'platform' => 'x',
+        'sections' => ['hello'],
+        'status' => 'pending',
+    ]);
+}
+
+it('skips a target whose account is disabled instead of publishing', function () {
+    $target = disabledPublishTarget();
+
+    app(PublishPostTarget::class, ['target' => $target])->handle(
+        app(PublishConnectorRegistry::class),
+        app(TokenManager::class),
+        app(PostStatusRollup::class),
+        app(BackoffSchedule::class),
+    );
+
+    expect($target->fresh()->status)->toBe(PostTargetStatus::Skipped)
+        ->and($target->fresh()->attemptLogs()->count())->toBe(0);
+});


### PR DESCRIPTION
## What

Adds a workspace-level **disable** toggle for individual connected accounts. A disabled account stays fully connected (OAuth tokens preserved) but goes dormant: it's hidden as a publish target and skipped at publish time. Instantly reversible.

This mirrors the instance platform-freeze pattern, scoped to a single `connected_accounts` row instead of a whole platform.

## Behavior

- **Hidden as a target** — a disabled account no longer appears in the composer, the shared shell account list, or draft targeting, so it can't be selected for new posts.
- **Skipped at publish** — `PublishPostTarget` marks a disabled account's target `Skipped` at publish time. This catches posts that were already scheduled *before* the account was disabled. Since `Skipped` is retryable, re-enabling + retry just works.
- **Reversible** — toggling only flips a `disabled_at` timestamp; no secrets are touched.
- **Permissions** — gated by the existing `ConnectedAccount` `update` policy (same as disconnect / make-default).
- **Default handling** — disabling the account currently set as the workspace default also clears `default_connected_account_id`, so "default"/"all" targeting never points at a dormant account.

## Changes

- **Migration/model** — nullable `connected_accounts.disabled_at` (null = enabled), plus `isDisabled()` and a `scopeEnabled()` query scope.
- **Publish guard** — `PublishPostTarget::handle()` skips a disabled account's target before any attempt/connector call.
- **Targeting filters** — `DraftService::resolveDestinationAccountIds()`, `ComposerController::show()`, and `HandleInertiaRequests::shellData()` all exclude disabled accounts. The `/accounts` management page stays unfiltered so accounts remain re-enableable.
- **Endpoint** — `PATCH accounts/{account}/toggle`, redirecting back with a flash message.
- **Frontend** — a toggle `Switch` on each account card, with dimming + a "Disabled" badge (distinct from the instance-level "Platform disabled" state), wired with an optimistic update.

## Testing

- New feature tests cover: model helper/scope, publish-time skip (including the already-scheduled case), exclusion from composer/shell/draft targeting, the toggle endpoint (round-trip, default-clearing, authorization 403), and the payload flag.
- Full suite green: Pest 1205/1205, Larastan level 7 clean, Pint clean, tsc + oxlint clean, frontend build succeeds.

## Note

The UI (switch animation, card dimming, badge placement) was verified mechanically only — worth an eyeball in the running app before merging.