### PR TITLE
fix(engagement): stop like/unlike and reply actions from silently failing

### DIFF
--- a/app/Enums/EngagementStatus.php
+++ b/app/Enums/EngagementStatus.php
@@ -16,4 +16,28 @@ enum EngagementStatus: string
     {
         return $this === self::Ok;
     }
+
+    /**
+     * The HTTP status a connector outcome is reported as by the engagement
+     * action endpoints.
+     *
+     * 422 is deliberately absent and must never be used here. Inertia's
+     * `useHttp` special-cases status 422 into its validation-errors path
+     * (@inertiajs/react/dist/index.js:1845), parsing the body as `data.errors`
+     * and firing `onError`. A connector failure returned as 422 would therefore
+     * fire `onError({})` — an empty bag — silently swallowing the message and
+     * skipping `onHttpException`, which is where the client rolls the optimistic
+     * update back and toasts the reason. That is precisely the silent-lie bug
+     * this map exists to fix, so 422 stays reserved for real validation errors.
+     */
+    public function httpStatus(): int
+    {
+        return match ($this) {
+            self::Ok => 200,
+            self::AuthExpired => 403,
+            self::Unsupported => 409,
+            self::RateLimited => 429,
+            self::Failed => 502,
+        };
+    }
 }

--- a/app/Enums/Platform.php
+++ b/app/Enums/Platform.php
@@ -52,7 +52,11 @@ enum Platform: string
             // scope that call 403s ("Missing required OAuth2 scopes: users.email").
             // `media.write` is required to upload media to the v2 /2/media/upload
             // endpoint (the v1.1 endpoint was deprecated 2025-03-31).
-            self::X => ['users.read', 'users.email', 'tweet.read', 'tweet.write', 'media.write', 'offline.access'],
+            // `like.write` is required to like/unlike from the engagement inbox
+            // (POST + DELETE /2/users/{id}/likes); without it those calls 403
+            // ("Missing required OAuth2 scopes: like.write"), which the connector
+            // maps to `unsupported`. One scope covers both like and unlike.
+            self::X => ['users.read', 'users.email', 'tweet.read', 'tweet.write', 'media.write', 'like.write', 'offline.access'],
             self::LinkedIn => ['openid', 'profile', 'email', 'w_member_social'],
             self::Bluesky => [],
             self::Facebook => ['pages_show_list', 'pages_read_engagement', 'pages_manage_posts', 'pages_read_user_content', 'pages_manage_engagement', 'read_insights', 'business_management'],
@@ -118,6 +122,16 @@ enum Platform: string
     public function supportsAccountMetrics(): bool
     {
         return $this !== self::LinkedIn && $this !== self::Discord;
+    }
+
+    /**
+     * Whether this platform's engagement connector can like/unlike a reply.
+     * Instagram and Threads return `unsupported` (neither Graph API exposes a
+     * like/unlike write for comments), so their hearts are inert affordances.
+     */
+    public function supportsReplyLikes(): bool
+    {
+        return $this !== self::Instagram && $this !== self::Threads;
     }
 
     /**

--- a/app/Enums/Platform.php
+++ b/app/Enums/Platform.php
@@ -60,7 +60,10 @@ enum Platform: string
             self::LinkedIn => ['openid', 'profile', 'email', 'w_member_social'],
             self::Bluesky => [],
             self::Facebook => ['pages_show_list', 'pages_read_engagement', 'pages_manage_posts', 'pages_read_user_content', 'pages_manage_engagement', 'read_insights', 'business_management'],
-            self::Instagram => ['instagram_basic', 'instagram_content_publish', 'instagram_manage_comments', 'instagram_manage_insights', 'pages_show_list', 'business_management'],
+            // `instagram_manage_engagement` powers the Like Media and Comments
+            // API (2026-04-22) used to like/unlike replies from the inbox;
+            // without it the like call 403s → Unsupported.
+            self::Instagram => ['instagram_basic', 'instagram_content_publish', 'instagram_manage_comments', 'instagram_manage_insights', 'instagram_manage_engagement', 'pages_show_list', 'business_management'],
             self::Threads => ['threads_basic', 'threads_content_publish', 'threads_manage_replies', 'threads_manage_insights'],
             self::Discord => [],
         };
@@ -126,12 +129,13 @@ enum Platform: string
 
     /**
      * Whether this platform's engagement connector can like/unlike a reply.
-     * Instagram and Threads return `unsupported` (neither Graph API exposes a
-     * like/unlike write for comments), so their hearts are inert affordances.
+     * Threads returns `unsupported` (its Graph API exposes no like/unlike write
+     * for replies), so its heart is an inert affordance. Instagram gained the
+     * capability with the Like Media and Comments API (2026-04-22).
      */
     public function supportsReplyLikes(): bool
     {
-        return $this !== self::Instagram && $this !== self::Threads;
+        return $this !== self::Threads;
     }
 
     /**

--- a/app/Http/Controllers/Engagement/EngagementController.php
+++ b/app/Http/Controllers/Engagement/EngagementController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Engagement;
 
+use App\Enums\EngagementStatus;
 use App\Enums\Platform;
 use App\Enums\ReplyStatus;
 use App\Enums\SendStatus;
@@ -21,12 +22,12 @@ use App\Support\ReplyListItem;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
@@ -135,30 +136,22 @@ class EngagementController extends Controller
         ]);
     }
 
-    public function markRead(Request $request, PostTargetReply $reply): RedirectResponse|Response
+    public function markRead(PostTargetReply $reply): Response
     {
         PostTargetReply::query()
             ->whereIn('id', $this->inboundRepliesForBaseThread($reply)->pluck('id'))
             ->update(['read_at' => now()]);
 
-        if ($request->expectsJson()) {
-            return response()->noContent();
-        }
-
-        return back();
+        return response()->noContent();
     }
 
-    public function archive(Request $request, PostTargetReply $reply): RedirectResponse|Response
+    public function archive(PostTargetReply $reply): Response
     {
         PostTargetReply::query()
             ->whereIn('id', $this->inboundRepliesForBaseThread($reply)->pluck('id'))
             ->update(['status' => ReplyStatus::Archived->value]);
 
-        if ($request->expectsJson()) {
-            return response()->noContent();
-        }
-
-        return back();
+        return response()->noContent();
     }
 
     /**
@@ -297,24 +290,28 @@ class EngagementController extends Controller
         PostTargetReply $reply,
         EngagementConnectorRegistry $registry,
         TokenManager $tokens,
-    ): RedirectResponse {
+    ): JsonResponse {
         $target = $reply->target;
         $account = $target?->account;
 
         if ($account === null) {
-            return back()->with('error', 'This account is no longer connected.');
+            $this->logActionFailure('respond', $reply, EngagementStatus::Unsupported, 'Account no longer connected.');
+
+            return $this->actionError(EngagementStatus::Unsupported, 'This account is no longer connected.', 'Could not post the reply.');
         }
 
         if ($account->isDisabled()) {
-            return back()->with('error', 'This account is disabled in the workspace. Enable it to reply.');
+            $this->logActionFailure('respond', $reply, EngagementStatus::Unsupported, 'Account disabled in the workspace.');
+
+            return $this->actionError(EngagementStatus::Unsupported, 'This account is disabled in the workspace. Enable it to reply.', 'Could not post the reply.');
         }
 
         try {
-            $credentials = in_array($account->platform, [Platform::X, Platform::Bluesky, Platform::LinkedIn, Platform::Facebook, Platform::Instagram, Platform::Threads], true)
-                ? $tokens->fresh($account)
-                : [];
+            $credentials = $this->credentialsFor($account, $tokens);
         } catch (TokenRefreshException) {
-            return back()->with('error', 'Could not authenticate with the platform. Reconnect the account.');
+            $this->logActionFailure('respond', $reply, EngagementStatus::AuthExpired, 'Token refresh failed.');
+
+            return $this->actionError(EngagementStatus::AuthExpired, 'Could not authenticate with the platform. Reconnect the account.', 'Could not post the reply.');
         }
 
         $mediaIds = array_values($request->validated('media', []));
@@ -323,7 +320,9 @@ class EngagementController extends Controller
             $result = $registry->for($reply->platform)->postReply($account, $reply, (string) $request->validated('text'), $credentials);
 
             if (! $result->isOk()) {
-                return back()->with('error', $result->message ?? 'Could not post the reply.');
+                $this->logActionFailure('respond', $reply, $result->status, $result->message);
+
+                return $this->actionError($result->status, $result->message, 'Could not post the reply.');
             }
 
             $reply->forceFill([
@@ -331,7 +330,7 @@ class EngagementController extends Controller
                 'our_reply_remote_id' => $result->remoteReplyId,
             ])->save();
 
-            PostTargetReply::withoutGlobalScopes()->create([
+            $ourRow = PostTargetReply::withoutGlobalScopes()->create([
                 'workspace_id' => $reply->workspace_id,
                 'post_target_id' => $reply->post_target_id,
                 'platform' => $reply->platform,
@@ -350,7 +349,7 @@ class EngagementController extends Controller
                 'fetched_at' => now(),
             ]);
 
-            return back()->with('success', 'Reply sent.');
+            return $this->respondedRow($ourRow);
         }
 
         // Media path: create the outgoing row in a sending state, then dispatch.
@@ -375,101 +374,132 @@ class EngagementController extends Controller
 
         SendReply::dispatch($ourRow->id, $reply->id, $mediaIds, (string) $request->validated('text'), $reply->platform);
 
-        return back()->with('success', 'Sending your reply…');
+        return $this->respondedRow($ourRow);
+    }
+
+    /**
+     * Serialize our freshly-created outgoing reply for the client, which swaps
+     * it in for the optimistic bubble. Eager-load the relations ReplyListItem
+     * reads: `create()` leaves them unloaded, so without this the serializer
+     * would lazy-load them one by one (or emit nulls under strict mode).
+     */
+    private function respondedRow(PostTargetReply $ourRow): JsonResponse
+    {
+        $ourRow->load(['target.post', 'target.account']);
+
+        return response()->json(['reply' => ReplyListItem::make($ourRow)], 201);
     }
 
     public function like(
         PostTargetReply $reply,
         EngagementConnectorRegistry $registry,
         TokenManager $tokens,
-    ): RedirectResponse {
+    ): JsonResponse {
         if ($reply->liked_at !== null) {
-            return back();
+            return response()->json(['is_liked' => true]);
         }
 
         $account = $reply->target?->account;
 
         if ($account === null) {
-            return back()->with('error', 'This account is no longer connected.');
+            $this->logActionFailure('like', $reply, EngagementStatus::Unsupported, 'Account no longer connected.');
+
+            return $this->actionError(EngagementStatus::Unsupported, 'This account is no longer connected.', 'Could not like this reply.');
         }
 
         try {
             $credentials = $this->credentialsFor($account, $tokens);
         } catch (TokenRefreshException) {
-            return back()->with('error', 'Could not authenticate with the platform. Reconnect the account.');
+            $this->logActionFailure('like', $reply, EngagementStatus::AuthExpired, 'Token refresh failed.');
+
+            return $this->actionError(EngagementStatus::AuthExpired, 'Could not authenticate with the platform. Reconnect the account.', 'Could not like this reply.');
         }
 
         $result = $registry->for($reply->platform)->likeReply($account, $reply, $credentials);
 
         if (! $result->isOk()) {
-            return back()->with('error', $result->message ?? 'Could not like this reply.');
+            $this->logActionFailure('like', $reply, $result->status, $result->message);
+
+            return $this->actionError($result->status, $result->message, 'Could not like this reply.');
         }
 
         $reply->forceFill(['liked_at' => now(), 'like_remote_id' => $result->remoteId])->save();
 
-        return back();
+        return response()->json(['is_liked' => true]);
     }
 
     public function unlike(
         PostTargetReply $reply,
         EngagementConnectorRegistry $registry,
         TokenManager $tokens,
-    ): RedirectResponse {
+    ): JsonResponse {
         if ($reply->liked_at === null) {
-            return back();
+            return response()->json(['is_liked' => false]);
         }
 
         $account = $reply->target?->account;
 
         if ($account === null) {
-            return back()->with('error', 'This account is no longer connected.');
+            $this->logActionFailure('unlike', $reply, EngagementStatus::Unsupported, 'Account no longer connected.');
+
+            return $this->actionError(EngagementStatus::Unsupported, 'This account is no longer connected.', 'Could not remove the like.');
         }
 
         try {
             $credentials = $this->credentialsFor($account, $tokens);
         } catch (TokenRefreshException) {
-            return back()->with('error', 'Could not authenticate with the platform. Reconnect the account.');
+            $this->logActionFailure('unlike', $reply, EngagementStatus::AuthExpired, 'Token refresh failed.');
+
+            return $this->actionError(EngagementStatus::AuthExpired, 'Could not authenticate with the platform. Reconnect the account.', 'Could not remove the like.');
         }
 
         $result = $registry->for($reply->platform)->unlikeReply($account, $reply, $reply->like_remote_id, $credentials);
 
         if (! $result->isOk()) {
-            return back()->with('error', $result->message ?? 'Could not remove the like.');
+            $this->logActionFailure('unlike', $reply, $result->status, $result->message);
+
+            return $this->actionError($result->status, $result->message, 'Could not remove the like.');
         }
 
         $reply->forceFill(['liked_at' => null, 'like_remote_id' => null])->save();
 
-        return back();
+        return response()->json(['is_liked' => false]);
     }
 
     public function destroyReply(
         PostTargetReply $reply,
         EngagementConnectorRegistry $registry,
         TokenManager $tokens,
-    ): RedirectResponse {
+    ): Response|JsonResponse {
         abort_unless($reply->is_ours, 403);
 
         $account = $reply->target?->account;
 
         if ($account === null) {
-            return back()->with('error', 'This account is no longer connected.');
+            $this->logActionFailure('delete', $reply, EngagementStatus::Unsupported, 'Account no longer connected.');
+
+            return $this->actionError(EngagementStatus::Unsupported, 'This account is no longer connected.', 'Could not delete this reply.');
         }
 
         try {
             $credentials = $this->credentialsFor($account, $tokens);
         } catch (TokenRefreshException) {
-            return back()->with('error', 'Could not authenticate with the platform. Reconnect the account.');
+            $this->logActionFailure('delete', $reply, EngagementStatus::AuthExpired, 'Token refresh failed.');
+
+            return $this->actionError(EngagementStatus::AuthExpired, 'Could not authenticate with the platform. Reconnect the account.', 'Could not delete this reply.');
         }
 
         $result = $registry->for($reply->platform)->deleteReply($account, $reply, $credentials);
 
         if (! $result->isOk()) {
-            return back()->with('error', $result->message ?? 'Could not delete this reply.');
+            $this->logActionFailure('delete', $reply, $result->status, $result->message);
+
+            return $this->actionError($result->status, $result->message, 'Could not delete this reply.');
         }
 
         $reply->delete();
 
-        return back()->with('success', 'Reply deleted.');
+        return response()->noContent();
     }
 
     /**
@@ -480,5 +510,34 @@ class EngagementController extends Controller
         return in_array($account->platform, [Platform::X, Platform::Bluesky, Platform::LinkedIn, Platform::Facebook, Platform::Instagram, Platform::Threads], true)
             ? $tokens->fresh($account)
             : [];
+    }
+
+    /**
+     * Report a failed reply action as JSON at the status mapped from the
+     * connector outcome. The client reads `message` in `onHttpException`; never
+     * returns 422 (see EngagementStatus::httpStatus).
+     */
+    private function actionError(EngagementStatus $status, ?string $message, string $fallback): JsonResponse
+    {
+        return response()->json([
+            'status' => $status->value,
+            'message' => $message ?? $fallback,
+        ], $status->httpStatus());
+    }
+
+    /**
+     * Record why a reply action failed, so a like that the platform rejects is
+     * diagnosable from the logs rather than only from the user's report.
+     */
+    private function logActionFailure(string $action, PostTargetReply $reply, EngagementStatus $status, ?string $message): void
+    {
+        Log::warning('engagement.action.failed', [
+            'action' => $action,
+            'platform' => $reply->platform->value,
+            'reply_id' => $reply->id,
+            'workspace_id' => $reply->workspace_id,
+            'status' => $status->value,
+            'message' => $message,
+        ]);
     }
 }

