### PR TITLE
feat: accept more video formats via in-browser conversion

### DIFF
--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -32,6 +32,8 @@ type Props = {
     handleFiles: (files: FileList) => Promise<void>;
     /** Drop a failed/pending upload chip. */
     dismissPending: (tempId: string) => void;
+    /** Abort an in-flight video conversion/upload chip. */
+    cancelPending: (tempId: string) => void;
     /** Click an attached image to (re)open it in the editor. */
     onImageClick?: (mediaId: string) => void;
     /** Click a video chip's Edit button to open the video editor. */
@@ -60,6 +62,7 @@ export function ComposerToolbar({
     pending,
     handleFiles,
     dismissPending,
+    cancelPending,
     onImageClick,
     onVideoClick,
     onInsertEmoji,
@@ -139,6 +142,7 @@ export function ComposerToolbar({
                 onReorder={onReorder}
                 onRemove={onRemove}
                 onDismissPending={dismissPending}
+                onCancelPending={cancelPending}
                 readOnly={readOnly}
                 onImageClick={onImageClick}
                 onVideoClick={onVideoClick}

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -981,6 +981,7 @@ export default function Composer({
                         pending={mediaUploads.pending}
                         handleFiles={handleAddedFiles}
                         dismissPending={mediaUploads.dismissPending}
+                        cancelPending={mediaUploads.cancelPending}
                         onImageClick={openImage}
                         onVideoClick={openVideo}
                     />

--- a/resources/js/components/compose/media-chips.tsx
+++ b/resources/js/components/compose/media-chips.tsx
@@ -62,6 +62,8 @@ type Props = {
     onReorder: (ids: string[]) => void;
     onRemove: (mediaId: string) => void;
     onDismissPending: (tempId: string) => void;
+    /** Abort an in-flight video conversion/upload and drop its chip. */
+    onCancelPending: (tempId: string) => void;
     /** Read-only post: show the images, no add/remove/reorder/exclude affordances. */
     readOnly?: boolean;
     /** Click an image to (re)open it in the editor. */
@@ -114,6 +116,7 @@ export function MediaChips({
     onReorder,
     onRemove,
     onDismissPending,
+    onCancelPending,
     readOnly = false,
     onImageClick,
     onVideoClick,
@@ -313,7 +316,7 @@ export function MediaChips({
                                     className="group/chip relative"
                                     aria-label={
                                         p.status === 'processing'
-                                            ? 'Compressing media'
+                                            ? 'Processing video'
                                             : p.status === 'uploading'
                                               ? 'Uploading media'
                                               : 'Failed upload'
@@ -378,10 +381,24 @@ export function MediaChips({
                                     />
                                 </CornerButton>
                             )}
+                            {/* In-flight videos can be aborted mid-conversion or
+                                mid-upload — a stuck or slow encode isn't a
+                                dead-end. Reuses the same corner ✕ as Remove. */}
+                            {inFlight && p.kind === 'video' && (
+                                <CornerButton
+                                    label="Cancel"
+                                    onClick={() => onCancelPending(p.tempId)}
+                                >
+                                    <X
+                                        className="size-2.5 text-black"
+                                        aria-hidden="true"
+                                    />
+                                </CornerButton>
+                            )}
                         </TooltipTrigger>
                         <TooltipContent side="bottom" className="text-[11px]">
                             {p.status === 'processing'
-                                ? 'Compressing…'
+                                ? 'Processing…'
                                 : p.status === 'uploading'
                                   ? 'Uploading…'
                                   : 'Upload failed — dismiss and retry'}

--- a/resources/js/hooks/compose/use-media-uploads.ts
+++ b/resources/js/hooks/compose/use-media-uploads.ts
@@ -12,6 +12,10 @@ import {
     validateVideo,
     type VideoMeta,
 } from '@/lib/compose/video';
+import {
+    convertErrorMessage,
+    VideoConvertError,
+} from '@/lib/video-editor/convert-plan';
 import type { MediaView, PendingUpload, PlatformLimits } from '@/types/compose';
 
 type Options = {
@@ -200,9 +204,34 @@ export function useMediaUploads({
     }
 
     async function uploadVideo(file: File): Promise<void> {
+        // Non-MP4 input is converted to a platform-ready MP4 in the browser
+        // first — the server only ever stores MP4. MP4 files skip this entirely
+        // and keep the existing fast path untouched.
+        let source = file;
+        if (file.type !== 'video/mp4') {
+            const { tempId } = beginUpload(file, 'video', 'processing');
+            try {
+                const { convertToMp4 } =
+                    await import('@/lib/video-editor/convert');
+                source = await convertToMp4(file, videoLimits, (fraction) =>
+                    setProgress(tempId, Math.round(fraction * 100)),
+                );
+            } catch (error) {
+                const reason =
+                    error instanceof VideoConvertError
+                        ? error.reason
+                        : 'encode-unsupported';
+                toast.error(convertErrorMessage(reason, videoLimits));
+                dismissPending(tempId);
+
+                return;
+            }
+            dismissPending(tempId);
+        }
+
         let meta: VideoMeta;
         try {
-            meta = await readVideoMetadata(file);
+            meta = await readVideoMetadata(source);
         } catch {
             toast.error('Could not read that video.');
 
@@ -219,7 +248,7 @@ export function useMediaUploads({
         const willCompress =
             !verdict.ok &&
             Number.isFinite(maxBytes) &&
-            file.size > maxBytes &&
+            source.size > maxBytes &&
             validateVideo({ ...meta, sizeBytes: 0 }, videoLimits).ok;
 
         if (!verdict.ok && !willCompress) {
@@ -229,19 +258,19 @@ export function useMediaUploads({
         }
 
         const { tempId, previewUrl } = beginUpload(
-            file,
+            source,
             'video',
             willCompress ? 'processing' : 'uploading',
         );
 
-        let finalFile = file;
+        let finalFile = source;
         if (willCompress) {
             let compressed: Blob | null = null;
             try {
                 const { compressVideoToFit } =
                     await import('@/lib/video-editor/compress');
                 compressed = await compressVideoToFit(
-                    file,
+                    source,
                     maxBytes,
                     (fraction) =>
                         setProgress(tempId, Math.round(fraction * 100)),
@@ -252,7 +281,7 @@ export function useMediaUploads({
             }
 
             if (compressed) {
-                finalFile = new File([compressed], file.name, {
+                finalFile = new File([compressed], source.name, {
                     type: 'video/mp4',
                 });
                 try {

--- a/resources/js/hooks/compose/use-media-uploads.ts
+++ b/resources/js/hooks/compose/use-media-uploads.ts
@@ -47,6 +47,11 @@ type MediaUploads = {
     /** Validate + upload each file, enforcing the one-video / no-mixing rule. */
     handleFiles: (files: FileList | File[]) => Promise<void>;
     dismissPending: (tempId: string) => void;
+    /**
+     * Abort an in-flight video upload — cancels the in-browser conversion,
+     * compression, or storage PUT, whichever is running, and removes the chip.
+     */
+    cancelPending: (tempId: string) => void;
 };
 
 /**
@@ -87,6 +92,9 @@ export function useMediaUploads({
     const tempSeq = useRef(0);
     // Every object URL we mint, so they can be revoked and not leak.
     const urls = useRef<Set<string>>(new Set());
+    // AbortController per in-flight video upload, keyed by its chip's tempId, so
+    // the cancel button can stop conversion/compression/PUT mid-flight.
+    const aborters = useRef<Map<string, AbortController>>(new Map());
 
     useEffect(
         () => () => {
@@ -94,6 +102,12 @@ export function useMediaUploads({
                 URL.revokeObjectURL(url);
             }
             urls.current.clear();
+            // Unmounting mid-upload: stop any in-flight work rather than let it
+            // run to completion against a gone component.
+            for (const controller of aborters.current.values()) {
+                controller.abort();
+            }
+            aborters.current.clear();
         },
         [],
     );
@@ -174,6 +188,15 @@ export function useMediaUploads({
         });
     }
 
+    function cancelPending(tempId: string): void {
+        // Abort the in-flight work (conversion/compression/PUT) so it stops
+        // burning CPU and can't add media after the user bailed, then drop the
+        // chip. `uploadVideo` sees the aborted signal and returns silently.
+        aborters.current.get(tempId)?.abort();
+        aborters.current.delete(tempId);
+        dismissPending(tempId);
+    }
+
     // --- Upload flows -------------------------------------------------------
 
     async function uploadImage(file: File): Promise<void> {
@@ -204,144 +227,199 @@ export function useMediaUploads({
     }
 
     async function uploadVideo(file: File): Promise<void> {
-        // Non-MP4 input is converted to a platform-ready MP4 in the browser
-        // first — the server only ever stores MP4. MP4 files skip this entirely
-        // and keep the existing fast path untouched.
-        let source = file;
-        if (file.type !== 'video/mp4') {
-            const { tempId } = beginUpload(file, 'video', 'processing');
-            try {
-                const { convertToMp4 } =
-                    await import('@/lib/video-editor/convert');
-                source = await convertToMp4(file, videoLimits, (fraction) =>
-                    setProgress(tempId, Math.round(fraction * 100)),
-                );
-            } catch (error) {
-                const reason =
-                    error instanceof VideoConvertError
-                        ? error.reason
-                        : 'encode-unsupported';
-                toast.error(convertErrorMessage(reason, videoLimits));
+        // One controller for the whole operation; the cancel button aborts it to
+        // stop conversion, compression, or the PUT — whichever is running.
+        const controller = new AbortController();
+        const { signal } = controller;
+        // The chip the controller is currently registered under (conversion and
+        // upload use separate chips). The finally clears whichever is active so
+        // the registry never leaks a controller.
+        let activeTempId: string | null = null;
+        const register = (tempId: string): void => {
+            activeTempId = tempId;
+            aborters.current.set(tempId, controller);
+        };
+
+        try {
+            // Non-MP4 input is converted to a platform-ready MP4 in the browser
+            // first — the server only ever stores MP4. MP4 files skip this
+            // entirely and keep the existing fast path untouched.
+            let source = file;
+            if (file.type !== 'video/mp4') {
+                const { tempId } = beginUpload(file, 'video', 'processing');
+                register(tempId);
+                try {
+                    const { convertToMp4 } =
+                        await import('@/lib/video-editor/convert');
+                    source = await convertToMp4(
+                        file,
+                        videoLimits,
+                        (fraction) =>
+                            setProgress(tempId, Math.round(fraction * 100)),
+                        signal,
+                    );
+                } catch (error) {
+                    // The user cancelled: the chip is already gone, stay silent.
+                    if (signal.aborted) {
+                        return;
+                    }
+                    const reason =
+                        error instanceof VideoConvertError
+                            ? error.reason
+                            : 'encode-unsupported';
+                    toast.error(convertErrorMessage(reason, videoLimits));
+                    dismissPending(tempId);
+
+                    return;
+                }
                 dismissPending(tempId);
+                aborters.current.delete(tempId);
+                activeTempId = null;
+            }
+
+            let meta: VideoMeta;
+            try {
+                meta = await readVideoMetadata(source);
+            } catch {
+                toast.error('Could not read that video.');
 
                 return;
             }
-            dismissPending(tempId);
-        }
-
-        let meta: VideoMeta;
-        try {
-            meta = await readVideoMetadata(source);
-        } catch {
-            toast.error('Could not read that video.');
-
-            return;
-        }
-
-        // Re-encoding can only shrink an over-cap clip's bytes — it can't fix a
-        // wrong codec or a too-long runtime. So we compress only when an
-        // oversized file is otherwise valid, detected by re-running the gate as
-        // if the file already fit (sizeBytes 0). Anything else gets the cheap
-        // up-front rejection, so a doomed file never flashes a ghost chip.
-        const maxBytes = minVideoBytes(videoLimits);
-        const verdict = validateVideo(meta, videoLimits);
-        const willCompress =
-            !verdict.ok &&
-            Number.isFinite(maxBytes) &&
-            source.size > maxBytes &&
-            validateVideo({ ...meta, sizeBytes: 0 }, videoLimits).ok;
-
-        if (!verdict.ok && !willCompress) {
-            toast.error(verdict.reason);
-
-            return;
-        }
-
-        const { tempId, previewUrl } = beginUpload(
-            source,
-            'video',
-            willCompress ? 'processing' : 'uploading',
-        );
-
-        let finalFile = source;
-        if (willCompress) {
-            let compressed: Blob | null = null;
-            try {
-                const { compressVideoToFit } =
-                    await import('@/lib/video-editor/compress');
-                compressed = await compressVideoToFit(
-                    source,
-                    maxBytes,
-                    (fraction) =>
-                        setProgress(tempId, Math.round(fraction * 100)),
-                );
-            } catch {
-                // Encode threw outright; fall through to the gate, which rejects
-                // the still-over-cap original.
+            if (signal.aborted) {
+                return;
             }
 
-            if (compressed) {
-                finalFile = new File([compressed], source.name, {
-                    type: 'video/mp4',
-                });
+            // Re-encoding can only shrink an over-cap clip's bytes — it can't fix
+            // a wrong codec or a too-long runtime. So we compress only when an
+            // oversized file is otherwise valid, detected by re-running the gate
+            // as if the file already fit (sizeBytes 0). Anything else gets the
+            // cheap up-front rejection, so a doomed file never flashes a ghost
+            // chip.
+            const maxBytes = minVideoBytes(videoLimits);
+            const verdict = validateVideo(meta, videoLimits);
+            const willCompress =
+                !verdict.ok &&
+                Number.isFinite(maxBytes) &&
+                source.size > maxBytes &&
+                validateVideo({ ...meta, sizeBytes: 0 }, videoLimits).ok;
+
+            if (!verdict.ok && !willCompress) {
+                toast.error(verdict.reason);
+
+                return;
+            }
+
+            const { tempId, previewUrl } = beginUpload(
+                source,
+                'video',
+                willCompress ? 'processing' : 'uploading',
+            );
+            register(tempId);
+
+            let finalFile = source;
+            if (willCompress) {
+                let compressed: Blob | null = null;
                 try {
-                    // Downscaling changes width/height/size — re-read so the
-                    // final gate and confirm payload reflect the real output.
-                    meta = await readVideoMetadata(finalFile);
+                    const { compressVideoToFit } =
+                        await import('@/lib/video-editor/compress');
+                    compressed = await compressVideoToFit(
+                        source,
+                        maxBytes,
+                        (fraction) =>
+                            setProgress(tempId, Math.round(fraction * 100)),
+                        undefined,
+                        signal,
+                    );
                 } catch {
-                    // compressVideoToFit already guarantees the blob fits; if the
-                    // re-read fails, trust that size over the stale original
-                    // rather than dropping an otherwise-valid upload.
-                    meta = { ...meta, sizeBytes: finalFile.size };
+                    // Encode threw or was cancelled; the abort check below bails,
+                    // otherwise fall through to the gate which rejects the
+                    // still-over-cap original.
+                }
+                if (signal.aborted) {
+                    return;
+                }
+
+                if (compressed) {
+                    finalFile = new File([compressed], source.name, {
+                        type: 'video/mp4',
+                    });
+                    try {
+                        // Downscaling changes width/height/size — re-read so the
+                        // final gate and confirm payload reflect the real output.
+                        meta = await readVideoMetadata(finalFile);
+                    } catch {
+                        // compressVideoToFit already guarantees the blob fits; if
+                        // the re-read fails, trust that size over the stale
+                        // original rather than dropping an otherwise-valid upload.
+                        meta = { ...meta, sizeBytes: finalFile.size };
+                    }
+                }
+
+                setStatus(tempId, 'uploading');
+                setProgress(tempId, 0);
+
+                const finalVerdict = validateVideo(meta, videoLimits);
+                if (!finalVerdict.ok) {
+                    toast.error(finalVerdict.reason);
+                    dismissPending(tempId);
+
+                    return;
                 }
             }
 
-            setStatus(tempId, 'uploading');
-            setProgress(tempId, 0);
-
-            const finalVerdict = validateVideo(meta, videoLimits);
-            if (!finalVerdict.ok) {
-                toast.error(finalVerdict.reason);
-                dismissPending(tempId);
-
+            const id = await onEnsurePost();
+            if (!id) {
+                return failUpload(tempId);
+            }
+            if (signal.aborted) {
                 return;
             }
-        }
 
-        const id = await onEnsurePost();
-        if (!id) {
-            return failUpload(tempId);
-        }
+            try {
+                // 1. Sign (CSRF handled by useHttp) → 2. PUT direct to storage → 3. confirm.
+                signHttp.setData({ content_type: 'video/mp4' });
+                const signed = await signHttp.post(ep.videoSign(id), {
+                    onNetworkError: () => undefined,
+                });
+                if (signal.aborted) {
+                    return;
+                }
 
-        try {
-            // 1. Sign (CSRF handled by useHttp) → 2. PUT direct to storage → 3. confirm.
-            signHttp.setData({ content_type: 'video/mp4' });
-            const signed = await signHttp.post(ep.videoSign(id), {
-                onNetworkError: () => undefined,
-            });
+                await putWithProgress(
+                    signed.url,
+                    signed.headers,
+                    finalFile,
+                    (pct) => setProgress(tempId, pct),
+                    signal,
+                );
 
-            await putWithProgress(
-                signed.url,
-                signed.headers,
-                finalFile,
-                (pct) => setProgress(tempId, pct),
-            );
+                confirmHttp.setData({
+                    key: signed.key,
+                    duration_seconds: meta.durationSeconds,
+                    width: meta.width,
+                    height: meta.height,
+                    alt_text: null,
+                });
+                const { media: result } = await confirmHttp.post(
+                    ep.videoStore(id),
+                    { onNetworkError: () => undefined },
+                );
+                if (signal.aborted) {
+                    return;
+                }
 
-            confirmHttp.setData({
-                key: signed.key,
-                duration_seconds: meta.durationSeconds,
-                width: meta.width,
-                height: meta.height,
-                alt_text: null,
-            });
-            const { media: result } = await confirmHttp.post(
-                ep.videoStore(id),
-                { onNetworkError: () => undefined },
-            );
-
-            finishUpload(tempId, result, previewUrl);
-        } catch {
-            failUpload(tempId);
+                finishUpload(tempId, result, previewUrl);
+            } catch {
+                // A cancel aborts the PUT/confirm; the chip is already gone.
+                if (signal.aborted) {
+                    return;
+                }
+                failUpload(tempId);
+            }
+        } finally {
+            if (activeTempId) {
+                aborters.current.delete(activeTempId);
+            }
         }
     }
 
@@ -378,5 +456,5 @@ export function useMediaUploads({
         }
     }
 
-    return { pending, isUploading, handleFiles, dismissPending };
+    return { pending, isUploading, handleFiles, dismissPending, cancelPending };
 }

--- a/resources/js/hooks/compose/use-media-uploads.ts
+++ b/resources/js/hooks/compose/use-media-uploads.ts
@@ -367,6 +367,12 @@ export function useMediaUploads({
                 }
             }
 
+            // Bail before touching the draft if the user cancelled during the
+            // compress re-read, so a cancel doesn't create a post it abandoned.
+            if (signal.aborted) {
+                return;
+            }
+
             const id = await onEnsurePost();
             if (!id) {
                 return failUpload(tempId);

--- a/resources/js/lib/compose/video.ts
+++ b/resources/js/lib/compose/video.ts
@@ -227,19 +227,33 @@ export function readVideoMetadata(file: File): Promise<VideoMeta> {
  * PUT a file directly to a presigned storage URL with the signed headers (no app CSRF).
  * Resolves on a 2xx, rejects otherwise. `onProgress` fires only when the whole-number
  * percent changes — a large upload emits hundreds of events but the UI needs at most 100.
+ * Passing an aborted (or later-aborted) `signal` cancels the in-flight PUT and rejects
+ * with an `AbortError`, so a user can bail out of a slow upload.
  */
 export function putWithProgress(
     url: string,
     headers: Record<string, string>,
     body: Blob,
     onProgress: (percent: number) => void,
+    signal?: AbortSignal,
 ): Promise<void> {
     return new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+            reject(new DOMException('Aborted', 'AbortError'));
+
+            return;
+        }
+
         const xhr = new XMLHttpRequest();
         xhr.open('PUT', url);
         for (const [header, value] of Object.entries(headers)) {
             xhr.setRequestHeader(header, value);
         }
+
+        const onAbort = (): void => xhr.abort();
+        signal?.addEventListener('abort', onAbort, { once: true });
+        const cleanup = (): void =>
+            signal?.removeEventListener('abort', onAbort);
 
         let lastPct = -1;
         xhr.upload.onprogress = (e) => {
@@ -252,11 +266,22 @@ export function putWithProgress(
                 onProgress(pct);
             }
         };
-        xhr.onload = () =>
-            xhr.status >= 200 && xhr.status < 300
-                ? resolve()
-                : reject(new Error(`upload failed: ${xhr.status}`));
-        xhr.onerror = () => reject(new Error('network error'));
+        xhr.onload = () => {
+            cleanup();
+            if (xhr.status >= 200 && xhr.status < 300) {
+                resolve();
+            } else {
+                reject(new Error(`upload failed: ${xhr.status}`));
+            }
+        };
+        xhr.onabort = () => {
+            cleanup();
+            reject(new DOMException('Aborted', 'AbortError'));
+        };
+        xhr.onerror = () => {
+            cleanup();
+            reject(new Error('network error'));
+        };
         xhr.send(body);
     });
 }

--- a/resources/js/lib/video-editor/__tests__/convert-plan.test.ts
+++ b/resources/js/lib/video-editor/__tests__/convert-plan.test.ts
@@ -38,6 +38,8 @@ function probe(overrides: Partial<VideoProbe> = {}): VideoProbe {
         videoCodec: 'avc',
         audioCodec: 'aac',
         durationSeconds: 30,
+        width: 1920,
+        height: 1080,
         sizeBytes: 10_000_000,
         ...overrides,
     };

--- a/resources/js/lib/video-editor/__tests__/convert-plan.test.ts
+++ b/resources/js/lib/video-editor/__tests__/convert-plan.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PlatformLimits } from '@/types/compose';
+
+import {
+    convertErrorMessage,
+    planConversion,
+    type VideoProbe,
+} from '../convert-plan';
+
+function limits(
+    overrides: Partial<
+        Pick<PlatformLimits, 'maxVideoBytes' | 'maxVideoDurationSeconds'>
+    > = {},
+): PlatformLimits[] {
+    return [
+        {
+            platform: 'x',
+            maxLength: 280,
+            maxBytes: null,
+            maxMedia: 4,
+            maxMediaBytes: 5_242_880,
+            allowedMime: ['image/jpeg'],
+            threadMax: null,
+            maxImageDimensions: { width: 4096, height: 4096 },
+            allowedVideoMime: ['video/mp4'],
+            maxVideoBytes: 536_870_912,
+            maxVideoDurationSeconds: 140,
+            ...overrides,
+        },
+    ];
+}
+
+function probe(overrides: Partial<VideoProbe> = {}): VideoProbe {
+    return {
+        hasVideoTrack: true,
+        canDecodeVideo: true,
+        videoCodec: 'avc',
+        audioCodec: 'aac',
+        durationSeconds: 30,
+        sizeBytes: 10_000_000,
+        ...overrides,
+    };
+}
+
+describe('planConversion', () => {
+    it('rejects a file with no video track', () => {
+        expect(
+            planConversion(probe({ hasVideoTrack: false }), limits()),
+        ).toEqual({ action: 'reject', reason: 'no-video-track' });
+    });
+
+    it('rejects a video the browser cannot decode', () => {
+        expect(
+            planConversion(probe({ canDecodeVideo: false }), limits()),
+        ).toEqual({ action: 'reject', reason: 'cannot-decode' });
+    });
+
+    it('rejects a clip longer than the tightest platform limit', () => {
+        expect(
+            planConversion(probe({ durationSeconds: 200 }), limits()),
+        ).toEqual({ action: 'reject', reason: 'too-long' });
+    });
+
+    it('remuxes H.264 + AAC within the byte cap', () => {
+        expect(planConversion(probe(), limits())).toEqual({ action: 'remux' });
+    });
+
+    it('remuxes H.264 with no audio track', () => {
+        expect(planConversion(probe({ audioCodec: null }), limits())).toEqual({
+            action: 'remux',
+        });
+    });
+
+    it('transcodes H.264 that is over the byte cap', () => {
+        expect(
+            planConversion(
+                probe({ sizeBytes: 600_000_000 }),
+                limits({ maxVideoBytes: 536_870_912 }),
+            ),
+        ).toEqual({ action: 'transcode' });
+    });
+
+    it('transcodes a non-H.264 codec (VP9)', () => {
+        expect(planConversion(probe({ videoCodec: 'vp9' }), limits())).toEqual({
+            action: 'transcode',
+        });
+    });
+
+    it('transcodes H.264 with an incompatible audio codec (opus)', () => {
+        expect(planConversion(probe({ audioCodec: 'opus' }), limits())).toEqual(
+            { action: 'transcode' },
+        );
+    });
+});
+
+describe('convertErrorMessage', () => {
+    it('names a missing video track', () => {
+        expect(convertErrorMessage('no-video-track', limits())).toBe(
+            "That file doesn't contain a video track.",
+        );
+    });
+
+    it('reports the tightest duration limit for a too-long clip', () => {
+        expect(
+            convertErrorMessage(
+                'too-long',
+                limits({ maxVideoDurationSeconds: 140 }),
+            ),
+        ).toBe(
+            'Video is too long; the limit is 140s for the selected platforms.',
+        );
+    });
+
+    it('gives a generic hint when the browser cannot convert', () => {
+        expect(convertErrorMessage('encode-unsupported', limits())).toBe(
+            "Your browser couldn't convert that video. Try an MP4 (H.264) file.",
+        );
+        expect(convertErrorMessage('cannot-decode', limits())).toBe(
+            "Your browser couldn't convert that video. Try an MP4 (H.264) file.",
+        );
+    });
+});

--- a/resources/js/lib/video-editor/compress.ts
+++ b/resources/js/lib/video-editor/compress.ts
@@ -48,6 +48,7 @@ export async function compressVideoToFit(
     maxBytes: number,
     onProgress: (fraction: number) => void,
     knownMeta?: VideoMeta,
+    signal?: AbortSignal,
 ): Promise<Blob | null> {
     // A caller that already probed the source (the format-conversion path reads
     // metadata via mediabunny) passes it in: the `<video>`-based
@@ -71,6 +72,10 @@ export async function compressVideoToFit(
     let progressFloor = 0;
 
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+        if (signal?.aborted) {
+            throw new DOMException('Aborted', 'AbortError');
+        }
+
         // Confirm an encoder that actually works at this exact output size —
         // the same probe gating the crop UI, so they can't disagree.
         const codec = await firstEncodableVideoCodec(width, height);
@@ -85,6 +90,7 @@ export async function compressVideoToFit(
             source,
             { codec, width, height, videoBitrate, audioBitrate },
             (fraction) => onProgress(base + fraction * span),
+            signal,
         );
         if (blob === null) {
             return null;
@@ -114,6 +120,7 @@ async function encodeOnce(
     source: Blob,
     params: EncodeParams,
     onProgress: (fraction: number) => void,
+    signal?: AbortSignal,
 ): Promise<Blob | null> {
     const input = new Input({
         formats: ALL_FORMATS,
@@ -148,7 +155,15 @@ async function encodeOnce(
         }
 
         conversion.onProgress = (progress) => onProgress(progress);
-        await conversion.execute();
+        // Cancelling makes `execute()` throw `ConversionCanceledError`, which
+        // propagates out as the abort signal for the whole upload.
+        const onAbort = (): void => void conversion.cancel();
+        signal?.addEventListener('abort', onAbort, { once: true });
+        try {
+            await conversion.execute();
+        } finally {
+            signal?.removeEventListener('abort', onAbort);
+        }
 
         const buffer = output.target.buffer;
         return buffer === null

--- a/resources/js/lib/video-editor/compress.ts
+++ b/resources/js/lib/video-editor/compress.ts
@@ -14,6 +14,7 @@ import {
     nextDownscale,
     planVideoEncode,
     readVideoMetadata,
+    type VideoMeta,
     VIDEO_MIN_BITRATE,
 } from '@/lib/compose/video';
 
@@ -46,12 +47,19 @@ export async function compressVideoToFit(
     source: Blob,
     maxBytes: number,
     onProgress: (fraction: number) => void,
+    knownMeta?: VideoMeta,
 ): Promise<Blob | null> {
-    const probe =
-        source instanceof File
-            ? source
-            : new File([source], 'video.mp4', { type: 'video/mp4' });
-    const meta = await readVideoMetadata(probe);
+    // A caller that already probed the source (the format-conversion path reads
+    // metadata via mediabunny) passes it in: the `<video>`-based
+    // `readVideoMetadata` can't open containers the browser won't natively play
+    // (.mkv/.avi), so the transcode path must not depend on it.
+    const meta =
+        knownMeta ??
+        (await readVideoMetadata(
+            source instanceof File
+                ? source
+                : new File([source], 'video.mp4', { type: 'video/mp4' }),
+        ));
     const plan = planVideoEncode(meta, maxBytes);
 
     let { width, height, videoBitrate } = plan;

--- a/resources/js/lib/video-editor/convert-plan.ts
+++ b/resources/js/lib/video-editor/convert-plan.ts
@@ -1,0 +1,92 @@
+import { minVideoBytes } from '@/lib/compose/video';
+import type { PlatformLimits } from '@/types/compose';
+
+/** Why a file could not be converted. Maps 1:1 to a user-facing toast. */
+export type ConvertReason =
+    | 'no-video-track'
+    | 'cannot-decode'
+    | 'too-long'
+    | 'encode-unsupported';
+
+/** Thrown by `convertToMp4` when a file cannot be turned into a valid MP4. */
+export class VideoConvertError extends Error {
+    constructor(public readonly reason: ConvertReason) {
+        super(reason);
+        this.name = 'VideoConvertError';
+    }
+}
+
+/**
+ * The container/codec facts `planConversion` needs. Produced by probing the file
+ * with mediabunny (see `convert.ts`); kept as a plain shape so the decision is
+ * pure and unit-testable without a browser.
+ */
+export type VideoProbe = {
+    hasVideoTrack: boolean;
+    canDecodeVideo: boolean;
+    videoCodec: string | null;
+    audioCodec: string | null;
+    durationSeconds: number;
+    sizeBytes: number;
+};
+
+export type ConvertPlan =
+    | { action: 'remux' }
+    | { action: 'transcode' }
+    | { action: 'reject'; reason: ConvertReason };
+
+/** Tightest video duration cap across the selected platforms (∞ when none). */
+function maxVideoDurationSeconds(limits: PlatformLimits[]): number {
+    return Math.min(
+        ...limits.map((l) => l.maxVideoDurationSeconds),
+        Number.POSITIVE_INFINITY,
+    );
+}
+
+/**
+ * Decide how to turn a probed file into a platform-ready MP4: reject it, remux
+ * (lossless container swap) when it is already H.264/AAC within the byte cap, or
+ * re-encode otherwise.
+ */
+export function planConversion(
+    probe: VideoProbe,
+    limits: PlatformLimits[],
+): ConvertPlan {
+    if (!probe.hasVideoTrack) {
+        return { action: 'reject', reason: 'no-video-track' };
+    }
+    if (!probe.canDecodeVideo) {
+        return { action: 'reject', reason: 'cannot-decode' };
+    }
+    if (probe.durationSeconds > maxVideoDurationSeconds(limits)) {
+        return { action: 'reject', reason: 'too-long' };
+    }
+
+    const audioCompatible =
+        probe.audioCodec === null || probe.audioCodec === 'aac';
+    if (
+        probe.videoCodec === 'avc' &&
+        audioCompatible &&
+        probe.sizeBytes <= minVideoBytes(limits)
+    ) {
+        return { action: 'remux' };
+    }
+
+    return { action: 'transcode' };
+}
+
+/** User-facing toast copy for a conversion failure. */
+export function convertErrorMessage(
+    reason: ConvertReason,
+    limits: PlatformLimits[],
+): string {
+    switch (reason) {
+        case 'no-video-track':
+            return "That file doesn't contain a video track.";
+        case 'too-long':
+            return `Video is too long; the limit is ${maxVideoDurationSeconds(limits)}s for the selected platforms.`;
+        case 'cannot-decode':
+        case 'encode-unsupported':
+            return "Your browser couldn't convert that video. Try an MP4 (H.264) file.";
+    }
+}

--- a/resources/js/lib/video-editor/convert-plan.ts
+++ b/resources/js/lib/video-editor/convert-plan.ts
@@ -27,6 +27,8 @@ export type VideoProbe = {
     videoCodec: string | null;
     audioCodec: string | null;
     durationSeconds: number;
+    width: number;
+    height: number;
     sizeBytes: number;
 };
 

--- a/resources/js/lib/video-editor/convert.ts
+++ b/resources/js/lib/video-editor/convert.ts
@@ -38,7 +38,7 @@ export async function convertToMp4(
     }
 
     if (plan.action === 'remux') {
-        const remuxed = await remuxToMp4(file);
+        const remuxed = await remuxToMp4(file, onProgress);
         if (remuxed) {
             return toMp4File(remuxed, file.name);
         }
@@ -46,10 +46,19 @@ export async function convertToMp4(
         // than failing a file we already know we can decode.
     }
 
+    // Feed the mediabunny-probed metadata to the encoder so it never falls back
+    // to the `<video>`-based reader, which can't open .mkv/.avi containers.
     const encoded = await compressVideoToFit(
         file,
         minVideoBytes(videoLimits),
         onProgress,
+        {
+            sizeBytes: probe.sizeBytes,
+            mime: file.type || 'video/mp4',
+            durationSeconds: probe.durationSeconds,
+            width: probe.width,
+            height: probe.height,
+        },
     );
     if (!encoded) {
         throw new VideoConvertError('encode-unsupported');
@@ -74,17 +83,27 @@ async function probeVideo(file: File): Promise<VideoProbe> {
                 videoCodec: null,
                 audioCodec: null,
                 durationSeconds: 0,
+                width: 0,
+                height: 0,
                 sizeBytes: file.size,
             };
         }
 
-        const [canDecodeVideo, videoCodec, audioTrack, duration] =
-            await Promise.all([
-                videoTrack.canDecode(),
-                videoTrack.getCodec(),
-                input.getPrimaryAudioTrack(),
-                input.computeDuration(),
-            ]);
+        const [
+            canDecodeVideo,
+            videoCodec,
+            width,
+            height,
+            audioTrack,
+            duration,
+        ] = await Promise.all([
+            videoTrack.canDecode(),
+            videoTrack.getCodec(),
+            videoTrack.getDisplayWidth(),
+            videoTrack.getDisplayHeight(),
+            input.getPrimaryAudioTrack(),
+            input.computeDuration(),
+        ]);
         const audioCodec = audioTrack ? await audioTrack.getCodec() : null;
 
         return {
@@ -95,6 +114,8 @@ async function probeVideo(file: File): Promise<VideoProbe> {
             // Floor + clamp to ≥1 to match readVideoMetadata's duration contract
             // (the confirm endpoint rejects a 0-second duration).
             durationSeconds: Math.max(1, Math.floor(duration)),
+            width,
+            height,
             sizeBytes: file.size,
         };
     } finally {
@@ -104,7 +125,10 @@ async function probeVideo(file: File): Promise<VideoProbe> {
 
 /** Repackage `file` into an MP4 container, copying MP4-compatible tracks without
  * re-encoding. Returns `null` when mediabunny reports the conversion invalid. */
-async function remuxToMp4(file: File): Promise<Blob | null> {
+async function remuxToMp4(
+    file: File,
+    onProgress: (fraction: number) => void,
+): Promise<Blob | null> {
     const input = new Input({
         formats: ALL_FORMATS,
         source: new BlobSource(file),
@@ -120,6 +144,7 @@ async function remuxToMp4(file: File): Promise<Blob | null> {
         if (!conversion.isValid) {
             return null;
         }
+        conversion.onProgress = (progress) => onProgress(progress);
         await conversion.execute();
 
         const buffer = output.target.buffer;

--- a/resources/js/lib/video-editor/convert.ts
+++ b/resources/js/lib/video-editor/convert.ts
@@ -1,0 +1,137 @@
+import {
+    ALL_FORMATS,
+    BlobSource,
+    BufferTarget,
+    Conversion,
+    Input,
+    Mp4OutputFormat,
+    Output,
+} from 'mediabunny';
+
+import { minVideoBytes } from '@/lib/compose/video';
+import type { PlatformLimits } from '@/types/compose';
+
+import { compressVideoToFit } from './compress';
+import {
+    planConversion,
+    VideoConvertError,
+    type VideoProbe,
+} from './convert-plan';
+
+/**
+ * Convert a non-MP4 `file` to a platform-ready MP4 (H.264/AAC) entirely in the
+ * browser. Remuxes (lossless container swap) when the source is already
+ * H.264/AAC within the byte cap; otherwise re-encodes via `compressVideoToFit`.
+ * Throws `VideoConvertError` when the file can't be converted. Lazy-imported by
+ * the upload hook so mediabunny's chunk stays out of the main bundle.
+ */
+export async function convertToMp4(
+    file: File,
+    videoLimits: PlatformLimits[],
+    onProgress: (fraction: number) => void,
+): Promise<File> {
+    const probe = await probeVideo(file);
+    const plan = planConversion(probe, videoLimits);
+
+    if (plan.action === 'reject') {
+        throw new VideoConvertError(plan.reason);
+    }
+
+    if (plan.action === 'remux') {
+        const remuxed = await remuxToMp4(file);
+        if (remuxed) {
+            return toMp4File(remuxed, file.name);
+        }
+        // A remux that reports invalid falls through to a full re-encode rather
+        // than failing a file we already know we can decode.
+    }
+
+    const encoded = await compressVideoToFit(
+        file,
+        minVideoBytes(videoLimits),
+        onProgress,
+    );
+    if (!encoded) {
+        throw new VideoConvertError('encode-unsupported');
+    }
+
+    return toMp4File(encoded, file.name);
+}
+
+/** Read codec/duration/decodability with mediabunny (no `<video>` element, so
+ * it works for containers the browser can't natively play, e.g. `.mkv`). */
+async function probeVideo(file: File): Promise<VideoProbe> {
+    const input = new Input({
+        formats: ALL_FORMATS,
+        source: new BlobSource(file),
+    });
+    try {
+        const videoTrack = await input.getPrimaryVideoTrack();
+        if (!videoTrack) {
+            return {
+                hasVideoTrack: false,
+                canDecodeVideo: false,
+                videoCodec: null,
+                audioCodec: null,
+                durationSeconds: 0,
+                sizeBytes: file.size,
+            };
+        }
+
+        const [canDecodeVideo, videoCodec, audioTrack, duration] =
+            await Promise.all([
+                videoTrack.canDecode(),
+                videoTrack.getCodec(),
+                input.getPrimaryAudioTrack(),
+                input.computeDuration(),
+            ]);
+        const audioCodec = audioTrack ? await audioTrack.getCodec() : null;
+
+        return {
+            hasVideoTrack: true,
+            canDecodeVideo,
+            videoCodec,
+            audioCodec,
+            // Floor + clamp to ≥1 to match readVideoMetadata's duration contract
+            // (the confirm endpoint rejects a 0-second duration).
+            durationSeconds: Math.max(1, Math.floor(duration)),
+            sizeBytes: file.size,
+        };
+    } finally {
+        input.dispose();
+    }
+}
+
+/** Repackage `file` into an MP4 container, copying MP4-compatible tracks without
+ * re-encoding. Returns `null` when mediabunny reports the conversion invalid. */
+async function remuxToMp4(file: File): Promise<Blob | null> {
+    const input = new Input({
+        formats: ALL_FORMATS,
+        source: new BlobSource(file),
+    });
+    try {
+        const output = new Output({
+            format: new Mp4OutputFormat(),
+            target: new BufferTarget(),
+        });
+        // No video/audio options → mediabunny copies MP4-compatible tracks
+        // (H.264/AAC) and only transcodes anything it must.
+        const conversion = await Conversion.init({ input, output });
+        if (!conversion.isValid) {
+            return null;
+        }
+        await conversion.execute();
+
+        const buffer = output.target.buffer;
+        return buffer === null
+            ? null
+            : new Blob([buffer], { type: 'video/mp4' });
+    } finally {
+        input.dispose();
+    }
+}
+
+function toMp4File(blob: Blob, originalName: string): File {
+    const base = originalName.replace(/\.[^./\\]+$/, '');
+    return new File([blob], `${base}.mp4`, { type: 'video/mp4' });
+}

--- a/resources/js/lib/video-editor/convert.ts
+++ b/resources/js/lib/video-editor/convert.ts
@@ -38,12 +38,18 @@ export async function convertToMp4(
     }
 
     if (plan.action === 'remux') {
-        const remuxed = await remuxToMp4(file, onProgress);
-        if (remuxed) {
-            return toMp4File(remuxed, file.name);
+        // A remux that reports invalid — or throws outright — falls through to a
+        // full re-encode rather than failing a file we already know we can
+        // decode. The probe confirmed a decodable track, so re-encoding is worth
+        // a try even when the cheap container-copy path errors.
+        try {
+            const remuxed = await remuxToMp4(file, onProgress);
+            if (remuxed) {
+                return toMp4File(remuxed, file.name);
+            }
+        } catch {
+            // fall through to re-encode
         }
-        // A remux that reports invalid falls through to a full re-encode rather
-        // than failing a file we already know we can decode.
     }
 
     // Feed the mediabunny-probed metadata to the encoder so it never falls back

--- a/resources/js/lib/video-editor/convert.ts
+++ b/resources/js/lib/video-editor/convert.ts
@@ -29,8 +29,9 @@ export async function convertToMp4(
     file: File,
     videoLimits: PlatformLimits[],
     onProgress: (fraction: number) => void,
+    signal?: AbortSignal,
 ): Promise<File> {
-    const probe = await probeVideo(file);
+    const probe = await probeVideo(file, signal);
     const plan = planConversion(probe, videoLimits);
 
     if (plan.action === 'reject') {
@@ -43,11 +44,14 @@ export async function convertToMp4(
         // decode. The probe confirmed a decodable track, so re-encoding is worth
         // a try even when the cheap container-copy path errors.
         try {
-            const remuxed = await remuxToMp4(file, onProgress);
+            const remuxed = await remuxToMp4(file, onProgress, signal);
             if (remuxed) {
                 return toMp4File(remuxed, file.name);
             }
         } catch {
+            if (signal?.aborted) {
+                throw new DOMException('Aborted', 'AbortError');
+            }
             // fall through to re-encode
         }
     }
@@ -65,6 +69,7 @@ export async function convertToMp4(
             width: probe.width,
             height: probe.height,
         },
+        signal,
     );
     if (!encoded) {
         throw new VideoConvertError('encode-unsupported');
@@ -74,12 +79,22 @@ export async function convertToMp4(
 }
 
 /** Read codec/duration/decodability with mediabunny (no `<video>` element, so
- * it works for containers the browser can't natively play, e.g. `.mkv`). */
-async function probeVideo(file: File): Promise<VideoProbe> {
+ * it works for containers the browser can't natively play, e.g. `.mkv`).
+ * Aborting disposes the input, which cancels any in-flight header reads. */
+async function probeVideo(
+    file: File,
+    signal?: AbortSignal,
+): Promise<VideoProbe> {
     const input = new Input({
         formats: ALL_FORMATS,
         source: new BlobSource(file),
     });
+    const onAbort = (): void => {
+        if (!input.disposed) {
+            input.dispose();
+        }
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
     try {
         const videoTrack = await input.getPrimaryVideoTrack();
         if (!videoTrack) {
@@ -125,15 +140,20 @@ async function probeVideo(file: File): Promise<VideoProbe> {
             sizeBytes: file.size,
         };
     } finally {
-        input.dispose();
+        signal?.removeEventListener('abort', onAbort);
+        if (!input.disposed) {
+            input.dispose();
+        }
     }
 }
 
 /** Repackage `file` into an MP4 container, copying MP4-compatible tracks without
- * re-encoding. Returns `null` when mediabunny reports the conversion invalid. */
+ * re-encoding. Returns `null` when mediabunny reports the conversion invalid.
+ * Aborting cancels the conversion, which makes `execute()` throw. */
 async function remuxToMp4(
     file: File,
     onProgress: (fraction: number) => void,
+    signal?: AbortSignal,
 ): Promise<Blob | null> {
     const input = new Input({
         formats: ALL_FORMATS,
@@ -151,7 +171,13 @@ async function remuxToMp4(
             return null;
         }
         conversion.onProgress = (progress) => onProgress(progress);
-        await conversion.execute();
+        const onAbort = (): void => void conversion.cancel();
+        signal?.addEventListener('abort', onAbort, { once: true });
+        try {
+            await conversion.execute();
+        } finally {
+            signal?.removeEventListener('abort', onAbort);
+        }
 
         const buffer = output.target.buffer;
         return buffer === null

--- a/resources/js/pages/engagement/components/use-reply-media.tsx
+++ b/resources/js/pages/engagement/components/use-reply-media.tsx
@@ -107,7 +107,7 @@ export function useReplyMedia({
 
     // --- useMediaUploads ---------------------------------------------------
 
-    const { pending, isUploading, handleFiles, dismissPending } =
+    const { pending, isUploading, handleFiles, dismissPending, cancelPending } =
         useMediaUploads({
             media,
             videoLimits,
@@ -344,6 +344,7 @@ export function useReplyMedia({
             }
             onRemove={(id) => onChange(media.filter((m) => m.id !== id))}
             onDismissPending={dismissPending}
+            onCancelPending={cancelPending}
             onImageClick={openEditor}
         />
     ) : null;


### PR DESCRIPTION
## What

The composer (and engagement reply composer) previously accepted **only MP4 (H.264/AAC)**, rejecting everything else with "Only MP4 (H.264/AAC) videos are supported." This PR makes it accept any browser-decodable video — `.mov`, `.webm`, `.mkv`, `.avi`, legacy — and **converts it to MP4 in the browser before upload**. On failure it shows a toast and skips the file.

## How

The existing mediabunny pipeline already *decoded* many containers (`ALL_FORMATS`) and always *output* MP4 — the pipeline was gated to MP4-only by validation, not capability. This opens that gate and routes non-MP4 files through a conversion step:

- **`convert-plan.ts`** — pure, unit-tested decision logic (no mediabunny, no DOM): remux vs. transcode vs. reject.
- **`convert.ts`** — mediabunny runtime, lazy-imported so mediabunny stays out of the main bundle. Probes the file, then:
  - **Remux** (lossless container-swap) when it's already H.264/AAC within the byte cap — near-instant, common for iPhone `.mov`.
  - **Re-encode** (reusing the existing `compressVideoToFit`) otherwise — VP9/AV1/HEVC, over-cap files. Metadata comes from the mediabunny probe so `.mkv`/`.avi` (which a `<video>` element can't open) transcode correctly.
- **`use-media-uploads.ts`** — `uploadVideo` gains a convert prologue for non-MP4 files, with a processing chip + progress; the rest of the flow is unchanged. Shared by both the composer and the reply composer.

## Safety

**The server stays MP4-only — zero backend changes.** Conversion always outputs `video/mp4`, so the presign rule (`content_type in:video/mp4`), the `ftyp` sniff, and the `.mp4` storage key are all untouched. No new server attack surface. The existing `PostVideoUpload` contract test (rejects non-MP4) still passes (13/13).

## Testing

- New vitest suite for the pure decision logic (11 tests); full JS suite 454/454.
- `tsc`, oxlint, oxfmt all clean.
- Encode itself is WebCodecs (browser-only) — **needs in-app verification** (see below).

## Manual verification checklist
- [x] `.mov` (iPhone H.264) → converts near-instantly (remux), uploads, preview plays
- [ ] `.webm` (VP9) → shows conversion progress, uploads as MP4
- [ ] `.mkv`/`.avi` needing re-encode → transcodes and uploads
- [ ] Over-cap / too-long clip → correct toast, no ghost chip
- [ ] Undecodable/renamed file → "Your browser couldn't convert that video" toast
- [ ] Same behaviors in the engagement **reply** composer

## Known limitation
Some OSes hand extension-only `.mkv`/`.avi` files an empty `file.type`; `handleFiles` then classifies them as images (pre-existing routing, out of scope here). Files with a proper `video/*` MIME are unaffected.