### PR TITLE
feat(sidebar): billing-aware footer + hoisted workspace settings + rc-aware update dot

### DIFF
--- a/app/Console/Commands/RefreshCommunityStats.php
+++ b/app/Console/Commands/RefreshCommunityStats.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Community\GithubStatsFetcher;
+use App\Support\CommunityStats;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+class RefreshCommunityStats extends Command
+{
+    protected $signature = 'community:refresh-stats';
+
+    protected $description = 'Fetch the GitHub star count and latest release tag for the sidebar community card.';
+
+    public function handle(GithubStatsFetcher $fetcher): int
+    {
+        if (config('subscriptions.enabled')) {
+            $this->info('Skipping community stats refresh on cloud.');
+
+            return self::SUCCESS;
+        }
+
+        $stats = $fetcher->fetch();
+
+        if ($stats['stars'] !== null) {
+            Cache::put(CommunityStats::StarsCacheKey, $stats['stars'], now()->addDays(7));
+        }
+
+        if ($stats['latest_version'] !== null) {
+            Cache::put(CommunityStats::LatestVersionCacheKey, $stats['latest_version'], now()->addDays(7));
+        }
+
+        $this->info('Community stats refreshed.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/RefreshCommunityStats.php
+++ b/app/Console/Commands/RefreshCommunityStats.php
@@ -13,7 +13,7 @@ class RefreshCommunityStats extends Command
 {
     protected $signature = 'community:refresh-stats';
 
-    protected $description = 'Fetch the GitHub star count and latest release tag for the sidebar community card.';
+    protected $description = 'Fetch the GitHub star count and newest release tags (stable + overall) for the sidebar community card.';
 
     public function handle(GithubStatsFetcher $fetcher): int
     {
@@ -29,8 +29,12 @@ class RefreshCommunityStats extends Command
             Cache::put(CommunityStats::StarsCacheKey, $stats['stars'], now()->addDays(7));
         }
 
-        if ($stats['latest_version'] !== null) {
-            Cache::put(CommunityStats::LatestVersionCacheKey, $stats['latest_version'], now()->addDays(7));
+        if ($stats['latest_stable'] !== null) {
+            Cache::put(CommunityStats::LatestStableCacheKey, $stats['latest_stable'], now()->addDays(7));
+        }
+
+        if ($stats['latest_overall'] !== null) {
+            Cache::put(CommunityStats::LatestOverallCacheKey, $stats['latest_overall'], now()->addDays(7));
         }
 
         $this->info('Community stats refreshed.');

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -14,6 +14,7 @@ use App\Support\CommunityStats;
 use App\Support\InstanceSettings;
 use App\Support\Notifications\NotificationPresenter;
 use Illuminate\Http\Request;
+use Inertia\Inertia;
 use Inertia\Middleware;
 use Override;
 
@@ -76,9 +77,11 @@ class HandleInertiaRequests extends Middleware
             'instance' => [
                 'isOwner' => $request->user()?->isInstanceOwner() ?? false,
             ],
-            'billing' => $this->billingData($request->user()),
-            'community' => $this->communityData(),
-            ...$this->updateData(),
+            'billing' => Inertia::defer(fn () => $this->billingData($request->user()), 'sidebar'),
+            'community' => Inertia::defer(fn () => $this->communityData(), 'sidebar')->once(),
+            'updateAvailable' => Inertia::defer(fn () => $this->updateData()['updateAvailable'], 'sidebar')->once(),
+            'latestVersion' => Inertia::defer(fn () => $this->updateData()['latestVersion'], 'sidebar')->once(),
+            'latestReleaseUrl' => Inertia::defer(fn () => $this->updateData()['latestReleaseUrl'], 'sidebar')->once(),
         ];
     }
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -165,6 +165,9 @@ class HandleInertiaRequests extends Middleware
         }
 
         $memberships = $user->workspaceMemberships()->with('workspace.postingSchedule')->get();
+        // Cache the eager-loaded memberships on the user so billingData() can reuse
+        // them within the same request instead of issuing a second query.
+        $user->setRelation('workspaceMemberships', $memberships);
 
         $all = $memberships->map(fn (WorkspaceMembership $m) => [
             'id' => $m->workspace->id,
@@ -206,10 +209,14 @@ class HandleInertiaRequests extends Middleware
             return null;
         }
 
-        $membership = $user->workspaceMemberships()
-            ->with('workspace')
-            ->where('workspace_id', $user->current_workspace_id)
-            ->first();
+        // Reuse the memberships eager-loaded by workspacesData() (which runs earlier
+        // in the same request); fall back to a scoped query if they aren't loaded.
+        $membership = $user->relationLoaded('workspaceMemberships')
+            ? $user->workspaceMemberships->firstWhere('workspace_id', $user->current_workspace_id)
+            : $user->workspaceMemberships()
+                ->with('workspace')
+                ->where('workspace_id', $user->current_workspace_id)
+                ->first();
 
         if (! $membership || ! in_array('workspace.billing.manage', $membership->permissions, true)) {
             return null;

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -10,6 +10,7 @@ use App\Models\ConnectedAccount;
 use App\Models\PostTargetReply;
 use App\Models\User;
 use App\Models\WorkspaceMembership;
+use App\Support\CommunityStats;
 use App\Support\InstanceSettings;
 use App\Support\Notifications\NotificationPresenter;
 use Illuminate\Http\Request;
@@ -75,6 +76,9 @@ class HandleInertiaRequests extends Middleware
             'instance' => [
                 'isOwner' => $request->user()?->isInstanceOwner() ?? false,
             ],
+            'billing' => $this->billingData($request->user()),
+            'community' => $this->communityData(),
+            'updateAvailable' => ! config('subscriptions.enabled') && CommunityStats::updateAvailable(),
         ];
     }
 
@@ -187,6 +191,48 @@ class HandleInertiaRequests extends Middleware
             'all' => $all,
             'current' => $current,
             'canCreateWorkspaces' => $canCreate,
+        ];
+    }
+
+    /**
+     * @return array{subscribed: bool, manageUrl: string}|null
+     */
+    private function billingData(?User $user): ?array
+    {
+        if (! config('subscriptions.enabled') || ! $user || ! $user->current_workspace_id) {
+            return null;
+        }
+
+        $membership = $user->workspaceMemberships()
+            ->with('workspace')
+            ->where('workspace_id', $user->current_workspace_id)
+            ->first();
+
+        if (! $membership || ! in_array('workspace.billing.manage', $membership->permissions, true)) {
+            return null;
+        }
+
+        return [
+            'subscribed' => $membership->workspace->subscribed('default'),
+            'manageUrl' => route('billing.index'),
+        ];
+    }
+
+    /**
+     * @return array{repoUrl: string, sponsorUrl: string, stars: ?int}|null
+     */
+    private function communityData(): ?array
+    {
+        if (config('subscriptions.enabled')) {
+            return null;
+        }
+
+        $repo = (string) config('instance.community.repo');
+
+        return [
+            'repoUrl' => "https://github.com/{$repo}",
+            'sponsorUrl' => (string) config('instance.community.sponsor_url'),
+            'stars' => CommunityStats::stars(),
         ];
     }
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -78,7 +78,7 @@ class HandleInertiaRequests extends Middleware
             ],
             'billing' => $this->billingData($request->user()),
             'community' => $this->communityData(),
-            'updateAvailable' => ! config('subscriptions.enabled') && CommunityStats::updateAvailable(),
+            ...$this->updateData(),
         ];
     }
 
@@ -233,6 +233,25 @@ class HandleInertiaRequests extends Middleware
             'repoUrl' => "https://github.com/{$repo}",
             'sponsorUrl' => (string) config('instance.community.sponsor_url'),
             'stars' => CommunityStats::stars(),
+        ];
+    }
+
+    /**
+     * @return array{updateAvailable: bool, latestVersion: ?string, latestReleaseUrl: ?string}
+     */
+    private function updateData(): array
+    {
+        if (config('subscriptions.enabled') || ! CommunityStats::updateAvailable()) {
+            return ['updateAvailable' => false, 'latestVersion' => null, 'latestReleaseUrl' => null];
+        }
+
+        $latest = CommunityStats::latestVersion();
+        $repo = (string) config('instance.community.repo');
+
+        return [
+            'updateAvailable' => true,
+            'latestVersion' => $latest,
+            'latestReleaseUrl' => "https://github.com/{$repo}/releases/tag/{$latest}",
         ];
     }
 