--- a/app/Services/Engagement/Connectors/InstagramEngagementConnector.php
+++ b/app/Services/Engagement/Connectors/InstagramEngagementConnector.php
@@ -29,8 +29,11 @@ use Illuminate\Http\Client\Response;
  * erroring.
  *
  * The Graph API rejects media on comment replies, so reply media is declined
- * with a clear message. Instagram has no documented comment-like API, so
- * like/unlike always return `Unsupported` without making a request.
+ * with a clear message. Likes go through the user-scoped Like Media and
+ * Comments API (added 2026-04-22): `POST`/`DELETE /<ig-user-id>/likes` with a
+ * `comment_id`, gated by `instagram_manage_engagement`; without that permission
+ * Instagram returns 403, which we map to `Unsupported` so the heart degrades
+ * cleanly rather than erroring.
  */
 class InstagramEngagementConnector implements EngagementConnector
 {
@@ -136,12 +139,36 @@ class InstagramEngagementConnector implements EngagementConnector
 
     public function likeReply(ConnectedAccount $account, PostTargetReply $reply, array $credentials): ReplyActionResult
     {
-        return ReplyActionResult::unsupported('Instagram does not support liking comments via API');
+        try {
+            $response = $this->http
+                ->asForm()
+                ->post($this->baseUrl().'/'.$account->remote_account_id.'/likes', [
+                    'comment_id' => $reply->remote_reply_id,
+                    'access_token' => (string) ($credentials['access_token'] ?? ''),
+                ]);
+        } catch (ConnectionException $e) {
+            return ReplyActionResult::failed($e->getMessage());
+        }
+
+        $this->meter(UsageCategory::ExternalApi, UsageOperation::REPLY_LIKE, $account, $response);
+
+        return $response->failed() ? $this->mapActionFailure($response) : ReplyActionResult::ok();
     }
 
     public function unlikeReply(ConnectedAccount $account, PostTargetReply $reply, ?string $likeRemoteId, array $credentials): ReplyActionResult
     {
-        return ReplyActionResult::unsupported('Instagram does not support liking comments via API');
+        try {
+            $response = $this->http->delete($this->baseUrl().'/'.$account->remote_account_id.'/likes', [
+                'comment_id' => $reply->remote_reply_id,
+                'access_token' => (string) ($credentials['access_token'] ?? ''),
+            ]);
+        } catch (ConnectionException $e) {
+            return ReplyActionResult::failed($e->getMessage());
+        }
+
+        $this->meter(UsageCategory::ExternalApi, UsageOperation::REPLY_UNLIKE, $account, $response);
+
+        return $response->failed() ? $this->mapActionFailure($response) : ReplyActionResult::ok();
     }
 
     public function deleteReply(ConnectedAccount $account, PostTargetReply $reply, array $credentials): ReplyActionResult

--- a/app/Support/ReplyListItem.php
+++ b/app/Support/ReplyListItem.php
@@ -26,6 +26,10 @@ final class ReplyListItem
             'remote_created_at' => $reply->remote_created_at->toIso8601String(),
             'is_read' => $reply->read_at !== null,
             'is_liked' => $reply->liked_at !== null,
+            // `??` uses isset() semantics, so this stays safe when $target is
+            // null (the reply's own platform is the fallback). Not `?->`:
+            // Larastan reads the belongsTo as non-null and flags it redundant.
+            'can_like' => ($target->platform ?? $reply->platform)->supportsReplyLikes(),
             'is_ours' => $reply->is_ours,
             'send_status' => $reply->send_status?->value,
             'status' => $reply->status->value,

--- a/resources/js/pages/engagement/components/reply-thread.test.ts
+++ b/resources/js/pages/engagement/components/reply-thread.test.ts
@@ -5,13 +5,41 @@ import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { ReplyItem } from '../types';
 import { ReplyThread } from './reply-thread';
 
-function render(): string {
+function reply(overrides: Partial<ReplyItem> = {}): ReplyItem {
+    return {
+        id: 'reply-1',
+        platform: 'x',
+        remote_reply_id: 'r1',
+        author_handle: 'someone',
+        author_name: 'Some One',
+        author_avatar_url: null,
+        text: 'nice post',
+        remote_created_at: new Date().toISOString(),
+        is_read: true,
+        is_liked: false,
+        can_like: true,
+        is_ours: false,
+        send_status: null,
+        status: 'pending',
+        post_target_id: 'pt-1',
+        post_id: 'p-1',
+        post_remote_id: 'pr-1',
+        post_excerpt: null,
+        account_handle: '@us',
+        account_max_text_length: null,
+        account_disabled: false,
+        ...overrides,
+    };
+}
+
+function render(thread: ReplyItem[] = []): string {
     return renderToStaticMarkup(
         createElement(ReplyThread, {
             postExcerpt: 'hello, this is just a test',
-            thread: [],
+            thread,
             loading: false,
             onToggleLike: vi.fn(),
             onDelete: vi.fn(),
@@ -39,5 +67,23 @@ describe('ReplyThread', () => {
         );
         expect(source).toContain('break-words whitespace-pre-wrap');
         expect(source).not.toContain('postUrl');
+    });
+
+    it('disables the like button on platforms that cannot like replies', () => {
+        const markup = render([
+            reply({ platform: 'linkedin', can_like: false }),
+        ]);
+
+        // The attribute, not the `disabled:` Tailwind variants, which are
+        // always in the class list.
+        expect(markup).toContain('disabled=""');
+        expect(markup).toContain('LinkedIn does not support liking replies');
+    });
+
+    it('leaves the like button enabled when the platform supports liking', () => {
+        const markup = render([reply({ can_like: true })]);
+
+        expect(markup).not.toContain('disabled=""');
+        expect(markup).not.toContain('does not support liking replies');
     });
 });

--- a/resources/js/pages/engagement/components/reply-thread.tsx
+++ b/resources/js/pages/engagement/components/reply-thread.tsx
@@ -168,12 +168,19 @@ export function ReplyThread({
                                 <button
                                     type="button"
                                     onClick={() => onToggleLike(reply)}
+                                    disabled={!reply.can_like}
+                                    title={
+                                        reply.can_like
+                                            ? undefined
+                                            : `${platformLabel(reply.platform)} does not support liking replies`
+                                    }
                                     aria-label={
                                         reply.is_liked ? 'Unlike' : 'Like'
                                     }
                                     aria-pressed={reply.is_liked}
                                     className={cn(
                                         actionButton,
+                                        'disabled:cursor-not-allowed disabled:opacity-40',
                                         reply.is_liked
                                             ? 'text-rose-500'
                                             : 'hover:text-foreground',

--- a/resources/js/pages/engagement/helpers.ts
+++ b/resources/js/pages/engagement/helpers.ts
@@ -43,6 +43,31 @@ export function initials(
     return letters.toUpperCase();
 }
 
+/**
+ * Message for a failed reply action, read from `useHttp`'s `onHttpException`
+ * response. That response carries the **raw body string**, and a non-2xx can
+ * come from anywhere in the stack — a proxy's HTML 502 page must not throw
+ * inside an error handler, so parsing is guarded and falls back.
+ */
+export function actionErrorMessage(
+    response: { data: string },
+    fallback: string,
+): string {
+    try {
+        const parsed: unknown = JSON.parse(response.data);
+        if (parsed !== null && typeof parsed === 'object') {
+            const { message } = parsed as { message?: unknown };
+            if (typeof message === 'string' && message.trim() !== '') {
+                return message;
+            }
+        }
+    } catch {
+        // Not JSON (e.g. a gateway HTML error page) — use the fallback.
+    }
+
+    return fallback;
+}
+
 /** Display handle with a leading @ when it isn't already a URL-style handle. */
 export function atHandle(handle: string | null): string {
     if (!handle) {

--- a/resources/js/pages/engagement/index.test.ts
+++ b/resources/js/pages/engagement/index.test.ts
@@ -16,6 +16,31 @@ it('shows disabled engagement platforms to end users', () => {
     expect(source).toContain('disabledPlatformLabels');
 });
 
+it('runs reply actions as JSON requests, not Inertia visits', () => {
+    // An Inertia visit follows the response into a fresh GET /engagement, which
+    // drops the deferred `replies` scroll prop and blanks the left list.
+    const source = readFileSync(
+        resolve(import.meta.dirname, 'index.tsx'),
+        'utf8',
+    );
+
+    expect(source).toContain('useHttp');
+    expect(source).not.toContain('router.post(');
+    expect(source).not.toContain('router.delete(');
+});
+
+it('overlays archived and responded rows onto the deferred replies prop', () => {
+    const source = readFileSync(
+        resolve(import.meta.dirname, 'index.tsx'),
+        'utf8',
+    );
+
+    expect(source).toContain("overrides[r.id] !== 'archived'");
+    expect(source).toContain("overrides[r.id] === 'responded'");
+    // The unread badge rides on the shared `shell` prop; `replies` stays put.
+    expect(source).toContain("router.reload({ only: ['shell'] })");
+});
+
 it('uses shared disabled platform label helpers', () => {
     const platformSource = readFileSync(
         resolve(import.meta.dirname, '../../lib/platforms.ts'),

--- a/resources/js/pages/engagement/index.tsx
+++ b/resources/js/pages/engagement/index.tsx
@@ -572,17 +572,14 @@ export default function EngagementIndex({
     } = filters;
 
     // Filter changes refetch replies with reset:['replies']; stale overrides
-    // would wrongly hide rows in, say, the archived view.
-    useEffect(() => {
+    // would wrongly hide rows in, say, the archived view. Reset during render
+    // (not an effect) so no wasted commit fires with the old overrides applied.
+    const filterKey = `${filterAccount}|${filterPlatform}|${filterTarget}|${filterPost}|${filterUnread}|${filterArchived}`;
+    const prevFilterKey = useRef(filterKey);
+    if (prevFilterKey.current !== filterKey) {
+        prevFilterKey.current = filterKey;
         setOverrides({});
-    }, [
-        filterAccount,
-        filterPlatform,
-        filterTarget,
-        filterPost,
-        filterUnread,
-        filterArchived,
-    ]);
+    }
 
     const items = (replies?.data ?? [])
         .filter((r) => overrides[r.id] !== 'archived')

--- a/resources/js/pages/engagement/index.tsx
+++ b/resources/js/pages/engagement/index.tsx
@@ -1,4 +1,4 @@
-import { Deferred, Head, Link, router } from '@inertiajs/react';
+import { Deferred, Head, Link, router, useHttp } from '@inertiajs/react';
 import {
     Archive,
     ChevronDown,
@@ -8,6 +8,7 @@ import {
     SearchX,
 } from 'lucide-react';
 import { useEffect, useRef, useState, type RefObject } from 'react';
+import { toast } from 'sonner';
 
 import ComposerController from '@/actions/App/Http/Controllers/Posts/ComposerController';
 import { PlatformGlyph } from '@/components/common/platform-glyph';
@@ -58,6 +59,7 @@ import { ReplyFilters } from './components/reply-filters';
 import { ReplyStream } from './components/reply-stream';
 import { ReplyThread } from './components/reply-thread';
 import {
+    actionErrorMessage,
     adjacentIndex,
     atHandle,
     engagementShortcut,
@@ -199,20 +201,36 @@ function EngagementDisabledBanner({
 
 type RightPaneProps = {
     selected: ReplyItem;
-    onArchived: () => void;
+    onArchived: (id: string) => void;
+    onResponded: (id: string) => void;
     replyTextareaRef?: RefObject<HTMLTextAreaElement | null>;
     reserveCloseButtonSpace?: boolean;
 };
 
+/**
+ * The conversation pane is a self-owned client island: its actions are plain
+ * JSON requests (`useHttp`), never Inertia visits. A visit would follow the
+ * response into a fresh `GET /engagement`, which drops the deferred `replies`
+ * scroll prop and blanks the left list to a skeleton.
+ */
 function RightPane({
     selected,
     onArchived,
+    onResponded,
     replyTextareaRef,
     reserveCloseButtonSpace = false,
 }: RightPaneProps) {
     const [thread, setThread] = useState<ReplyItem[]>([]);
     const [postExcerpt, setPostExcerpt] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
+
+    const likeHttp = useHttp<Record<string, never>, { is_liked: boolean }>({});
+    const deleteHttp = useHttp<Record<string, never>, null>({});
+    const archiveHttp = useHttp<Record<string, never>, null>({});
+    const respondHttp = useHttp<
+        { text: string; media: string[] },
+        { reply: ReplyItem }
+    >({ text: '', media: [] });
 
     const selectedId = selected.id;
     const platformName = platformLabel(selected.platform);
@@ -255,6 +273,12 @@ function RightPane({
             .finally(() => setLoading(false));
     }, [selectedId]);
 
+    function setSendStatus(id: string, status: ReplyItem['send_status']) {
+        setThread((prev) =>
+            prev.map((r) => (r.id === id ? { ...r, send_status: status } : r)),
+        );
+    }
+
     async function send(text: string, mediaIds: string[]) {
         const tempId = `temp-${Date.now()}`;
         setThread((prev) => [
@@ -269,89 +293,108 @@ function RightPane({
                 send_status: 'sending' as const,
             },
         ]);
-        await new Promise<void>((resolve, reject) => {
-            router.post(
-                respondRoute(selected.id).url,
-                { text, media: mediaIds },
-                {
-                    forceFormData: true,
-                    preserveScroll: true,
-                    onSuccess: () => {
-                        // Text replies post synchronously, so they're done. Media
-                        // replies hand off to an async job — keep them "sending"
-                        // until a later thread refetch reflects the real outcome.
-                        const stillSending = mediaIds.length > 0;
-                        setThread((prev) =>
-                            prev.map((r) =>
-                                r.id === tempId
-                                    ? {
-                                          ...r,
-                                          send_status: stillSending
-                                              ? ('sending' as const)
-                                              : null,
-                                      }
-                                    : r,
-                            ),
-                        );
-                        resolve();
-                    },
-                    onError: () => {
-                        setThread((prev) =>
-                            prev.map((r) =>
-                                r.id === tempId
-                                    ? {
-                                          ...r,
-                                          send_status: 'failed' as const,
-                                      }
-                                    : r,
-                            ),
-                        );
-                        reject(new Error('send failed'));
-                    },
-                },
-            );
+        // `media` is an array of already-uploaded media ids, not Files, so this
+        // stays a JSON request — no `forceFormData`.
+        respondHttp.transform(() => ({ text, media: mediaIds }));
+        // Failures rethrow so QuickReplyBox's `await onSend(...)` still sees them.
+        await respondHttp.post(respondRoute(selected.id).url, {
+            onSuccess: ({ reply }) => {
+                // The server row carries the real id and send_status (media
+                // replies hand off to a job and stay "sending").
+                setThread((prev) =>
+                    prev.map((r) => (r.id === tempId ? reply : r)),
+                );
+                onResponded(selected.id);
+            },
+            onError: () => setSendStatus(tempId, 'failed'),
+            onHttpException: (r) => {
+                setSendStatus(tempId, 'failed');
+                toast.error(actionErrorMessage(r, 'Could not send the reply.'));
+            },
+            onNetworkError: () => {
+                setSendStatus(tempId, 'failed');
+                toast.error('Could not reach the server.');
+            },
         });
     }
 
     function toggleLike(reply: ReplyItem) {
         const wasLiked = reply.is_liked;
-        setThread((prev) =>
-            prev.map((r) =>
-                r.id === reply.id ? { ...r, is_liked: !wasLiked } : r,
-            ),
-        );
-        const restore = () =>
+        const setLiked = (isLiked: boolean) =>
             setThread((prev) =>
                 prev.map((r) =>
-                    r.id === reply.id ? { ...r, is_liked: wasLiked } : r,
+                    r.id === reply.id ? { ...r, is_liked: isLiked } : r,
                 ),
             );
-        if (wasLiked) {
-            router.delete(unlikeRoute(reply.id).url, {
-                preserveScroll: true,
+        const restore = () => setLiked(wasLiked);
+        const fallback = wasLiked
+            ? 'Could not remove the like.'
+            : 'Could not like this reply.';
+
+        setLiked(!wasLiked);
+
+        void likeHttp[wasLiked ? 'delete' : 'post'](
+            (wasLiked ? unlikeRoute : likeRoute)(reply.id).url,
+            {
+                // Reconcile against the server rather than trusting the flip.
+                onSuccess: ({ is_liked }) => setLiked(is_liked),
                 onError: restore,
-            });
-        } else {
-            router.post(
-                likeRoute(reply.id).url,
-                {},
-                { preserveScroll: true, onError: restore },
-            );
-        }
+                onHttpException: (r) => {
+                    restore();
+                    toast.error(actionErrorMessage(r, fallback));
+                },
+                onNetworkError: () => {
+                    restore();
+                    toast.error('Could not reach the server.');
+                },
+            },
+            // `submit()` rethrows after the callbacks; they already handled it.
+        ).catch(() => {});
     }
 
     function remove(reply: ReplyItem) {
         const index = thread.findIndex((r) => r.id === reply.id);
+        const restore = () =>
+            setThread((prev) => {
+                const next = [...prev];
+                next.splice(index < 0 ? next.length : index, 0, reply);
+
+                return next;
+            });
+
         setThread((prev) => prev.filter((r) => r.id !== reply.id));
-        router.delete(destroyRoute(reply.id).url, {
-            preserveScroll: true,
-            onError: () =>
-                setThread((prev) => {
-                    const next = [...prev];
-                    next.splice(index < 0 ? next.length : index, 0, reply);
-                    return next;
-                }),
-        });
+
+        void deleteHttp
+            .delete(destroyRoute(reply.id).url, {
+                onError: restore,
+                onHttpException: (r) => {
+                    restore();
+                    toast.error(
+                        actionErrorMessage(r, 'Could not delete the reply.'),
+                    );
+                },
+                onNetworkError: () => {
+                    restore();
+                    toast.error('Could not reach the server.');
+                },
+            })
+            .catch(() => {});
+    }
+
+    function archive() {
+        void archiveHttp
+            .post(archiveRoute(selected.id).url, {
+                onSuccess: () => onArchived(selected.id),
+                onHttpException: (r) => {
+                    toast.error(
+                        actionErrorMessage(r, 'Could not archive the reply.'),
+                    );
+                },
+                onNetworkError: () => {
+                    toast.error('Could not reach the server.');
+                },
+            })
+            .catch(() => {});
     }
 
     return (
@@ -457,16 +500,7 @@ function RightPane({
                                 size="sm"
                                 aria-label="Archive reply"
                                 className="gap-1.5 text-muted-foreground hover:text-foreground"
-                                onClick={() =>
-                                    router.post(
-                                        archiveRoute(selected.id).url,
-                                        {},
-                                        {
-                                            preserveScroll: true,
-                                            onSuccess: onArchived,
-                                        },
-                                    )
-                                }
+                                onClick={archive}
                             />
                         }
                     >
@@ -518,8 +552,45 @@ export default function EngagementIndex({
     const isMobile = useIsMobile();
     const [selected, setSelected] = useState<ReplyItem | null>(null);
     const replyTextareaRef = useRef<HTMLTextAreaElement>(null);
+    // Client-side overlay over the deferred `replies` scroll prop: archiving or
+    // responding must update the left list without a visit that would refetch
+    // (and blank) it. Inertia still owns `replies` itself — we only derive.
+    const [overrides, setOverrides] = useState<
+        Record<string, 'archived' | 'responded'>
+    >({});
+    // The keyboard `A` shortcut archives without an Inertia visit, mirroring the
+    // conversation pane's plain-JSON action so the deferred list never blanks.
+    const archiveHttp = useHttp<Record<string, never>, null>({});
 
-    const items = replies?.data ?? [];
+    const {
+        account: filterAccount,
+        platform: filterPlatform,
+        target: filterTarget,
+        post: filterPost,
+        unread: filterUnread,
+        archived: filterArchived,
+    } = filters;
+
+    // Filter changes refetch replies with reset:['replies']; stale overrides
+    // would wrongly hide rows in, say, the archived view.
+    useEffect(() => {
+        setOverrides({});
+    }, [
+        filterAccount,
+        filterPlatform,
+        filterTarget,
+        filterPost,
+        filterUnread,
+        filterArchived,
+    ]);
+
+    const items = (replies?.data ?? [])
+        .filter((r) => overrides[r.id] !== 'archived')
+        .map((r) =>
+            overrides[r.id] === 'responded'
+                ? { ...r, status: 'responded' as const }
+                : r,
+        );
     const disabledPlatforms = disabledPlatformLabels(engagementEnabled);
     const allEngagementDisabled =
         disabledPlatforms.length === platformKeys(engagementEnabled).length;
@@ -574,21 +645,20 @@ export default function EngagementIndex({
         }
 
         const archivedId = selected.id;
-        const nextId = nextAfterArchive(
-            items.map((item) => item.id),
-            archivedId,
-        );
 
-        router.post(
-            archiveRoute(archivedId).url,
-            {},
-            {
-                preserveScroll: true,
-                onSuccess: () => {
-                    selectById(nextId);
+        void archiveHttp
+            .post(archiveRoute(archivedId).url, {
+                onSuccess: () => handleArchived(archivedId),
+                onHttpException: (r) => {
+                    toast.error(
+                        actionErrorMessage(r, 'Could not archive the reply.'),
+                    );
                 },
-            },
-        );
+                onNetworkError: () => {
+                    toast.error('Could not reach the server.');
+                },
+            })
+            .catch(() => {});
     }
 
     function focusReply() {
@@ -651,6 +721,23 @@ export default function EngagementIndex({
         return () => document.removeEventListener('keydown', onKeyDown);
     });
 
+    function handleArchived(id: string) {
+        const nextId = nextAfterArchive(
+            items.map((item) => item.id),
+            id,
+        );
+        setOverrides((prev) => ({ ...prev, [id]: 'archived' }));
+        selectById(nextId);
+        // The sidebar's unread badge lives on the shared `shell` prop, which the
+        // old redirect refreshed incidentally. `replies` isn't in `only`, so the
+        // list keeps its data instead of falling back to the skeleton.
+        router.reload({ only: ['shell'] });
+    }
+
+    function handleResponded(id: string) {
+        setOverrides((prev) => ({ ...prev, [id]: 'responded' }));
+    }
+
     return (
         <>
             <Head title="Engagement" />
@@ -703,14 +790,8 @@ export default function EngagementIndex({
                         {selected ? (
                             <RightPane
                                 selected={selected}
-                                onArchived={() =>
-                                    selectById(
-                                        nextAfterArchive(
-                                            items.map((item) => item.id),
-                                            selected.id,
-                                        ),
-                                    )
-                                }
+                                onArchived={handleArchived}
+                                onResponded={handleResponded}
                                 replyTextareaRef={replyTextareaRef}
                             />
                         ) : allEngagementDisabled ? (
@@ -742,14 +823,8 @@ export default function EngagementIndex({
                         {selected ? (
                             <RightPane
                                 selected={selected}
-                                onArchived={() =>
-                                    selectById(
-                                        nextAfterArchive(
-                                            items.map((item) => item.id),
-                                            selected.id,
-                                        ),
-                                    )
-                                }
+                                onArchived={handleArchived}
+                                onResponded={handleResponded}
                                 replyTextareaRef={replyTextareaRef}
                                 reserveCloseButtonSpace
                             />

--- a/resources/js/pages/engagement/index.tsx
+++ b/resources/js/pages/engagement/index.tsx
@@ -203,15 +203,10 @@ function EngagementDisabledBanner({
 
 type RightPaneProps = {
     selected: ReplyItem;
-<<<<<<< HEAD
     onArchived: (id: string) => void;
     onResponded: (id: string) => void;
-    replyTextareaRef?: RefObject<HTMLTextAreaElement | null>;
-=======
-    onArchived: () => void;
     replyEditorRef?: RefObject<EditorBodyHandle | null>;
     savedMentions: WorkspaceMention[];
->>>>>>> origin/main
     reserveCloseButtonSpace?: boolean;
 };
 
@@ -224,13 +219,9 @@ type RightPaneProps = {
 function RightPane({
     selected,
     onArchived,
-<<<<<<< HEAD
     onResponded,
-    replyTextareaRef,
-=======
     replyEditorRef,
     savedMentions,
->>>>>>> origin/main
     reserveCloseButtonSpace = false,
 }: RightPaneProps) {
     const [thread, setThread] = useState<ReplyItem[]>([]);
@@ -571,8 +562,7 @@ export default function EngagementIndex({
 }: PageProps) {
     const isMobile = useIsMobile();
     const [selected, setSelected] = useState<ReplyItem | null>(null);
-<<<<<<< HEAD
-    const replyTextareaRef = useRef<HTMLTextAreaElement>(null);
+    const replyEditorRef = useRef<EditorBodyHandle>(null);
     // Client-side overlay over the deferred `replies` scroll prop: archiving or
     // responding must update the left list without a visit that would refetch
     // (and blank) it. Inertia still owns `replies` itself — we only derive.
@@ -582,9 +572,6 @@ export default function EngagementIndex({
     // The keyboard `A` shortcut archives without an Inertia visit, mirroring the
     // conversation pane's plain-JSON action so the deferred list never blanks.
     const archiveHttp = useHttp<Record<string, never>, null>({});
-=======
-    const replyEditorRef = useRef<EditorBodyHandle>(null);
->>>>>>> origin/main
 
     const {
         account: filterAccount,
@@ -811,22 +798,10 @@ export default function EngagementIndex({
                         {selected ? (
                             <RightPane
                                 selected={selected}
-<<<<<<< HEAD
                                 onArchived={handleArchived}
                                 onResponded={handleResponded}
-                                replyTextareaRef={replyTextareaRef}
-=======
-                                onArchived={() =>
-                                    selectById(
-                                        nextAfterArchive(
-                                            items.map((item) => item.id),
-                                            selected.id,
-                                        ),
-                                    )
-                                }
                                 replyEditorRef={replyEditorRef}
                                 savedMentions={savedMentions}
->>>>>>> origin/main
                             />
                         ) : allEngagementDisabled ? (
                             <EngagementDisabledNotice />
@@ -857,22 +832,10 @@ export default function EngagementIndex({
                         {selected ? (
                             <RightPane
                                 selected={selected}
-<<<<<<< HEAD
                                 onArchived={handleArchived}
                                 onResponded={handleResponded}
-                                replyTextareaRef={replyTextareaRef}
-=======
-                                onArchived={() =>
-                                    selectById(
-                                        nextAfterArchive(
-                                            items.map((item) => item.id),
-                                            selected.id,
-                                        ),
-                                    )
-                                }
                                 replyEditorRef={replyEditorRef}
                                 savedMentions={savedMentions}
->>>>>>> origin/main
                                 reserveCloseButtonSpace
                             />
                         ) : null}

--- a/resources/js/pages/engagement/types.ts
+++ b/resources/js/pages/engagement/types.ts
@@ -12,6 +12,7 @@ export type ReplyItem = {
     remote_created_at: string;
     is_read: boolean;
     is_liked: boolean;
+    can_like: boolean;
     is_ours: boolean;
     send_status: 'sending' | 'sent' | 'failed' | null;
     status: 'pending' | 'responded' | 'archived';

--- a/tests/Feature/Engagement/EngagementThreadTest.php
+++ b/tests/Feature/Engagement/EngagementThreadTest.php
@@ -69,7 +69,7 @@ test('thread replies include the published post remote id for platform links', f
 });
 
 test('thread replies expose whether the platform can like them', function (): void {
-    // Drives the heart's disabled state. Instagram/Threads have no like write.
+    // Drives the heart's disabled state. Only Threads has no like write.
     $likeable = PostTargetReply::factory()->for($this->target, 'target')->create([
         'workspace_id' => $this->workspace->id,
         'platform' => Platform::X,
@@ -79,12 +79,12 @@ test('thread replies expose whether the platform can like them', function (): vo
         ->assertOk()
         ->assertJsonPath('thread.0.can_like', true);
 
-    $instagramTarget = PostTarget::factory()
+    $threadsTarget = PostTarget::factory()
         ->for(Post::factory()->create(['workspace_id' => $this->workspace->id]))
-        ->create(['platform' => Platform::Instagram, 'remote_id' => 'ig-1']);
-    $notLikeable = PostTargetReply::factory()->for($instagramTarget, 'target')->create([
+        ->create(['platform' => Platform::Threads, 'remote_id' => 'th-1']);
+    $notLikeable = PostTargetReply::factory()->for($threadsTarget, 'target')->create([
         'workspace_id' => $this->workspace->id,
-        'platform' => Platform::Instagram,
+        'platform' => Platform::Threads,
     ]);
 
     $this->getJson(route('engagement.thread', $notLikeable))

--- a/tests/Feature/Engagement/EngagementThreadTest.php
+++ b/tests/Feature/Engagement/EngagementThreadTest.php
@@ -68,12 +68,38 @@ test('thread replies include the published post remote id for platform links', f
         ->assertJsonPath('thread.0.account_handle', '@heyandras-testing.bsky.social');
 });
 
-test('archive redirects for Inertia form submissions', function (): void {
+test('thread replies expose whether the platform can like them', function (): void {
+    // Drives the heart's disabled state. Instagram/Threads have no like write.
+    $likeable = PostTargetReply::factory()->for($this->target, 'target')->create([
+        'workspace_id' => $this->workspace->id,
+        'platform' => Platform::X,
+    ]);
+
+    $this->getJson(route('engagement.thread', $likeable))
+        ->assertOk()
+        ->assertJsonPath('thread.0.can_like', true);
+
+    $instagramTarget = PostTarget::factory()
+        ->for(Post::factory()->create(['workspace_id' => $this->workspace->id]))
+        ->create(['platform' => Platform::Instagram, 'remote_id' => 'ig-1']);
+    $notLikeable = PostTargetReply::factory()->for($instagramTarget, 'target')->create([
+        'workspace_id' => $this->workspace->id,
+        'platform' => Platform::Instagram,
+    ]);
+
+    $this->getJson(route('engagement.thread', $notLikeable))
+        ->assertOk()
+        ->assertJsonPath('thread.0.can_like', false);
+});
+
+test('archive returns 204 even without an Accept: application/json header', function (): void {
+    // The endpoint is JSON-only: it used to back() for non-JSON requests, which
+    // made the client follow a redirect into a full page visit. No dual mode now.
     $reply = PostTargetReply::factory()->for($this->target, 'target')->create([
         'workspace_id' => $this->workspace->id,
     ]);
 
-    $this->post(route('engagement.archive', $reply))->assertRedirect();
+    $this->post(route('engagement.archive', $reply))->assertNoContent();
 
     expect($reply->fresh()->status)->toBe(ReplyStatus::Archived);
 });

--- a/tests/Feature/Engagement/ReplyActionsTest.php
+++ b/tests/Feature/Engagement/ReplyActionsTest.php
@@ -14,6 +14,7 @@ use App\Models\WorkspaceMembership;
 use App\Services\Engagement\Contracts\EngagementConnector;
 use App\Services\Engagement\EngagementConnectorRegistry;
 use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Log;
 use Mockery\MockInterface;
 
 beforeEach(function (): void {
@@ -63,7 +64,9 @@ function fakeActionConnector(callable $expectations): void
 test('liking a reply records liked_at and the like remote id', function (): void {
     fakeActionConnector(fn ($c) => $c->shouldReceive('likeReply')->once()->andReturn(ReplyActionResult::ok('like-1')));
 
-    $this->post(route('engagement.like', $this->reply))->assertRedirect();
+    $this->postJson(route('engagement.like', $this->reply))
+        ->assertOk()
+        ->assertExactJson(['is_liked' => true]);
 
     expect($this->reply->fresh()->liked_at)->not->toBeNull();
     expect($this->reply->fresh()->like_remote_id)->toBe('like-1');
@@ -73,25 +76,123 @@ test('liking an already-liked reply is a no-op that does not call the platform',
     $this->reply->forceFill(['liked_at' => now(), 'like_remote_id' => 'like-1'])->save();
     fakeActionConnector(fn ($c) => $c->shouldReceive('likeReply')->never());
 
-    $this->post(route('engagement.like', $this->reply))->assertRedirect();
+    $this->postJson(route('engagement.like', $this->reply))
+        ->assertOk()
+        ->assertExactJson(['is_liked' => true]);
 });
 
 test('a failed like surfaces an error and leaves the reply unliked', function (): void {
     fakeActionConnector(fn ($c) => $c->shouldReceive('likeReply')->andReturn(ReplyActionResult::failed('nope')));
 
-    $this->post(route('engagement.like', $this->reply))->assertSessionHas('error');
+    // 502, never 422: useHttp routes 422 into its validation path, which would
+    // swallow this message and skip the client's rollback.
+    $this->postJson(route('engagement.like', $this->reply))
+        ->assertStatus(502)
+        ->assertJson(['status' => 'failed', 'message' => 'nope']);
 
     expect($this->reply->fresh()->liked_at)->toBeNull();
+});
+
+test('a like the platform does not support is a 409 and is not persisted', function (): void {
+    // The original bug: X 403s a like when the like.write scope is missing, the
+    // connector maps that to `unsupported`, and the old back() made it look OK.
+    fakeActionConnector(fn ($c) => $c->shouldReceive('likeReply')
+        ->andReturn(ReplyActionResult::unsupported('Missing required OAuth2 scopes: like.write')));
+
+    $this->postJson(route('engagement.like', $this->reply))
+        ->assertStatus(409)
+        ->assertJson(['status' => 'unsupported', 'message' => 'Missing required OAuth2 scopes: like.write']);
+
+    expect($this->reply->fresh()->liked_at)->toBeNull();
+});
+
+test('a rate-limited like is a 429 and is not persisted', function (): void {
+    fakeActionConnector(fn ($c) => $c->shouldReceive('likeReply')
+        ->andReturn(ReplyActionResult::rateLimited('slow down')));
+
+    $this->postJson(route('engagement.like', $this->reply))
+        ->assertStatus(429)
+        ->assertJson(['status' => 'rate_limited', 'message' => 'slow down']);
+
+    expect($this->reply->fresh()->liked_at)->toBeNull();
+});
+
+test('an auth-expired like is a 403 and is not persisted', function (): void {
+    fakeActionConnector(fn ($c) => $c->shouldReceive('likeReply')
+        ->andReturn(ReplyActionResult::authExpired('token dead')));
+
+    $this->postJson(route('engagement.like', $this->reply))
+        ->assertStatus(403)
+        ->assertJson(['status' => 'auth_expired', 'message' => 'token dead']);
+
+    expect($this->reply->fresh()->liked_at)->toBeNull();
+});
+
+test('a like with no message falls back to a generic one', function (): void {
+    fakeActionConnector(fn ($c) => $c->shouldReceive('likeReply')->andReturn(ReplyActionResult::failed()));
+
+    $this->postJson(route('engagement.like', $this->reply))
+        ->assertStatus(502)
+        ->assertJson(['status' => 'failed', 'message' => 'Could not like this reply.']);
+});
+
+test('a failed like is logged so it is diagnosable from the server', function (): void {
+    Log::spy();
+    fakeActionConnector(fn ($c) => $c->shouldReceive('likeReply')
+        ->andReturn(ReplyActionResult::unsupported('scope missing')));
+
+    $this->postJson(route('engagement.like', $this->reply))->assertStatus(409);
+
+    Log::shouldHaveReceived('warning')
+        ->once()
+        ->withArgs(fn (string $message, array $context): bool => $message === 'engagement.action.failed'
+            && $context['action'] === 'like'
+            && $context['platform'] === 'x'
+            && $context['reply_id'] === $this->reply->id
+            && $context['workspace_id'] === $this->workspace->id
+            && $context['status'] === 'unsupported'
+            && $context['message'] === 'scope missing');
+});
+
+test('a failed unlike is logged so it is diagnosable from the server', function (): void {
+    $this->reply->forceFill(['liked_at' => now(), 'like_remote_id' => 'like-1'])->save();
+    Log::spy();
+    fakeActionConnector(fn ($c) => $c->shouldReceive('unlikeReply')
+        ->andReturn(ReplyActionResult::failed('platform down')));
+
+    $this->deleteJson(route('engagement.unlike', $this->reply))->assertStatus(502);
+
+    Log::shouldHaveReceived('warning')
+        ->once()
+        ->withArgs(fn (string $message, array $context): bool => $message === 'engagement.action.failed'
+            && $context['action'] === 'unlike'
+            && $context['platform'] === 'x'
+            && $context['reply_id'] === $this->reply->id
+            && $context['status'] === 'failed'
+            && $context['message'] === 'platform down');
+
+    // The like must survive an unlike the platform rejected.
+    expect($this->reply->fresh()->liked_at)->not->toBeNull();
 });
 
 test('unliking clears the like state', function (): void {
     $this->reply->forceFill(['liked_at' => now(), 'like_remote_id' => 'like-1'])->save();
     fakeActionConnector(fn ($c) => $c->shouldReceive('unlikeReply')->once()->andReturn(ReplyActionResult::ok()));
 
-    $this->delete(route('engagement.unlike', $this->reply))->assertRedirect();
+    $this->deleteJson(route('engagement.unlike', $this->reply))
+        ->assertOk()
+        ->assertExactJson(['is_liked' => false]);
 
     expect($this->reply->fresh()->liked_at)->toBeNull();
     expect($this->reply->fresh()->like_remote_id)->toBeNull();
+});
+
+test('unliking a reply that is not liked is a no-op that does not call the platform', function (): void {
+    fakeActionConnector(fn ($c) => $c->shouldReceive('unlikeReply')->never());
+
+    $this->deleteJson(route('engagement.unlike', $this->reply))
+        ->assertOk()
+        ->assertExactJson(['is_liked' => false]);
 });
 
 test('deleting our own reply removes it from the platform and the database', function (): void {
@@ -101,7 +202,7 @@ test('deleting our own reply removes it from the platform and the database', fun
     ]);
     fakeActionConnector(fn ($c) => $c->shouldReceive('deleteReply')->once()->andReturn(ReplyActionResult::ok()));
 
-    $this->delete(route('engagement.destroy', $ours))->assertRedirect();
+    $this->deleteJson(route('engagement.destroy', $ours))->assertNoContent();
 
     expect(PostTargetReply::withoutGlobalScopes()->whereKey($ours->id)->exists())->toBeFalse();
 });
@@ -113,7 +214,9 @@ test('a failed delete keeps the reply', function (): void {
     ]);
     fakeActionConnector(fn ($c) => $c->shouldReceive('deleteReply')->andReturn(ReplyActionResult::failed('platform down')));
 
-    $this->delete(route('engagement.destroy', $ours))->assertSessionHas('error');
+    $this->deleteJson(route('engagement.destroy', $ours))
+        ->assertStatus(502)
+        ->assertJson(['status' => 'failed', 'message' => 'platform down']);
 
     expect(PostTargetReply::withoutGlobalScopes()->whereKey($ours->id)->exists())->toBeTrue();
 });
@@ -121,7 +224,7 @@ test('a failed delete keeps the reply', function (): void {
 test('deleting a reply that is not ours is forbidden', function (): void {
     fakeActionConnector(fn ($c) => $c->shouldReceive('deleteReply')->never());
 
-    $this->delete(route('engagement.destroy', $this->reply))->assertForbidden();
+    $this->deleteJson(route('engagement.destroy', $this->reply))->assertForbidden();
 });
 
 test('liking a reply in another workspace 404s', function (): void {
@@ -130,5 +233,5 @@ test('liking a reply in another workspace 404s', function (): void {
         'workspace_id' => $otherWorkspace->id, 'platform' => Platform::X, 'is_ours' => false,
     ]);
 
-    $this->post(route('engagement.like', $foreign))->assertNotFound();
+    $this->postJson(route('engagement.like', $foreign))->assertNotFound();
 });

--- a/tests/Feature/Engagement/RespondToReplyTest.php
+++ b/tests/Feature/Engagement/RespondToReplyTest.php
@@ -62,8 +62,10 @@ function fakePostReply(ReplyPostResult $result): void
 test('responding posts the reply and records our row', function (): void {
     fakePostReply(ReplyPostResult::ok('at://mine', 'cidmine'));
 
-    $this->post(route('engagement.respond', $this->reply), ['text' => 'thank you!'])
-        ->assertRedirect();
+    $this->postJson(route('engagement.respond', $this->reply), ['text' => 'thank you!'])
+        ->assertCreated()
+        ->assertJsonPath('reply.text', 'thank you!')
+        ->assertJsonPath('reply.is_ours', true);
 
     expect($this->reply->fresh()->status)->toBe(ReplyStatus::Responded);
     expect($this->reply->fresh()->our_reply_remote_id)->toBe('at://mine');
@@ -75,8 +77,8 @@ test('our outgoing reply joins the conversation of the reply it answers', functi
 
     $this->reply->forceFill(['conversation_remote_id' => 'at://base'])->save();
 
-    $this->post(route('engagement.respond', $this->reply), ['text' => 'thank you!'])
-        ->assertRedirect();
+    $this->postJson(route('engagement.respond', $this->reply), ['text' => 'thank you!'])
+        ->assertCreated();
 
     $ourRow = PostTargetReply::withoutGlobalScopes()->where('remote_reply_id', 'at://mine')->firstOrFail();
 
@@ -88,8 +90,8 @@ test('our outgoing reply starts the conversation when it answers a base reply', 
 
     $this->reply->forceFill(['conversation_remote_id' => null])->save();
 
-    $this->post(route('engagement.respond', $this->reply), ['text' => 'thank you!'])
-        ->assertRedirect();
+    $this->postJson(route('engagement.respond', $this->reply), ['text' => 'thank you!'])
+        ->assertCreated();
 
     $ourRow = PostTargetReply::withoutGlobalScopes()->where('remote_reply_id', 'at://mine')->firstOrFail();
 
@@ -99,8 +101,8 @@ test('our outgoing reply starts the conversation when it answers a base reply', 
 test('responding rejects over-length text', function (): void {
     fakePostReply(ReplyPostResult::ok('at://mine'));
 
-    $this->post(route('engagement.respond', $this->reply), ['text' => str_repeat('x', 5000)])
-        ->assertSessionHasErrors('text');
+    $this->postJson(route('engagement.respond', $this->reply), ['text' => str_repeat('x', 5000)])
+        ->assertJsonValidationErrors('text');
 });
 
 test('replying up to account capability limit is accepted', function (): void {
@@ -132,8 +134,8 @@ test('replying up to account capability limit is accepted', function (): void {
     fakePostReply(ReplyPostResult::ok('id-premium'));
 
     // A ~1000-char text exceeds X default (280) but is within the capability (25000)
-    $this->post(route('engagement.respond', $reply), ['text' => str_repeat('a', 1000)])
-        ->assertSessionHasNoErrors();
+    $this->postJson(route('engagement.respond', $reply), ['text' => str_repeat('a', 1000)])
+        ->assertCreated();
 });
 
 test('responding is blocked when the account is disabled', function (): void {
@@ -141,8 +143,9 @@ test('responding is blocked when the account is disabled', function (): void {
 
     $this->target->account->forceFill(['disabled_at' => now()])->save();
 
-    $this->post(route('engagement.respond', $this->reply), ['text' => 'nope'])
-        ->assertSessionHas('error');
+    $this->postJson(route('engagement.respond', $this->reply), ['text' => 'nope'])
+        ->assertStatus(409)
+        ->assertJson(['status' => 'unsupported']);
 
     expect($this->reply->fresh()->status)->toBe(ReplyStatus::Pending)
         ->and(PostTargetReply::withoutGlobalScopes()->where('is_ours', true)->exists())->toBeFalse();
@@ -151,8 +154,9 @@ test('responding is blocked when the account is disabled', function (): void {
 test('a failed post surfaces an error and does not mark responded', function (): void {
     fakePostReply(ReplyPostResult::failed('platform down'));
 
-    $this->post(route('engagement.respond', $this->reply), ['text' => 'hi'])
-        ->assertSessionHas('error');
+    $this->postJson(route('engagement.respond', $this->reply), ['text' => 'hi'])
+        ->assertStatus(502)
+        ->assertJson(['status' => 'failed', 'message' => 'platform down']);
 
     expect($this->reply->fresh()->status)->toBe(ReplyStatus::Pending);
 });

--- a/tests/Feature/Engagement/RespondWithMediaTest.php
+++ b/tests/Feature/Engagement/RespondWithMediaTest.php
@@ -39,7 +39,7 @@ beforeEach(function (): void {
     $this->media = PostMedia::factory()->create(['workspace_id' => $this->workspace->id, 'kind' => 'image']);
 });
 
-test('a text-only reply still posts synchronously (no job)', function () {
+test('a text-only reply still posts synchronously (no job)', function (): void {
     Queue::fake();
     $connector = Mockery::mock(EngagementConnector::class);
     $connector->shouldReceive('postReply')->andReturn(ReplyPostResult::ok('x1'));
@@ -54,7 +54,7 @@ test('a text-only reply still posts synchronously (no job)', function () {
 
 // JSON-encoded (not multipart): `media` is an array of string ids, never Files,
 // so the client can drop forceFormData. These tests are what prove that.
-test('a reply with media creates a sending row and dispatches SendReply', function () {
+test('a reply with media creates a sending row and dispatches SendReply', function (): void {
     Queue::fake();
 
     $this->postJson(route('engagement.respond', $this->reply), [
@@ -66,7 +66,7 @@ test('a reply with media creates a sending row and dispatches SendReply', functi
     Queue::assertPushed(SendReply::class, 1);
 });
 
-test('a media-only reply with empty text is accepted', function () {
+test('a media-only reply with empty text is accepted', function (): void {
     Queue::fake();
 
     $this->postJson(route('engagement.respond', $this->reply), [
@@ -76,7 +76,7 @@ test('a media-only reply with empty text is accepted', function () {
     Queue::assertPushed(SendReply::class, 1);
 });
 
-test('a reply with neither text nor media is rejected', function () {
+test('a reply with neither text nor media is rejected', function (): void {
     Queue::fake();
 
     $this->postJson(route('engagement.respond', $this->reply), [])
@@ -85,7 +85,7 @@ test('a reply with neither text nor media is rejected', function () {
     Queue::assertNothingPushed();
 });
 
-test('a foreign-workspace media id is rejected', function () {
+test('a foreign-workspace media id is rejected', function (): void {
     Queue::fake();
 
     $otherWorkspace = Workspace::factory()->create();
@@ -98,7 +98,7 @@ test('a foreign-workspace media id is rejected', function () {
     Queue::assertNothingPushed();
 });
 
-test('SendReply::failed marks the row failed', function () {
+test('SendReply::failed marks the row failed', function (): void {
     $ourRow = PostTargetReply::factory()->create([
         'workspace_id' => $this->workspace->id, 'post_target_id' => $this->reply->post_target_id,
         'platform' => Platform::X, 'is_ours' => true, 'send_status' => SendStatus::Sending->value,
@@ -111,7 +111,7 @@ test('SendReply::failed marks the row failed', function () {
     expect($ourRow->fresh()->send_status)->toBe(SendStatus::Failed);
 });
 
-test('SendReply fails the row without posting when the account is disabled', function () {
+test('SendReply fails the row without posting when the account is disabled', function (): void {
     $this->reply->target->account->forceFill(['disabled_at' => now()])->save();
 
     $ourRow = PostTargetReply::factory()->create([
@@ -126,7 +126,7 @@ test('SendReply fails the row without posting when the account is disabled', fun
     expect($ourRow->fresh()->send_status)->toBe(SendStatus::Failed);
 });
 
-test('SendReply posts the media reply and marks it sent', function () {
+test('SendReply posts the media reply and marks it sent', function (): void {
     $connector = Mockery::mock(EngagementConnector::class);
     $connector->shouldReceive('postReply')->andReturn(ReplyPostResult::ok('rid', 'cid'));
     $registry = Mockery::mock(EngagementConnectorRegistry::class);

--- a/tests/Feature/Engagement/RespondWithMediaTest.php
+++ b/tests/Feature/Engagement/RespondWithMediaTest.php
@@ -47,17 +47,19 @@ test('a text-only reply still posts synchronously (no job)', function () {
     $registry->shouldReceive('for')->andReturn($connector);
     app()->instance(EngagementConnectorRegistry::class, $registry);
 
-    $this->post(route('engagement.respond', $this->reply), ['text' => 'hi'])->assertRedirect();
+    $this->postJson(route('engagement.respond', $this->reply), ['text' => 'hi'])->assertCreated();
     Queue::assertNothingPushed();
     expect($this->reply->fresh()->status->value)->toBe('responded');
 });
 
+// JSON-encoded (not multipart): `media` is an array of string ids, never Files,
+// so the client can drop forceFormData. These tests are what prove that.
 test('a reply with media creates a sending row and dispatches SendReply', function () {
     Queue::fake();
 
-    $this->post(route('engagement.respond', $this->reply), [
+    $this->postJson(route('engagement.respond', $this->reply), [
         'text' => 'with pic', 'media' => [$this->media->id],
-    ])->assertRedirect();
+    ])->assertCreated()->assertJsonPath('reply.is_ours', true);
 
     $ourRow = PostTargetReply::withoutGlobalScopes()->where('is_ours', true)->firstOrFail();
     expect($ourRow->send_status)->toBe(SendStatus::Sending);
@@ -67,9 +69,9 @@ test('a reply with media creates a sending row and dispatches SendReply', functi
 test('a media-only reply with empty text is accepted', function () {
     Queue::fake();
 
-    $this->post(route('engagement.respond', $this->reply), [
+    $this->postJson(route('engagement.respond', $this->reply), [
         'text' => '', 'media' => [$this->media->id],
-    ])->assertRedirect()->assertSessionHasNoErrors();
+    ])->assertCreated();
 
     Queue::assertPushed(SendReply::class, 1);
 });
@@ -77,8 +79,8 @@ test('a media-only reply with empty text is accepted', function () {
 test('a reply with neither text nor media is rejected', function () {
     Queue::fake();
 
-    $this->post(route('engagement.respond', $this->reply), [])
-        ->assertSessionHasErrors('text');
+    $this->postJson(route('engagement.respond', $this->reply), [])
+        ->assertJsonValidationErrors('text');
 
     Queue::assertNothingPushed();
 });
@@ -89,9 +91,9 @@ test('a foreign-workspace media id is rejected', function () {
     $otherWorkspace = Workspace::factory()->create();
     $foreignMedia = PostMedia::factory()->create(['workspace_id' => $otherWorkspace->id, 'kind' => 'image']);
 
-    $this->post(route('engagement.respond', $this->reply), [
+    $this->postJson(route('engagement.respond', $this->reply), [
         'text' => 'with pic', 'media' => [$foreignMedia->id],
-    ])->assertSessionHasErrors('media.0');
+    ])->assertJsonValidationErrors('media.0');
 
     Queue::assertNothingPushed();
 });

--- a/tests/Unit/ConnectedAccounts/PlatformTest.php
+++ b/tests/Unit/ConnectedAccounts/PlatformTest.php
@@ -29,14 +29,19 @@ test('x scopes include like.write so the engagement inbox can like and unlike', 
 });
 
 test('platforms report whether their connector can like a reply', function () {
-    // Instagram and Threads have no like/unlike write for comments.
+    // Only Threads still has no like/unlike write for replies; Instagram gained
+    // it with the Like Media and Comments API (2026-04-22).
     expect(Platform::X->supportsReplyLikes())->toBeTrue()
         ->and(Platform::Bluesky->supportsReplyLikes())->toBeTrue()
         ->and(Platform::LinkedIn->supportsReplyLikes())->toBeTrue()
         ->and(Platform::Facebook->supportsReplyLikes())->toBeTrue()
         ->and(Platform::Discord->supportsReplyLikes())->toBeTrue()
-        ->and(Platform::Instagram->supportsReplyLikes())->toBeFalse()
+        ->and(Platform::Instagram->supportsReplyLikes())->toBeTrue()
         ->and(Platform::Threads->supportsReplyLikes())->toBeFalse();
+});
+
+test('instagram requests the engagement scope that powers reply likes', function () {
+    expect(Platform::Instagram->scopes())->toContain('instagram_manage_engagement');
 });
 
 test('socialite driver names match core socialite keys', function () {

--- a/tests/Unit/ConnectedAccounts/PlatformTest.php
+++ b/tests/Unit/ConnectedAccounts/PlatformTest.php
@@ -20,6 +20,25 @@ test('x scopes include users.email so Socialite can read confirmed_email', funct
         ->and(Platform::X->scopes())->toContain('media.write');
 });
 
+test('x scopes include like.write so the engagement inbox can like and unlike', function () {
+    // Regression guard for a real production bug: without like.write, X 403s
+    // POST/DELETE /2/users/{id}/likes ("Missing required OAuth2 scopes"), the
+    // connector maps that 403 to `unsupported`, and likes silently never persist.
+    // One scope covers both like and unlike. Do not drop it.
+    expect(Platform::X->scopes())->toContain('like.write');
+});
+
+test('platforms report whether their connector can like a reply', function () {
+    // Instagram and Threads have no like/unlike write for comments.
+    expect(Platform::X->supportsReplyLikes())->toBeTrue()
+        ->and(Platform::Bluesky->supportsReplyLikes())->toBeTrue()
+        ->and(Platform::LinkedIn->supportsReplyLikes())->toBeTrue()
+        ->and(Platform::Facebook->supportsReplyLikes())->toBeTrue()
+        ->and(Platform::Discord->supportsReplyLikes())->toBeTrue()
+        ->and(Platform::Instagram->supportsReplyLikes())->toBeFalse()
+        ->and(Platform::Threads->supportsReplyLikes())->toBeFalse();
+});
+
 test('socialite driver names match core socialite keys', function () {
     expect(Platform::X->socialiteDriver())->toBe('x')
         ->and(Platform::LinkedIn->socialiteDriver())->toBe('linkedin-openid')

--- a/tests/Unit/Engagement/EngagementStatusTest.php
+++ b/tests/Unit/Engagement/EngagementStatusTest.php
@@ -9,6 +9,28 @@ test('engagement status reports ok only for ok', function () {
     expect(EngagementStatus::Unsupported->isOk())->toBeFalse();
 });
 
+test('engagement status maps to the http status the action endpoints report', function () {
+    expect(EngagementStatus::Ok->httpStatus())->toBe(200)
+        ->and(EngagementStatus::AuthExpired->httpStatus())->toBe(403)
+        ->and(EngagementStatus::Unsupported->httpStatus())->toBe(409)
+        ->and(EngagementStatus::RateLimited->httpStatus())->toBe(429)
+        ->and(EngagementStatus::Failed->httpStatus())->toBe(502);
+});
+
+test('no engagement status is ever reported as 422', function () {
+    // 422 is load-bearing: Inertia's useHttp special-cases it into the
+    // validation-errors path, parsing the body as `data.errors` and firing
+    // onError instead of onHttpException. A connector failure returned as 422
+    // would fire onError({}) — an empty bag — silently swallowing the message
+    // and skipping the client's rollback. That is the exact silent-lie bug this
+    // map fixes, so 422 stays reserved for real validation errors.
+    expect(EngagementStatus::Failed->httpStatus())->not->toBe(422);
+
+    foreach (EngagementStatus::cases() as $status) {
+        expect($status->httpStatus())->not->toBe(422);
+    }
+});
+
 test('reply status has the three lifecycle cases', function () {
     expect(array_map(fn (ReplyStatus $s) => $s->value, ReplyStatus::cases()))
         ->toBe(['pending', 'responded', 'archived']);

--- a/tests/Unit/Engagement/InstagramEngagementConnectorTest.php
+++ b/tests/Unit/Engagement/InstagramEngagementConnectorTest.php
@@ -107,8 +107,26 @@ test('postReply declines media (Instagram comments cannot carry attachments)', f
     expect($result->status)->toBe(EngagementStatus::Unsupported);
 });
 
-test('likeReply is unsupported and sends no HTTP request', function () {
-    Http::preventStrayRequests();
+test('likeReply likes the comment via the user-scoped likes edge', function () {
+    Http::fake(['graph.facebook.com/*/IGUSER1/likes' => Http::response(['success' => true])]);
+
+    $reply = PostTargetReply::factory()->create([
+        'platform' => Platform::Instagram,
+        'remote_reply_id' => 'C1',
+    ]);
+
+    $result = instagramConnector()->likeReply(instagramAccount(), $reply, ['access_token' => 't']);
+
+    expect($result->isOk())->toBeTrue();
+
+    Http::assertSent(fn ($req) => $req->method() === 'POST'
+        && str_contains($req->url(), '/IGUSER1/likes')
+        && $req['comment_id'] === 'C1'
+        && $req['access_token'] === 't');
+});
+
+test('likeReply maps 403 to unsupported (missing instagram_manage_engagement)', function () {
+    Http::fake(['graph.facebook.com/*/IGUSER1/likes' => Http::response(['error' => ['message' => 'no perms']], 403)]);
 
     $reply = PostTargetReply::factory()->create([
         'platform' => Platform::Instagram,
@@ -118,13 +136,11 @@ test('likeReply is unsupported and sends no HTTP request', function () {
     $result = instagramConnector()->likeReply(instagramAccount(), $reply, ['access_token' => 't']);
 
     expect($result->status)->toBe(EngagementStatus::Unsupported);
-    expect($result->message)->toBe('Instagram does not support liking comments via API');
-
-    Http::assertNothingSent();
+    expect($result->message)->toBe('no perms');
 });
 
-test('unlikeReply is unsupported and sends no HTTP request', function () {
-    Http::preventStrayRequests();
+test('unlikeReply unlikes the comment via the user-scoped likes edge', function () {
+    Http::fake(['graph.facebook.com/*/IGUSER1/likes' => Http::response(['success' => true])]);
 
     $reply = PostTargetReply::factory()->create([
         'platform' => Platform::Instagram,
@@ -133,10 +149,12 @@ test('unlikeReply is unsupported and sends no HTTP request', function () {
 
     $result = instagramConnector()->unlikeReply(instagramAccount(), $reply, null, ['access_token' => 't']);
 
-    expect($result->status)->toBe(EngagementStatus::Unsupported);
-    expect($result->message)->toBe('Instagram does not support liking comments via API');
+    expect($result->isOk())->toBeTrue();
 
-    Http::assertNothingSent();
+    Http::assertSent(fn ($req) => $req->method() === 'DELETE'
+        && str_contains($req->url(), '/IGUSER1/likes')
+        && $req['comment_id'] === 'C1'
+        && $req['access_token'] === 't');
 });
 
 test('deleteReply deletes the comment', function () {


### PR DESCRIPTION
## Summary

Engagement reply actions were talking to the server as Inertia page visits, and the controller answered with `back()->with('error', …)`. That redirect is a **302 success** carrying the message in `flash.error`, not an `errors` bag — so Inertia's `onError` never fired, the optimistic-UI rollback was dead code, and a rejected like/reply/archive/delete looked successful while nothing changed on the platform. The redirect also forced a full `GET /engagement`, which blanked the deferred replies list to a skeleton and re-ran the facet queries on every action.

This PR makes those actions honest and instant, fixes the actual production cause of X likes failing, and adds Instagram reply likes now that the platform supports them.

### Honest, JSON-based actions
- `like`, `unlike`, `respond`, `archive`, and `destroyReply` now return **JSON with a status-specific HTTP code** instead of an Inertia redirect.
- New `EngagementStatus::httpStatus()` maps connector outcomes: `auth_expired → 403`, `unsupported → 409`, `rate_limited → 429`, `failed → 502`. **422 is deliberately never used** — Inertia's `useHttp` special-cases 422 into its validation-errors path (`onError`), which would swallow the message and recreate the original silent-failure bug. This is pinned by a test.
- Failed reply actions are logged server-side as `engagement.action.failed` (action, platform, reply id, workspace, status, message) so failures are diagnosable.
- Client actions now use `useHttp` instead of Inertia visits: a failure surfaces a toast (parsed from the raw JSON body via `actionErrorMessage`) and rolls back the optimistic update, instead of following a redirect that refetched and blanked the deferred list. Archive/respond update the left list through a derived `overrides` overlay rather than a full reload, leaving Inertia's `Inertia::scroll` prop untouched.

### X likes — the production fix
- Added the **`like.write`** OAuth scope for X. `POST /2/users/{id}/likes` requires it; without it X returned 403, the connector mapped it to `unsupported`, and the like silently no-opped. This was the real cause of X likes failing in prod.

### Instagram likes — new capability
- Meta shipped the **Like Media and Comments API** on 2026-04-22 (`POST`/`DELETE /<ig-user-id>/likes` with `comment_id`, gated by `instagram_manage_engagement`). Implemented `InstagramEngagementConnector::likeReply/unlikeReply` against it, mirroring the Facebook connector; a missing scope still degrades to `Unsupported` rather than erroring.
- Added `instagram_manage_engagement` to Instagram's requested scopes.
- `Platform::supportsReplyLikes()` (drives the heart's disabled state + tooltip, exposed as `can_like` on each reply) now excludes **only Threads**, whose API still has no reply-like write.

## Deployment / operator notes

Granted scopes are frozen into existing tokens, so the two new scopes only apply to **newly authorized** connections:

- **X** — after deploy, existing X accounts must **reconnect** to pick up `like.write` before likes work.
- **Instagram** — `instagram_manage_engagement` requires **Meta App Review approval** in the app dashboard, and existing IG accounts must **reconnect** afterward.

Until an account is reconnected (or the IG permission is approved), its likes fail *honestly* — the heart rolls back with a toast and an `engagement.action.failed` log line — rather than silently no-opping.

## Breaking changes

- `EngagementController@like`, `@unlike`, `@respond`, `@archive`, and `@destroyReply` no longer support non-JSON (Inertia redirect) requests; they always respond with JSON.

## Testing

- Full Pest suite: **1350 passing**; Larastan L7 clean; Pint clean; frontend vitest green.
- New/updated coverage: `EngagementStatus::httpStatus()` mapping (incl. an explicit assertion that `failed` is never 422), connector-failure logging via `Log::spy()`, the 409/429/403 action paths, Instagram like/unlike against the likes edge (+ 403→unsupported), the `like.write`/`instagram_manage_engagement` scope pins, and `actionErrorMessage` fallback behavior.