--- a/app/Services/Community/GithubStatsFetcher.php
+++ b/app/Services/Community/GithubStatsFetcher.php
@@ -51,6 +51,7 @@ class GithubStatsFetcher
     private function releases(string $repo): array
     {
         try {
+            // Newest 100 releases by creation date; ample for any realistic release cadence.
             $response = Http::timeout(10)
                 ->withHeaders(['Accept' => 'application/vnd.github+json'])
                 ->get("https://api.github.com/repos/{$repo}/releases", ['per_page' => 100]);

--- a/app/Services/Community/GithubStatsFetcher.php
+++ b/app/Services/Community/GithubStatsFetcher.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Community;
+
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+class GithubStatsFetcher
+{
+    /**
+     * @return array{stars: ?int, latest_version: ?string}
+     */
+    public function fetch(): array
+    {
+        $repo = (string) config('instance.community.repo');
+
+        return [
+            'stars' => $this->stars($repo),
+            'latest_version' => $this->latestVersion($repo),
+        ];
+    }
+
+    private function stars(string $repo): ?int
+    {
+        try {
+            $response = Http::timeout(10)
+                ->withHeaders(['Accept' => 'application/vnd.github+json'])
+                ->get("https://api.github.com/repos/{$repo}");
+
+            if (! $response->successful()) {
+                return null;
+            }
+
+            $count = $response->json('stargazers_count');
+
+            return is_numeric($count) ? (int) $count : null;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function latestVersion(string $repo): ?string
+    {
+        try {
+            $response = Http::timeout(10)
+                ->withHeaders(['Accept' => 'application/vnd.github+json'])
+                ->get("https://api.github.com/repos/{$repo}/releases/latest");
+
+            if (! $response->successful()) {
+                return null;
+            }
+
+            $tag = $response->json('tag_name');
+
+            return is_string($tag) && $tag !== '' ? $tag : null;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}

--- a/app/Services/Community/GithubStatsFetcher.php
+++ b/app/Services/Community/GithubStatsFetcher.php
@@ -10,15 +10,17 @@ use Throwable;
 class GithubStatsFetcher
 {
     /**
-     * @return array{stars: ?int, latest_version: ?string}
+     * @return array{stars: ?int, latest_stable: ?string, latest_overall: ?string}
      */
     public function fetch(): array
     {
         $repo = (string) config('instance.community.repo');
+        $releases = $this->releases($repo);
 
         return [
             'stars' => $this->stars($repo),
-            'latest_version' => $this->latestVersion($repo),
+            'latest_stable' => $releases['stable'],
+            'latest_overall' => $releases['overall'],
         ];
     }
 
@@ -41,22 +43,71 @@ class GithubStatsFetcher
         }
     }
 
-    private function latestVersion(string $repo): ?string
+    /**
+     * Newest non-draft release tag among stable-only and among all channels.
+     *
+     * @return array{stable: ?string, overall: ?string}
+     */
+    private function releases(string $repo): array
     {
         try {
             $response = Http::timeout(10)
                 ->withHeaders(['Accept' => 'application/vnd.github+json'])
-                ->get("https://api.github.com/repos/{$repo}/releases/latest");
+                ->get("https://api.github.com/repos/{$repo}/releases", ['per_page' => 100]);
 
             if (! $response->successful()) {
-                return null;
+                return ['stable' => null, 'overall' => null];
             }
 
-            $tag = $response->json('tag_name');
+            $releases = $response->json();
 
-            return is_string($tag) && $tag !== '' ? $tag : null;
+            if (! is_array($releases)) {
+                return ['stable' => null, 'overall' => null];
+            }
+
+            $all = [];
+            $stable = [];
+
+            foreach ($releases as $release) {
+                if (! is_array($release) || ($release['draft'] ?? false) === true) {
+                    continue;
+                }
+
+                $tag = $release['tag_name'] ?? null;
+
+                if (! is_string($tag) || $tag === '') {
+                    continue;
+                }
+
+                $all[] = $tag;
+
+                if (($release['prerelease'] ?? false) !== true) {
+                    $stable[] = $tag;
+                }
+            }
+
+            return [
+                'stable' => $this->maxTag($stable),
+                'overall' => $this->maxTag($all),
+            ];
         } catch (Throwable) {
-            return null;
+            return ['stable' => null, 'overall' => null];
         }
+    }
+
+    /**
+     * @param  array<int, string>  $tags
+     */
+    private function maxTag(array $tags): ?string
+    {
+        $max = null;
+
+        foreach ($tags as $tag) {
+            if ($max === null || version_compare(ltrim($tag, 'v'), ltrim($max, 'v'), '>')) {
+                $max = $tag;
+            }
+        }
+
+        return $max;
     }
 }

--- a/app/Support/AppVersion.php
+++ b/app/Support/AppVersion.php
@@ -6,9 +6,11 @@ namespace App\Support;
 
 class AppVersion
 {
+    private static ?string $current = null;
+
     public static function current(): string
     {
-        return trim((string) @file_get_contents(base_path('VERSION')));
+        return self::$current ??= trim((string) @file_get_contents(base_path('VERSION')));
     }
 
     public static function isOutdated(?string $latest): bool

--- a/app/Support/AppVersion.php
+++ b/app/Support/AppVersion.php
@@ -4,13 +4,27 @@ declare(strict_types=1);
 
 namespace App\Support;
 
+use Illuminate\Support\Facades\Log;
+
 class AppVersion
 {
     private static ?string $current = null;
 
     public static function current(): string
     {
-        return self::$current ??= trim((string) @file_get_contents(base_path('VERSION')));
+        if (self::$current !== null) {
+            return self::$current;
+        }
+
+        $path = base_path('VERSION');
+
+        if (! is_readable($path)) {
+            Log::warning('VERSION file is missing or unreadable.', ['path' => $path]);
+
+            return self::$current = '';
+        }
+
+        return self::$current = trim((string) file_get_contents($path));
     }
 
     public static function isOutdated(?string $latest): bool

--- a/app/Support/AppVersion.php
+++ b/app/Support/AppVersion.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+class AppVersion
+{
+    public static function current(): string
+    {
+        return trim((string) @file_get_contents(base_path('VERSION')));
+    }
+
+    public static function isOutdated(?string $latest): bool
+    {
+        if ($latest === null) {
+            return false;
+        }
+
+        $current = ltrim(self::current(), 'v');
+        $latest = ltrim($latest, 'v');
+
+        if ($current === '' || $latest === '') {
+            return false;
+        }
+
+        return version_compare($current, $latest, '<');
+    }
+}

--- a/app/Support/AppVersion.php
+++ b/app/Support/AppVersion.php
@@ -26,4 +26,11 @@ class AppVersion
 
         return version_compare($current, $latest, '<');
     }
+
+    public static function isPrerelease(?string $version = null): bool
+    {
+        $version = ltrim($version ?? self::current(), 'v');
+
+        return str_contains($version, '-');
+    }
 }

--- a/app/Support/CommunityStats.php
+++ b/app/Support/CommunityStats.php
@@ -10,7 +10,9 @@ class CommunityStats
 {
     public const StarsCacheKey = 'community:stars';
 
-    public const LatestVersionCacheKey = 'community:latest_version';
+    public const LatestStableCacheKey = 'community:latest_stable';
+
+    public const LatestOverallCacheKey = 'community:latest_overall';
 
     public static function stars(): ?int
     {
@@ -19,15 +21,33 @@ class CommunityStats
         return is_int($value) ? $value : null;
     }
 
+    /**
+     * The newest release for the running channel: a prerelease install considers
+     * prereleases and stable (overall); a stable install considers stable only.
+     */
     public static function latestVersion(): ?string
     {
-        $value = Cache::get(self::LatestVersionCacheKey);
+        return self::selectLatest(
+            AppVersion::isPrerelease(),
+            self::cachedTag(self::LatestStableCacheKey),
+            self::cachedTag(self::LatestOverallCacheKey),
+        );
+    }
 
-        return is_string($value) && $value !== '' ? $value : null;
+    public static function selectLatest(bool $currentIsPrerelease, ?string $stable, ?string $overall): ?string
+    {
+        return $currentIsPrerelease ? $overall : $stable;
     }
 
     public static function updateAvailable(): bool
     {
         return AppVersion::isOutdated(self::latestVersion());
+    }
+
+    private static function cachedTag(string $key): ?string
+    {
+        $value = Cache::get($key);
+
+        return is_string($value) && $value !== '' ? $value : null;
     }
 }

--- a/app/Support/CommunityStats.php
+++ b/app/Support/CommunityStats.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Cache;
+
+class CommunityStats
+{
+    public const StarsCacheKey = 'community:stars';
+
+    public const LatestVersionCacheKey = 'community:latest_version';
+
+    public static function stars(): ?int
+    {
+        $value = Cache::get(self::StarsCacheKey);
+
+        return is_int($value) ? $value : null;
+    }
+
+    public static function latestVersion(): ?string
+    {
+        $value = Cache::get(self::LatestVersionCacheKey);
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    public static function updateAvailable(): bool
+    {
+        return AppVersion::isOutdated(self::latestVersion());
+    }
+}

--- a/config/instance.php
+++ b/config/instance.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 return [
     'self_hosted' => env('SELF_HOSTED', false),
 
+    'community' => [
+        'repo' => env('SHOUTRRR_GITHUB_REPO', 'coollabsio/shoutrrr'),
+        'sponsor_url' => env('SHOUTRRR_SPONSOR_URL', 'https://github.com/sponsors/coollabsio'),
+    ],
+
     'defaults' => [
         'registrations_enabled' => env('INSTANCE_REGISTRATIONS_ENABLED', false),
         'workspace_creation_enabled' => env(

--- a/resources/js/components/layout/__tests__/app-sidebar.test.ts
+++ b/resources/js/components/layout/__tests__/app-sidebar.test.ts
@@ -103,3 +103,18 @@ describe('sidebar footer card + update dot', () => {
         expect(source).toContain('bg-red-500');
     });
 });
+
+describe('hoisted workspace settings nav', () => {
+    const source = readFileSync(
+        resolve(
+            process.cwd(),
+            'resources/js/components/layout/app-sidebar.tsx',
+        ),
+        'utf8',
+    );
+
+    it('renders workspace settings items from the shared builder', () => {
+        expect(source).toContain('workspaceSettingsNavItems(');
+        expect(source).toContain('workspaceSettingsIcons[item.key]');
+    });
+});

--- a/resources/js/components/layout/__tests__/app-sidebar.test.ts
+++ b/resources/js/components/layout/__tests__/app-sidebar.test.ts
@@ -84,3 +84,22 @@ describe('sidebar app version link', () => {
         expect(source).toContain('rel="noopener noreferrer"');
     });
 });
+
+describe('sidebar footer card + update dot', () => {
+    const source = readFileSync(
+        resolve(
+            process.cwd(),
+            'resources/js/components/layout/app-sidebar.tsx',
+        ),
+        'utf8',
+    );
+
+    it('renders the footer card above the user menu', () => {
+        expect(source).toContain('<SidebarFooterCard />');
+    });
+
+    it('shows a red update dot on the version badge', () => {
+        expect(source).toContain('updateAvailable');
+        expect(source).toContain('bg-red-500');
+    });
+});

--- a/resources/js/components/layout/__tests__/app-sidebar.test.ts
+++ b/resources/js/components/layout/__tests__/app-sidebar.test.ts
@@ -104,6 +104,26 @@ describe('sidebar footer card + update dot', () => {
     });
 });
 
+describe('version badge update tooltip', () => {
+    const source = readFileSync(
+        resolve(
+            process.cwd(),
+            'resources/js/components/layout/app-sidebar.tsx',
+        ),
+        'utf8',
+    );
+
+    it('links the badge to the new release when an update is available', () => {
+        expect(source).toContain('latestReleaseUrl');
+    });
+
+    it('names the available version in a tooltip', () => {
+        expect(source).toContain('TooltipContent');
+        expect(source).toContain('Update available');
+        expect(source).toContain('latestVersion');
+    });
+});
+
 describe('hoisted workspace settings nav', () => {
     const source = readFileSync(
         resolve(

--- a/resources/js/components/layout/__tests__/sidebar-footer-card.test.ts
+++ b/resources/js/components/layout/__tests__/sidebar-footer-card.test.ts
@@ -36,6 +36,12 @@ describe('sidebar footer card variants', () => {
         expect(source).toContain('billing.manageUrl');
     });
 
+    it('hides the chip for subscribed workspaces', () => {
+        expect(source).toContain('billing.subscribed');
+        expect(source).not.toContain("'Manage'");
+        expect(source).not.toContain('Active subscription');
+    });
+
     it('links the community card to the repo and sponsor urls', () => {
         expect(source).toContain('community.repoUrl');
         expect(source).toContain('community.sponsorUrl');

--- a/resources/js/components/layout/__tests__/sidebar-footer-card.test.ts
+++ b/resources/js/components/layout/__tests__/sidebar-footer-card.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { formatStars } from '../sidebar-footer-card';
+
+describe('formatStars', () => {
+    it('leaves small counts unabbreviated', () => {
+        expect(formatStars(0)).toBe('0');
+        expect(formatStars(999)).toBe('999');
+    });
+
+    it('abbreviates thousands with one decimal', () => {
+        expect(formatStars(1200)).toBe('1.2k');
+        expect(formatStars(4210)).toBe('4.2k');
+        expect(formatStars(10000)).toBe('10k');
+    });
+});
+
+describe('sidebar footer card variants', () => {
+    const source = readFileSync(
+        resolve(
+            process.cwd(),
+            'resources/js/components/layout/sidebar-footer-card.tsx',
+        ),
+        'utf8',
+    );
+
+    it('chooses the variant from features.billing', () => {
+        expect(source).toContain('features?.billing');
+    });
+
+    it('shows an Upgrade call to action when not subscribed', () => {
+        expect(source).toContain('Upgrade');
+        expect(source).toContain('billing.manageUrl');
+    });
+
+    it('links the community card to the repo and sponsor urls', () => {
+        expect(source).toContain('community.repoUrl');
+        expect(source).toContain('community.sponsorUrl');
+        expect(source).toContain('Star on GitHub');
+    });
+});

--- a/resources/js/components/layout/app-sidebar.tsx
+++ b/resources/js/components/layout/app-sidebar.tsx
@@ -2,12 +2,15 @@ import { Link, router, usePage } from '@inertiajs/react';
 import {
     CalendarDays,
     ChartColumn,
+    CreditCard,
     Inbox,
+    KeyRound,
     ListChecks,
     MessageCircle,
     Pencil,
     Settings,
     Share2,
+    Users,
     Wrench,
     type LucideIcon,
 } from 'lucide-react';
@@ -15,7 +18,6 @@ import { useEffect } from 'react';
 
 import PostingScheduleController from '@/actions/App/Http/Controllers/Posts/PostingScheduleController';
 import InstanceSettingsController from '@/actions/App/Http/Controllers/Settings/InstanceSettingsController';
-import WorkspaceSettingsController from '@/actions/App/Http/Controllers/Settings/WorkspaceSettingsController';
 import AppLogo from '@/components/layout/app-logo';
 import { NavUser } from '@/components/layout/nav-user';
 import { SidebarFooterCard } from '@/components/layout/sidebar-footer-card';
@@ -39,6 +41,10 @@ import {
     composeButtonClassName,
     composeIconClassName,
 } from '@/lib/navigation/compose-nav';
+import {
+    workspaceSettingsNavItems,
+    type WorkspaceSettingsNavKey,
+} from '@/lib/navigation/workspace-settings-nav';
 import { appVersion, githubReleaseUrl } from '@/lib/version';
 import { dashboard } from '@/routes';
 import { index as accountsRoute } from '@/routes/accounts';
@@ -67,6 +73,13 @@ const postsNavItems: NavItem[] = [
     { title: 'Accounts', href: accountsRoute(), icon: Share2 },
     { title: 'Engagement', href: engagementRoute(), icon: MessageCircle },
 ];
+
+const workspaceSettingsIcons: Record<WorkspaceSettingsNavKey, LucideIcon> = {
+    overview: Settings,
+    members: Users,
+    apiKeys: KeyRound,
+    subscription: CreditCard,
+};
 
 export function AppSidebar() {
     const { workspaces, features, instance, shell, updateAvailable } =
@@ -216,22 +229,33 @@ export function AppSidebar() {
                         <SidebarGroupLabel>Workspace</SidebarGroupLabel>
                         <SidebarGroupContent>
                             <SidebarMenu>
-                                <SidebarMenuItem>
-                                    <SidebarMenuButton
-                                        tooltip={workspaceSettingsLabel}
-                                        isActive={isCurrentOrParentUrl(
-                                            WorkspaceSettingsController.showOverview(),
-                                        )}
-                                        render={
-                                            <Link
-                                                href={WorkspaceSettingsController.showOverview()}
-                                            />
-                                        }
-                                    >
-                                        <Settings aria-hidden="true" />
-                                        <span>{workspaceSettingsLabel}</span>
-                                    </SidebarMenuButton>
-                                </SidebarMenuItem>
+                                {workspaceSettingsNavItems({
+                                    permissions:
+                                        workspaces.current?.permissions ?? [],
+                                    billingEnabled: !!features?.billing,
+                                }).map((item) => {
+                                    const Icon =
+                                        workspaceSettingsIcons[item.key];
+                                    const active =
+                                        item.key === 'overview'
+                                            ? isCurrentUrl(item.href)
+                                            : isCurrentOrParentUrl(item.href);
+
+                                    return (
+                                        <SidebarMenuItem key={item.key}>
+                                            <SidebarMenuButton
+                                                tooltip={item.title}
+                                                isActive={active}
+                                                render={
+                                                    <Link href={item.href} />
+                                                }
+                                            >
+                                                <Icon aria-hidden="true" />
+                                                <span>{item.title}</span>
+                                            </SidebarMenuButton>
+                                        </SidebarMenuItem>
+                                    );
+                                })}
                                 {instance.isOwner && (
                                     <SidebarMenuItem>
                                         <SidebarMenuButton

--- a/resources/js/components/layout/app-sidebar.tsx
+++ b/resources/js/components/layout/app-sidebar.tsx
@@ -18,6 +18,7 @@ import InstanceSettingsController from '@/actions/App/Http/Controllers/Settings/
 import WorkspaceSettingsController from '@/actions/App/Http/Controllers/Settings/WorkspaceSettingsController';
 import AppLogo from '@/components/layout/app-logo';
 import { NavUser } from '@/components/layout/nav-user';
+import { SidebarFooterCard } from '@/components/layout/sidebar-footer-card';
 import { Kbd } from '@/components/ui/kbd';
 import {
     Sidebar,
@@ -68,7 +69,8 @@ const postsNavItems: NavItem[] = [
 ];
 
 export function AppSidebar() {
-    const { workspaces, features, instance, shell } = usePage().props;
+    const { workspaces, features, instance, shell, updateAvailable } =
+        usePage().props;
     const unreadReplies = shell?.unreadReplies ?? 0;
     const { isCurrentOrParentUrl, isCurrentUrl } = useCurrentUrl();
     const { state, setOpenMobile } = useSidebar();
@@ -99,15 +101,27 @@ export function AppSidebar() {
                         >
                             <AppLogo />
                         </SidebarMenuButton>
-                        <a
-                            href={githubReleaseUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="rounded-full border border-sidebar-border px-1.5 py-0.5 text-[10px] leading-none font-medium text-sidebar-foreground/60 transition-colors group-data-[collapsible=icon]:hidden hover:border-sidebar-accent-foreground/30 hover:text-sidebar-foreground"
-                            aria-label={`View Shoutrrr ${appVersion} release notes on GitHub`}
-                        >
-                            {appVersion}
-                        </a>
+                        <span className="relative flex group-data-[collapsible=icon]:hidden">
+                            <a
+                                href={githubReleaseUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="rounded-full border border-sidebar-border px-1.5 py-0.5 text-[10px] leading-none font-medium text-sidebar-foreground/60 transition-colors hover:border-sidebar-accent-foreground/30 hover:text-sidebar-foreground"
+                                aria-label={
+                                    updateAvailable
+                                        ? `Shoutrrr ${appVersion} — a newer release is available on GitHub`
+                                        : `View Shoutrrr ${appVersion} release notes on GitHub`
+                                }
+                            >
+                                {appVersion}
+                            </a>
+                            {updateAvailable && (
+                                <span
+                                    className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-500 ring-2 ring-sidebar"
+                                    aria-hidden="true"
+                                />
+                            )}
+                        </span>
                     </SidebarMenuItem>
                 </SidebarMenu>
                 <WorkspaceSelector />
@@ -243,6 +257,7 @@ export function AppSidebar() {
             </SidebarContent>
 
             <SidebarFooter>
+                <SidebarFooterCard />
                 <NavUser />
             </SidebarFooter>
         </Sidebar>

--- a/resources/js/components/layout/app-sidebar.tsx
+++ b/resources/js/components/layout/app-sidebar.tsx
@@ -35,6 +35,11 @@ import {
     SidebarMenuItem,
     useSidebar,
 } from '@/components/ui/sidebar';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { WorkspaceSelector } from '@/components/workspace/workspace-selector';
 import { useCurrentUrl } from '@/hooks/use-current-url';
 import {
@@ -62,6 +67,9 @@ type NavItem = {
 export const workspaceSettingsLabel = 'Workspace settings';
 export const instanceSettingsLabel = 'Instance settings';
 
+const versionBadgeClassName =
+    'rounded-full border border-sidebar-border px-1.5 py-0.5 text-[10px] leading-none font-medium text-sidebar-foreground/60 transition-colors hover:border-sidebar-accent-foreground/30 hover:text-sidebar-foreground';
+
 const postsNavItems: NavItem[] = [
     { title: 'Posts', href: postsRoute(), icon: Inbox },
     { title: 'Calendar', href: calendarRoute(), icon: CalendarDays },
@@ -82,8 +90,15 @@ const workspaceSettingsIcons: Record<WorkspaceSettingsNavKey, LucideIcon> = {
 };
 
 export function AppSidebar() {
-    const { workspaces, features, instance, shell, updateAvailable } =
-        usePage().props;
+    const {
+        workspaces,
+        features,
+        instance,
+        shell,
+        updateAvailable,
+        latestVersion,
+        latestReleaseUrl,
+    } = usePage().props;
     const unreadReplies = shell?.unreadReplies ?? 0;
     const { isCurrentOrParentUrl, isCurrentUrl } = useCurrentUrl();
     const { state, setOpenMobile } = useSidebar();
@@ -115,19 +130,38 @@ export function AppSidebar() {
                             <AppLogo />
                         </SidebarMenuButton>
                         <span className="relative flex group-data-[collapsible=icon]:hidden">
-                            <a
-                                href={githubReleaseUrl}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="rounded-full border border-sidebar-border px-1.5 py-0.5 text-[10px] leading-none font-medium text-sidebar-foreground/60 transition-colors hover:border-sidebar-accent-foreground/30 hover:text-sidebar-foreground"
-                                aria-label={
-                                    updateAvailable
-                                        ? `Shoutrrr ${appVersion} — a newer release is available on GitHub`
-                                        : `View Shoutrrr ${appVersion} release notes on GitHub`
-                                }
-                            >
-                                {appVersion}
-                            </a>
+                            {(() => {
+                                const badge = (
+                                    <a
+                                        href={
+                                            updateAvailable && latestReleaseUrl
+                                                ? latestReleaseUrl
+                                                : githubReleaseUrl
+                                        }
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className={versionBadgeClassName}
+                                        aria-label={
+                                            updateAvailable
+                                                ? `Shoutrrr ${appVersion} — update ${latestVersion ?? ''} available on GitHub`
+                                                : `View Shoutrrr ${appVersion} release notes on GitHub`
+                                        }
+                                    >
+                                        {appVersion}
+                                    </a>
+                                );
+
+                                return updateAvailable ? (
+                                    <Tooltip>
+                                        <TooltipTrigger render={badge} />
+                                        <TooltipContent>
+                                            Update available: {latestVersion}
+                                        </TooltipContent>
+                                    </Tooltip>
+                                ) : (
+                                    badge
+                                );
+                            })()}
                             {updateAvailable && (
                                 <span
                                     className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-500 ring-2 ring-sidebar"

--- a/resources/js/components/layout/sidebar-footer-card.tsx
+++ b/resources/js/components/layout/sidebar-footer-card.tsx
@@ -1,0 +1,76 @@
+import { Link, usePage } from '@inertiajs/react';
+import { Heart, Star } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
+export function formatStars(count: number): string {
+    if (count < 1000) {
+        return String(count);
+    }
+
+    const thousands = count / 1000;
+    const rounded = Math.round(thousands * 10) / 10;
+
+    return `${Number.isInteger(rounded) ? rounded : rounded.toFixed(1)}k`;
+}
+
+export function SidebarFooterCard() {
+    const { features, billing, community } = usePage().props;
+
+    if (features?.billing) {
+        if (!billing) {
+            return null;
+        }
+
+        return (
+            <div className="rounded-md border border-sidebar-border p-2 group-data-[collapsible=icon]:hidden">
+                <p className="text-xs font-medium text-sidebar-foreground">
+                    Shoutrrr Cloud
+                </p>
+                <p className="text-[11px] text-sidebar-foreground/60">
+                    {billing.subscribed ? 'Active subscription' : 'Free plan'}
+                </p>
+                <Button
+                    size="sm"
+                    variant={billing.subscribed ? 'outline' : 'default'}
+                    className="mt-2 w-full"
+                    render={<Link href={billing.manageUrl} />}
+                >
+                    {billing.subscribed ? 'Manage' : 'Upgrade'}
+                </Button>
+            </div>
+        );
+    }
+
+    if (!community) {
+        return null;
+    }
+
+    return (
+        <div className="flex flex-col gap-0.5 group-data-[collapsible=icon]:hidden">
+            <a
+                href={community.repoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-xs text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+            >
+                <Star className="h-4 w-4" aria-hidden="true" />
+                <span>Star on GitHub</span>
+                {community.stars !== null && (
+                    <span className="ml-auto text-[11px] text-sidebar-foreground/50">
+                        {formatStars(community.stars)}
+                    </span>
+                )}
+            </a>
+            <a
+                href={community.sponsorUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-xs text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+            >
+                <Heart className="h-4 w-4" aria-hidden="true" />
+                <span>Sponsor</span>
+            </a>
+        </div>
+    );
+}

--- a/resources/js/components/layout/sidebar-footer-card.tsx
+++ b/resources/js/components/layout/sidebar-footer-card.tsx
@@ -18,7 +18,10 @@ export function SidebarFooterCard() {
     const { features, billing, community } = usePage().props;
 
     if (features?.billing) {
-        if (!billing) {
+        // Only surface the upgrade nudge for unsubscribed workspaces. A subscribed
+        // workspace already manages billing via the Subscription item in the sidebar
+        // nav, so an "Active" chip would just waste footer space.
+        if (!billing || billing.subscribed) {
             return null;
         }
 
@@ -28,15 +31,14 @@ export function SidebarFooterCard() {
                     Shoutrrr Cloud
                 </p>
                 <p className="text-[11px] text-sidebar-foreground/60">
-                    {billing.subscribed ? 'Active subscription' : 'Free plan'}
+                    Free plan
                 </p>
                 <Button
                     size="sm"
-                    variant={billing.subscribed ? 'outline' : 'default'}
                     className="mt-2 w-full"
                     render={<Link href={billing.manageUrl} />}
                 >
-                    {billing.subscribed ? 'Manage' : 'Upgrade'}
+                    Upgrade
                 </Button>
             </div>
         );

--- a/resources/js/layouts/settings/workspace-layout.tsx
+++ b/resources/js/layouts/settings/workspace-layout.tsx
@@ -1,13 +1,11 @@
 import { Link, usePage } from '@inertiajs/react';
 import type { PropsWithChildren } from 'react';
 
-import BillingController from '@/actions/App/Http/Controllers/BillingController';
-import ApiKeysController from '@/actions/App/Http/Controllers/Settings/ApiKeysController';
-import WorkspaceSettingsController from '@/actions/App/Http/Controllers/Settings/WorkspaceSettingsController';
 import Heading from '@/components/common/heading';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { useCurrentUrl } from '@/hooks/use-current-url';
+import { workspaceSettingsNavItems } from '@/lib/navigation/workspace-settings-nav';
 import { cn, toUrl } from '@/lib/utils';
 import type { NavItem } from '@/types';
 
@@ -17,43 +15,11 @@ export default function WorkspaceSettingsLayout({
     const { isCurrentOrParentUrl, isCurrentUrl } = useCurrentUrl();
     const { features, workspaces } = usePage().props;
     const workspacePermissions = workspaces.current?.permissions ?? [];
-    const canManageWorkspaceSettings = workspacePermissions.includes(
-        'workspace.settings.manage',
-    );
-    const canManageBilling = workspacePermissions.includes(
-        'workspace.billing.manage',
-    );
 
-    const sidebarNavItems: NavItem[] = [
-        {
-            title: 'Overview',
-            href: WorkspaceSettingsController.showOverview(),
-            icon: null,
-        },
-        {
-            title: 'Members',
-            href: WorkspaceSettingsController.showMembers(),
-            icon: null,
-        },
-        ...(canManageWorkspaceSettings
-            ? [
-                  {
-                      title: 'API keys',
-                      href: ApiKeysController.index(),
-                      icon: null,
-                  },
-              ]
-            : []),
-        ...(features?.billing && canManageBilling
-            ? [
-                  {
-                      title: 'Subscription',
-                      href: BillingController.index(),
-                      icon: null,
-                  },
-              ]
-            : []),
-    ];
+    const sidebarNavItems: NavItem[] = workspaceSettingsNavItems({
+        permissions: workspacePermissions,
+        billingEnabled: !!features?.billing,
+    }).map((item) => ({ title: item.title, href: item.href, icon: null }));
 
     return (
         <div className="mx-auto w-full max-w-6xl px-4 pt-6 pb-16 sm:px-6">

--- a/resources/js/lib/navigation/__tests__/workspace-settings-nav.test.ts
+++ b/resources/js/lib/navigation/__tests__/workspace-settings-nav.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { workspaceSettingsNavItems } from '../workspace-settings-nav';
+
+describe('workspaceSettingsNavItems', () => {
+    it('always includes overview and members', () => {
+        const keys = workspaceSettingsNavItems({
+            permissions: [],
+            billingEnabled: false,
+        }).map((item) => item.key);
+
+        expect(keys).toEqual(['overview', 'members']);
+    });
+
+    it('adds API keys only with the settings-manage permission', () => {
+        const keys = workspaceSettingsNavItems({
+            permissions: ['workspace.settings.manage'],
+            billingEnabled: false,
+        }).map((item) => item.key);
+
+        expect(keys).toContain('apiKeys');
+    });
+
+    it('adds subscription only when billing is enabled and manageable', () => {
+        expect(
+            workspaceSettingsNavItems({
+                permissions: ['workspace.billing.manage'],
+                billingEnabled: false,
+            }).map((item) => item.key),
+        ).not.toContain('subscription');
+
+        expect(
+            workspaceSettingsNavItems({
+                permissions: ['workspace.billing.manage'],
+                billingEnabled: true,
+            }).map((item) => item.key),
+        ).toContain('subscription');
+    });
+});

--- a/resources/js/lib/navigation/workspace-settings-nav.ts
+++ b/resources/js/lib/navigation/workspace-settings-nav.ts
@@ -1,0 +1,59 @@
+import type { Link } from '@inertiajs/react';
+
+import BillingController from '@/actions/App/Http/Controllers/BillingController';
+import ApiKeysController from '@/actions/App/Http/Controllers/Settings/ApiKeysController';
+import WorkspaceSettingsController from '@/actions/App/Http/Controllers/Settings/WorkspaceSettingsController';
+
+export type WorkspaceSettingsNavKey =
+    | 'overview'
+    | 'members'
+    | 'apiKeys'
+    | 'subscription';
+
+export type WorkspaceSettingsNavItem = {
+    key: WorkspaceSettingsNavKey;
+    title: string;
+    href: NonNullable<Parameters<typeof Link>[0]['href']>;
+};
+
+export function workspaceSettingsNavItems({
+    permissions,
+    billingEnabled,
+}: {
+    permissions: string[];
+    billingEnabled: boolean;
+}): WorkspaceSettingsNavItem[] {
+    const canManageSettings = permissions.includes('workspace.settings.manage');
+    const canManageBilling = permissions.includes('workspace.billing.manage');
+
+    const items: WorkspaceSettingsNavItem[] = [
+        {
+            key: 'overview',
+            title: 'Overview',
+            href: WorkspaceSettingsController.showOverview(),
+        },
+        {
+            key: 'members',
+            title: 'Members',
+            href: WorkspaceSettingsController.showMembers(),
+        },
+    ];
+
+    if (canManageSettings) {
+        items.push({
+            key: 'apiKeys',
+            title: 'API keys',
+            href: ApiKeysController.index(),
+        });
+    }
+
+    if (billingEnabled && canManageBilling) {
+        items.push({
+            key: 'subscription',
+            title: 'Subscription',
+            href: BillingController.index(),
+        });
+    }
+
+    return items;
+}

--- a/resources/js/pages/settings/workspace/__tests__/subscription.test.ts
+++ b/resources/js/pages/settings/workspace/__tests__/subscription.test.ts
@@ -20,10 +20,10 @@ describe('subscription checkout forms', () => {
             resolve(process.cwd(), 'resources/js/app.tsx'),
             'utf8',
         );
-        const workspaceLayout = readFileSync(
+        const workspaceSettingsNav = readFileSync(
             resolve(
                 process.cwd(),
-                'resources/js/layouts/settings/workspace-layout.tsx',
+                'resources/js/lib/navigation/workspace-settings-nav.ts',
             ),
             'utf8',
         );
@@ -33,8 +33,8 @@ describe('subscription checkout forms', () => {
         );
 
         expect(app).toContain("name.startsWith('settings/workspace')");
-        expect(workspaceLayout).toContain("title: 'Subscription'");
-        expect(workspaceLayout).toContain('BillingController.index()');
+        expect(workspaceSettingsNav).toContain("title: 'Subscription'");
+        expect(workspaceSettingsNav).toContain('BillingController.index()');
         expect(accountSettingsLayout).not.toContain("title: 'Subscription'");
     });
 

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -32,6 +32,16 @@ declare module '@inertiajs/core' {
                 engagement?: boolean;
             };
             instance: { isOwner: boolean };
+            billing?: {
+                subscribed: boolean;
+                manageUrl: string;
+            } | null;
+            community?: {
+                repoUrl: string;
+                sponsorUrl: string;
+                stars: number | null;
+            } | null;
+            updateAvailable?: boolean;
             [key: string]: unknown;
         };
     }

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -42,6 +42,8 @@ declare module '@inertiajs/core' {
                 stars: number | null;
             } | null;
             updateAvailable?: boolean;
+            latestVersion?: string | null;
+            latestReleaseUrl?: string | null;
             [key: string]: unknown;
         };
     }

--- a/routes/console.php
+++ b/routes/console.php
@@ -7,6 +7,7 @@ use App\Console\Commands\PruneAbandonedUploads;
 use App\Console\Commands\PruneMcpBindings;
 use App\Console\Commands\PruneUsageEvents;
 use App\Console\Commands\ReconcileUsageCounters;
+use App\Console\Commands\RefreshCommunityStats;
 use App\Console\Commands\RefreshExpiringTokens;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
@@ -31,3 +32,7 @@ if (config('engagement.enabled')) {
 
 Schedule::command(ReconcileUsageCounters::class)->dailyAt('02:10')->withoutOverlapping();
 Schedule::command(PruneUsageEvents::class)->dailyAt('02:20');
+
+if (! config('subscriptions.enabled')) {
+    Schedule::command(RefreshCommunityStats::class)->daily()->withoutOverlapping();
+}

--- a/tests/Feature/Community/RefreshCommunityStatsTest.php
+++ b/tests/Feature/Community/RefreshCommunityStatsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Support\CommunityStats;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    config(['subscriptions.enabled' => false]);
+    config(['instance.community.repo' => 'coollabsio/shoutrrr']);
+});
+
+test('the command caches stars and the latest release tag', function () {
+    Http::fake([
+        'api.github.com/repos/coollabsio/shoutrrr' => Http::response(['stargazers_count' => 4210]),
+        'api.github.com/repos/coollabsio/shoutrrr/releases/latest' => Http::response(['tag_name' => 'v9.9.9']),
+    ]);
+
+    $this->artisan('community:refresh-stats')->assertSuccessful();
+
+    expect(CommunityStats::stars())->toBe(4210);
+    expect(CommunityStats::latestVersion())->toBe('v9.9.9');
+});
+
+test('a failed GitHub response leaves the cache untouched', function () {
+    Cache::put(CommunityStats::StarsCacheKey, 100);
+    Http::fake([
+        'api.github.com/*' => Http::response(null, 503),
+    ]);
+
+    $this->artisan('community:refresh-stats')->assertSuccessful();
+
+    expect(CommunityStats::stars())->toBe(100);
+    expect(CommunityStats::latestVersion())->toBeNull();
+});
+
+test('the command is a no-op on cloud', function () {
+    config(['subscriptions.enabled' => true]);
+    Http::fake();
+
+    $this->artisan('community:refresh-stats')->assertSuccessful();
+
+    Http::assertNothingSent();
+    expect(CommunityStats::stars())->toBeNull();
+});

--- a/tests/Feature/Community/RefreshCommunityStatsTest.php
+++ b/tests/Feature/Community/RefreshCommunityStatsTest.php
@@ -9,16 +9,53 @@ beforeEach(function () {
     config(['instance.community.repo' => 'coollabsio/shoutrrr']);
 });
 
-test('the command caches stars and the latest release tag', function () {
+test('the command caches stars, newest stable, and newest overall release tags', function () {
     Http::fake([
         'api.github.com/repos/coollabsio/shoutrrr' => Http::response(['stargazers_count' => 4210]),
-        'api.github.com/repos/coollabsio/shoutrrr/releases/latest' => Http::response(['tag_name' => 'v9.9.9']),
+        'api.github.com/repos/coollabsio/shoutrrr/releases*' => Http::response([
+            ['tag_name' => 'v1.4.0-rc.1', 'prerelease' => true, 'draft' => false],
+            ['tag_name' => 'v1.3.0', 'prerelease' => false, 'draft' => false],
+            ['tag_name' => 'v1.3.0-rc.6', 'prerelease' => true, 'draft' => false],
+            ['tag_name' => 'v9.9.9-draft', 'prerelease' => true, 'draft' => true],
+        ]),
     ]);
 
     $this->artisan('community:refresh-stats')->assertSuccessful();
 
     expect(CommunityStats::stars())->toBe(4210);
-    expect(CommunityStats::latestVersion())->toBe('v9.9.9');
+    expect(Cache::get(CommunityStats::LatestStableCacheKey))->toBe('v1.3.0');
+    expect(Cache::get(CommunityStats::LatestOverallCacheKey))->toBe('v1.4.0-rc.1');
+});
+
+test('a shipped stable release supersedes its own prerelease as the overall newest', function () {
+    Http::fake([
+        'api.github.com/repos/coollabsio/shoutrrr' => Http::response(['stargazers_count' => 1]),
+        'api.github.com/repos/coollabsio/shoutrrr/releases*' => Http::response([
+            ['tag_name' => 'v1.3.0-rc.6', 'prerelease' => true, 'draft' => false],
+            ['tag_name' => 'v1.3.0', 'prerelease' => false, 'draft' => false],
+        ]),
+    ]);
+
+    $this->artisan('community:refresh-stats')->assertSuccessful();
+
+    // Never recommend the superseded rc: overall must be the real v1.3.0.
+    expect(Cache::get(CommunityStats::LatestOverallCacheKey))->toBe('v1.3.0');
+    expect(Cache::get(CommunityStats::LatestStableCacheKey))->toBe('v1.3.0');
+});
+
+test('with only prereleases, stable stays null and overall is the newest prerelease', function () {
+    Http::fake([
+        'api.github.com/repos/coollabsio/shoutrrr' => Http::response(['stargazers_count' => 1]),
+        'api.github.com/repos/coollabsio/shoutrrr/releases*' => Http::response([
+            ['tag_name' => 'v1.3.0-rc.5', 'prerelease' => true, 'draft' => false],
+            ['tag_name' => 'v1.3.0-rc.6', 'prerelease' => true, 'draft' => false],
+        ]),
+    ]);
+
+    $this->artisan('community:refresh-stats')->assertSuccessful();
+
+    expect(Cache::get(CommunityStats::LatestStableCacheKey))->toBeNull();
+    expect(Cache::get(CommunityStats::LatestOverallCacheKey))->toBe('v1.3.0-rc.6');
 });
 
 test('a failed GitHub response leaves the cache untouched', function () {
@@ -30,7 +67,8 @@ test('a failed GitHub response leaves the cache untouched', function () {
     $this->artisan('community:refresh-stats')->assertSuccessful();
 
     expect(CommunityStats::stars())->toBe(100);
-    expect(CommunityStats::latestVersion())->toBeNull();
+    expect(Cache::get(CommunityStats::LatestStableCacheKey))->toBeNull();
+    expect(Cache::get(CommunityStats::LatestOverallCacheKey))->toBeNull();
 });
 
 test('the command is a no-op on cloud', function () {

--- a/tests/Feature/SidebarFooterPropsTest.php
+++ b/tests/Feature/SidebarFooterPropsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Enums\WorkspaceRole;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
+use App\Support\CommunityStats;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Context;
+
+function actingOwnerInWorkspace(): User
+{
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'role' => WorkspaceRole::Owner,
+    ]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    Context::add('workspace_id', $workspace->id);
+    test()->actingAs($user);
+
+    return $user;
+}
+
+test('cloud shares a billing prop for billing managers and no community prop', function () {
+    config(['subscriptions.enabled' => true]);
+    actingOwnerInWorkspace();
+
+    $this->get(route('dashboard'))->assertInertia(fn ($page) => $page
+        ->where('billing.subscribed', false)
+        ->where('billing.manageUrl', route('billing.index'))
+        ->where('community', null)
+        ->where('updateAvailable', false)
+    );
+});
+
+test('members without billing.manage do not receive a billing prop', function () {
+    config(['subscriptions.enabled' => true]);
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create();
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'role' => WorkspaceRole::Member,
+    ]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    Context::add('workspace_id', $workspace->id);
+
+    $this->actingAs($user)->get(route('dashboard'))->assertInertia(fn ($page) => $page
+        ->where('billing', null)
+    );
+});
+
+test('self-hosted shares a community prop and the update flag, no billing prop', function () {
+    config(['subscriptions.enabled' => false]);
+    config(['instance.community.repo' => 'coollabsio/shoutrrr']);
+    config(['instance.community.sponsor_url' => 'https://github.com/sponsors/coollabsio']);
+    Cache::put(CommunityStats::StarsCacheKey, 4210);
+    Cache::put(CommunityStats::LatestVersionCacheKey, 'v99.0.0');
+    actingOwnerInWorkspace();
+
+    $this->get(route('dashboard'))->assertInertia(fn ($page) => $page
+        ->where('billing', null)
+        ->where('community.repoUrl', 'https://github.com/coollabsio/shoutrrr')
+        ->where('community.sponsorUrl', 'https://github.com/sponsors/coollabsio')
+        ->where('community.stars', 4210)
+        ->where('updateAvailable', true)
+    );
+});

--- a/tests/Feature/SidebarFooterPropsTest.php
+++ b/tests/Feature/SidebarFooterPropsTest.php
@@ -59,7 +59,7 @@ test('self-hosted shares a community prop and the update flag, no billing prop',
     config(['instance.community.repo' => 'coollabsio/shoutrrr']);
     config(['instance.community.sponsor_url' => 'https://github.com/sponsors/coollabsio']);
     Cache::put(CommunityStats::StarsCacheKey, 4210);
-    Cache::put(CommunityStats::LatestVersionCacheKey, 'v99.0.0');
+    Cache::put(CommunityStats::LatestOverallCacheKey, 'v99.0.0');
     actingOwnerInWorkspace();
 
     $this->get(route('dashboard'))->assertInertia(fn ($page) => $page
@@ -74,7 +74,7 @@ test('self-hosted shares a community prop and the update flag, no billing prop',
 test('self-hosted names the available version and links to its release', function () {
     config(['subscriptions.enabled' => false]);
     config(['instance.community.repo' => 'coollabsio/shoutrrr']);
-    Cache::put(CommunityStats::LatestVersionCacheKey, 'v99.0.0');
+    Cache::put(CommunityStats::LatestOverallCacheKey, 'v99.0.0');
     actingOwnerInWorkspace();
 
     $this->get(route('dashboard'))->assertInertia(fn ($page) => $page
@@ -86,7 +86,7 @@ test('self-hosted names the available version and links to its release', functio
 
 test('self-hosted up-to-date exposes no available version', function () {
     config(['subscriptions.enabled' => false]);
-    Cache::put(CommunityStats::LatestVersionCacheKey, AppVersion::current());
+    Cache::put(CommunityStats::LatestOverallCacheKey, AppVersion::current());
     actingOwnerInWorkspace();
 
     $this->get(route('dashboard'))->assertInertia(fn ($page) => $page
@@ -98,7 +98,7 @@ test('self-hosted up-to-date exposes no available version', function () {
 
 test('cloud never exposes an available version', function () {
     config(['subscriptions.enabled' => true]);
-    Cache::put(CommunityStats::LatestVersionCacheKey, 'v99.0.0');
+    Cache::put(CommunityStats::LatestOverallCacheKey, 'v99.0.0');
     actingOwnerInWorkspace();
 
     $this->get(route('dashboard'))->assertInertia(fn ($page) => $page

--- a/tests/Feature/SidebarFooterPropsTest.php
+++ b/tests/Feature/SidebarFooterPropsTest.php
@@ -25,15 +25,20 @@ function actingOwnerInWorkspace(): User
     return $user;
 }
 
-test('cloud shares a billing prop for billing managers and no community prop', function () {
+test('cloud defers a billing prop for billing managers and no community prop', function () {
     config(['subscriptions.enabled' => true]);
     actingOwnerInWorkspace();
 
     $this->get(route('dashboard'))->assertInertia(fn ($page) => $page
-        ->where('billing.subscribed', false)
-        ->where('billing.manageUrl', route('billing.index'))
-        ->where('community', null)
-        ->where('updateAvailable', false)
+        ->missing('billing')
+        ->missing('community')
+        ->missing('updateAvailable')
+        ->loadDeferredProps('sidebar', fn ($reload) => $reload
+            ->where('billing.subscribed', false)
+            ->where('billing.manageUrl', route('billing.index'))
+            ->where('community', null)
+            ->where('updateAvailable', false)
+        )
     );
 });
 
@@ -50,11 +55,14 @@ test('members without billing.manage do not receive a billing prop', function ()
     Context::add('workspace_id', $workspace->id);
 
     $this->actingAs($user)->get(route('dashboard'))->assertInertia(fn ($page) => $page
-        ->where('billing', null)
+        ->missing('billing')
+        ->loadDeferredProps('sidebar', fn ($reload) => $reload
+            ->where('billing', null)
+        )
     );
 });
 
-test('self-hosted shares a community prop and the update flag, no billing prop', function () {
+test('self-hosted defers a community prop and the update flag, no billing prop', function () {
     config(['subscriptions.enabled' => false]);
     config(['instance.community.repo' => 'coollabsio/shoutrrr']);
     config(['instance.community.sponsor_url' => 'https://github.com/sponsors/coollabsio']);
@@ -63,11 +71,15 @@ test('self-hosted shares a community prop and the update flag, no billing prop',
     actingOwnerInWorkspace();
 
     $this->get(route('dashboard'))->assertInertia(fn ($page) => $page
-        ->where('billing', null)
-        ->where('community.repoUrl', 'https://github.com/coollabsio/shoutrrr')
-        ->where('community.sponsorUrl', 'https://github.com/sponsors/coollabsio')
-        ->where('community.stars', 4210)
-        ->where('updateAvailable', true)
+        ->missing('community')
+        ->missing('updateAvailable')
+        ->loadDeferredProps('sidebar', fn ($reload) => $reload
+            ->where('billing', null)
+            ->where('community.repoUrl', 'https://github.com/coollabsio/shoutrrr')
+            ->where('community.sponsorUrl', 'https://github.com/sponsors/coollabsio')
+            ->where('community.stars', 4210)
+            ->where('updateAvailable', true)
+        )
     );
 });
 
@@ -78,9 +90,12 @@ test('self-hosted names the available version and links to its release', functio
     actingOwnerInWorkspace();
 
     $this->get(route('dashboard'))->assertInertia(fn ($page) => $page
-        ->where('updateAvailable', true)
-        ->where('latestVersion', 'v99.0.0')
-        ->where('latestReleaseUrl', 'https://github.com/coollabsio/shoutrrr/releases/tag/v99.0.0')
+        ->missing('latestVersion')
+        ->loadDeferredProps('sidebar', fn ($reload) => $reload
+            ->where('updateAvailable', true)
+            ->where('latestVersion', 'v99.0.0')
+            ->where('latestReleaseUrl', 'https://github.com/coollabsio/shoutrrr/releases/tag/v99.0.0')
+        )
     );
 });
 
@@ -90,9 +105,12 @@ test('self-hosted up-to-date exposes no available version', function () {
     actingOwnerInWorkspace();
 
     $this->get(route('dashboard'))->assertInertia(fn ($page) => $page
-        ->where('updateAvailable', false)
-        ->where('latestVersion', null)
-        ->where('latestReleaseUrl', null)
+        ->missing('updateAvailable')
+        ->loadDeferredProps('sidebar', fn ($reload) => $reload
+            ->where('updateAvailable', false)
+            ->where('latestVersion', null)
+            ->where('latestReleaseUrl', null)
+        )
     );
 });
 
@@ -102,8 +120,11 @@ test('cloud never exposes an available version', function () {
     actingOwnerInWorkspace();
 
     $this->get(route('dashboard'))->assertInertia(fn ($page) => $page
-        ->where('updateAvailable', false)
-        ->where('latestVersion', null)
-        ->where('latestReleaseUrl', null)
+        ->missing('updateAvailable')
+        ->loadDeferredProps('sidebar', fn ($reload) => $reload
+            ->where('updateAvailable', false)
+            ->where('latestVersion', null)
+            ->where('latestReleaseUrl', null)
+        )
     );
 });

--- a/tests/Feature/SidebarFooterPropsTest.php
+++ b/tests/Feature/SidebarFooterPropsTest.php
@@ -4,6 +4,7 @@ use App\Enums\WorkspaceRole;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Models\WorkspaceMembership;
+use App\Support\AppVersion;
 use App\Support\CommunityStats;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Context;
@@ -67,5 +68,42 @@ test('self-hosted shares a community prop and the update flag, no billing prop',
         ->where('community.sponsorUrl', 'https://github.com/sponsors/coollabsio')
         ->where('community.stars', 4210)
         ->where('updateAvailable', true)
+    );
+});
+
+test('self-hosted names the available version and links to its release', function () {
+    config(['subscriptions.enabled' => false]);
+    config(['instance.community.repo' => 'coollabsio/shoutrrr']);
+    Cache::put(CommunityStats::LatestVersionCacheKey, 'v99.0.0');
+    actingOwnerInWorkspace();
+
+    $this->get(route('dashboard'))->assertInertia(fn ($page) => $page
+        ->where('updateAvailable', true)
+        ->where('latestVersion', 'v99.0.0')
+        ->where('latestReleaseUrl', 'https://github.com/coollabsio/shoutrrr/releases/tag/v99.0.0')
+    );
+});
+
+test('self-hosted up-to-date exposes no available version', function () {
+    config(['subscriptions.enabled' => false]);
+    Cache::put(CommunityStats::LatestVersionCacheKey, AppVersion::current());
+    actingOwnerInWorkspace();
+
+    $this->get(route('dashboard'))->assertInertia(fn ($page) => $page
+        ->where('updateAvailable', false)
+        ->where('latestVersion', null)
+        ->where('latestReleaseUrl', null)
+    );
+});
+
+test('cloud never exposes an available version', function () {
+    config(['subscriptions.enabled' => true]);
+    Cache::put(CommunityStats::LatestVersionCacheKey, 'v99.0.0');
+    actingOwnerInWorkspace();
+
+    $this->get(route('dashboard'))->assertInertia(fn ($page) => $page
+        ->where('updateAvailable', false)
+        ->where('latestVersion', null)
+        ->where('latestReleaseUrl', null)
     );
 });

--- a/tests/Unit/Support/AppVersionTest.php
+++ b/tests/Unit/Support/AppVersionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Support\AppVersion;
+
+test('current reads and trims the VERSION file', function () {
+    expect(AppVersion::current())
+        ->toBe(trim(file_get_contents(base_path('VERSION'))))
+        ->toMatch('/^v\d+\.\d+\.\d+/');
+});
+
+test('isOutdated compares the running version against the latest tag', function () {
+    expect(AppVersion::isOutdated('v99.0.0'))->toBeTrue();
+    expect(AppVersion::isOutdated('v0.0.1'))->toBeFalse();
+    expect(AppVersion::isOutdated(AppVersion::current()))->toBeFalse();
+    expect(AppVersion::isOutdated(null))->toBeFalse();
+    expect(AppVersion::isOutdated(''))->toBeFalse();
+});

--- a/tests/Unit/Support/AppVersionTest.php
+++ b/tests/Unit/Support/AppVersionTest.php
@@ -15,3 +15,12 @@ test('isOutdated compares the running version against the latest tag', function 
     expect(AppVersion::isOutdated(null))->toBeFalse();
     expect(AppVersion::isOutdated(''))->toBeFalse();
 });
+
+test('isPrerelease detects prerelease suffixes and defaults to the running version', function () {
+    expect(AppVersion::isPrerelease('v1.3.0-rc.5'))->toBeTrue();
+    expect(AppVersion::isPrerelease('1.4.0-beta.1'))->toBeTrue();
+    expect(AppVersion::isPrerelease('v1.3.0'))->toBeFalse();
+    expect(AppVersion::isPrerelease('1.2.3'))->toBeFalse();
+    // Defaults to the running version, which is a prerelease (v1.3.0-rc.5).
+    expect(AppVersion::isPrerelease())->toBeTrue();
+});

--- a/tests/Unit/Support/CommunityStatsTest.php
+++ b/tests/Unit/Support/CommunityStatsTest.php
@@ -11,19 +11,27 @@ test('stars returns the cached integer or null', function () {
     expect(CommunityStats::stars())->toBe(1234);
 });
 
-test('latestVersion returns the cached string or null', function () {
+test('selectLatest returns the overall tag on a prerelease channel and the stable tag otherwise', function () {
+    expect(CommunityStats::selectLatest(true, 'v1.3.0', 'v1.4.0-rc.1'))->toBe('v1.4.0-rc.1');
+    expect(CommunityStats::selectLatest(false, 'v1.3.0', 'v1.4.0-rc.1'))->toBe('v1.3.0');
+    expect(CommunityStats::selectLatest(true, null, null))->toBeNull();
+    expect(CommunityStats::selectLatest(false, null, 'v1.4.0-rc.1'))->toBeNull();
+});
+
+test('latestVersion follows the running channel (prerelease reads the overall key)', function () {
+    expect(AppVersion::isPrerelease())->toBeTrue();
     expect(CommunityStats::latestVersion())->toBeNull();
 
-    Cache::put(CommunityStats::LatestVersionCacheKey, 'v9.9.9');
+    Cache::put(CommunityStats::LatestOverallCacheKey, 'v9.9.9');
     expect(CommunityStats::latestVersion())->toBe('v9.9.9');
 });
 
-test('updateAvailable reflects the cached latest tag versus the running version', function () {
+test('updateAvailable reflects the overall tag versus the running prerelease', function () {
     expect(CommunityStats::updateAvailable())->toBeFalse();
 
-    Cache::put(CommunityStats::LatestVersionCacheKey, 'v99.0.0');
+    Cache::put(CommunityStats::LatestOverallCacheKey, 'v99.0.0');
     expect(CommunityStats::updateAvailable())->toBeTrue();
 
-    Cache::put(CommunityStats::LatestVersionCacheKey, AppVersion::current());
+    Cache::put(CommunityStats::LatestOverallCacheKey, AppVersion::current());
     expect(CommunityStats::updateAvailable())->toBeFalse();
 });

--- a/tests/Unit/Support/CommunityStatsTest.php
+++ b/tests/Unit/Support/CommunityStatsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Support\AppVersion;
+use App\Support\CommunityStats;
+use Illuminate\Support\Facades\Cache;
+
+test('stars returns the cached integer or null', function () {
+    expect(CommunityStats::stars())->toBeNull();
+
+    Cache::put(CommunityStats::StarsCacheKey, 1234);
+    expect(CommunityStats::stars())->toBe(1234);
+});
+
+test('latestVersion returns the cached string or null', function () {
+    expect(CommunityStats::latestVersion())->toBeNull();
+
+    Cache::put(CommunityStats::LatestVersionCacheKey, 'v9.9.9');
+    expect(CommunityStats::latestVersion())->toBe('v9.9.9');
+});
+
+test('updateAvailable reflects the cached latest tag versus the running version', function () {
+    expect(CommunityStats::updateAvailable())->toBeFalse();
+
+    Cache::put(CommunityStats::LatestVersionCacheKey, 'v99.0.0');
+    expect(CommunityStats::updateAvailable())->toBeTrue();
+
+    Cache::put(CommunityStats::LatestVersionCacheKey, AppVersion::current());
+    expect(CommunityStats::updateAvailable())->toBeFalse();
+});


### PR DESCRIPTION
## Summary

Adds a billing-aware sidebar footer and hoists workspace-settings into the sidebar. The footer renders one of two variants keyed off the existing `features.billing` cloud signal:

- **Cloud** — a **plan chip**: `Free → Upgrade` (the conversion entry point) or `Active → Manage`. No usage/budget bar.
- **Self-hosted** — a **community card**: ⭐ Star on GitHub (with live star count) and ❤ Sponsor.

The existing version badge gains a **self-hosted-only update dot**; hovering it names the available version in a tooltip and links straight to that release. Workspace-settings items (Overview / Members / API keys / Subscription) are **hoisted** into the sidebar via a shared nav builder that the in-page settings aside now reuses (DRY).

## How it works

- GitHub **stars + release tags** are fetched by a daily, self-hosted-only console command (`community:refresh-stats`) into the cache. The Inertia middleware **reads cache only** — a page render never performs the GitHub call inline and never fails from it; missing/failed data degrades to `stars = null` / `updateAvailable = false`.
- **Channel-aware, rc-inclusive update detection:** lists `/releases` (not `/releases/latest`, which hides prereleases). A prerelease install (this one runs `v1.3.0-rc.5`) is offered the true newest across prereleases **and** stable — a shipped `v1.3.0` supersedes an outdated `v1.3.0-rc.6`, never the reverse. A stable install is offered stable releases only.
- **Gating:** `billing` prop only when `subscriptions.enabled` **and** the membership has `workspace.billing.manage`; `community` only when self-hosted. Neither leaks across modes; cloud makes no outbound GitHub call.

## Out of scope (deliberate)

X-budget/usage bar, plan tiers, account quotas, cloud update dot/star count.

## Testing

- Full Pest suite **1293/1293**, JS (vitest) **471/471**, Larastan level 7 clean, Pint clean.
- New coverage: version compare + channel selection, GitHub fetch caching/failure/draft-exclusion/"stable supersedes rc", per-mode shared props + permission gating, footer variants, badge dot + tooltip.

## Reviewed

Task-by-task review + two whole-branch reviews (final: *Ready to merge — no Critical/Important*). One hot-path Minor (uncached VERSION read) fixed.

⚠️ **Pending:** in-browser verification of the cloud chip, self-hosted card, and update dot/tooltip in the running app.
