### PR TITLE
feat(engagement): add emoji picker and mentions to quick reply box

### DIFF
--- a/app/Http/Controllers/Engagement/EngagementController.php
+++ b/app/Http/Controllers/Engagement/EngagementController.php
@@ -9,11 +9,13 @@ use App\Enums\ReplyStatus;
 use App\Enums\SendStatus;
 use App\Exceptions\TokenRefreshException;
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\WorkspaceMentionController;
 use App\Http\Requests\Engagement\RespondToReplyRequest;
 use App\Jobs\SendReply;
 use App\Models\ConnectedAccount;
 use App\Models\Post;
 use App\Models\PostTargetReply;
+use App\Models\WorkspaceMention;
 use App\Services\Engagement\EngagementConnectorRegistry;
 use App\Services\Publishing\TokenManager;
 use App\Support\InstanceSettings;
@@ -101,6 +103,14 @@ class EngagementController extends Controller
                 'bluesky' => $settings->engagementPollingEnabled(Platform::Bluesky),
                 'linkedin' => $settings->engagementPollingEnabled(Platform::LinkedIn),
             ],
+            // The reply box reuses the composer's @-mention picker, so it needs
+            // the same saved-mention library the composer receives.
+            'savedMentions' => WorkspaceMention::withoutGlobalScopes()
+                ->where('workspace_id', $request->user()->current_workspace_id)
+                ->orderBy('name')
+                ->get()
+                ->map(fn (WorkspaceMention $mention): array => WorkspaceMentionController::view($mention))
+                ->all(),
         ]);
     }
 

--- a/resources/js/components/compose/__tests__/editor-body.test.ts
+++ b/resources/js/components/compose/__tests__/editor-body.test.ts
@@ -11,6 +11,7 @@ import {
 import {
     hasPasteableMedia,
     isPasteableMediaFile,
+    isSubmitShortcut,
     shouldFocusEditorOnMount,
 } from '../editor-body';
 
@@ -62,6 +63,29 @@ describe('hasPasteableMedia', () => {
         expect(hasPasteableMedia(null)).toBe(false);
         expect(hasPasteableMedia(undefined)).toBe(false);
         expect(hasPasteableMedia(fileList(file('text/html')))).toBe(false);
+    });
+});
+
+describe('isSubmitShortcut', () => {
+    it('fires on Cmd+Enter and Ctrl+Enter', () => {
+        expect(
+            isSubmitShortcut({ key: 'Enter', metaKey: true, ctrlKey: false }),
+        ).toBe(true);
+        expect(
+            isSubmitShortcut({ key: 'Enter', metaKey: false, ctrlKey: true }),
+        ).toBe(true);
+    });
+
+    it('leaves plain Enter alone, so it newlines and the emoji typeahead can claim it', () => {
+        expect(
+            isSubmitShortcut({ key: 'Enter', metaKey: false, ctrlKey: false }),
+        ).toBe(false);
+    });
+
+    it('ignores other modified keys', () => {
+        expect(
+            isSubmitShortcut({ key: 'a', metaKey: true, ctrlKey: false }),
+        ).toBe(false);
     });
 });
 

--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -1,9 +1,8 @@
-import { Popover as PopoverPrimitive } from '@base-ui/react/popover';
 import { Image as ImageIcon, Shuffle, Smile, Split } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 
-import EmojiPicker from '@/components/compose/emoji-picker';
+import { EmojiPopover } from '@/components/compose/emoji-popover';
 import type { EmojiSkinTone } from '@/lib/compose/emoji/types';
 import { cn } from '@/lib/utils';
 import type { MediaView, PendingUpload, PlatformName } from '@/types/compose';
@@ -183,117 +182,24 @@ export function ComposerToolbar({
                     skinTone={emojiSkinTone}
                     onSkinToneChange={onEmojiSkinToneChange}
                     onSelect={onInsertEmoji}
-                />
+                    trigger={(open) => (
+                        <button
+                            type="button"
+                            title="Emoji"
+                            data-active={open}
+                            className={cn(
+                                'inline-flex h-8 items-center gap-1.5 rounded-md border border-transparent bg-transparent px-2.5 text-[12px] text-muted-foreground transition-colors sm:h-7',
+                                'hover:border-border hover:bg-background hover:text-foreground',
+                                'data-[active=true]:border-border data-[active=true]:bg-background data-[active=true]:text-foreground data-[active=true]:shadow-[0_1px_2px_0_rgb(0_0_0/0.04)]',
+                            )}
+                        />
+                    )}
+                >
+                    <Smile className="size-3.5" aria-hidden="true" />
+                    <span>Emoji</span>
+                </EmojiPopover>
             )}
         </div>
-    );
-}
-
-function EmojiPopover({
-    recents,
-    skinTone,
-    onSkinToneChange,
-    onSelect,
-}: {
-    recents: string[];
-    skinTone: EmojiSkinTone;
-    onSkinToneChange: (tone: EmojiSkinTone) => void;
-    onSelect: (emoji: string) => void;
-}) {
-    const [open, setOpen] = useState(false);
-    // Mount the picker once and keep it alive. Frimousse re-reads and re-parses
-    // the ~775KB emoji dataset and rebuilds its store on every fresh mount, so
-    // unmounting on close (the default) made each reopen — and the select
-    // that closes it — sluggish. We warm it during browser idle (never on the
-    // click, which the parse would block) and Portal `keepMounted` keeps it
-    // alive; when closed it's hidden via a transition, not unmounted.
-    const [mounted, setMounted] = useState(false);
-    useEffect(() => {
-        if (mounted) {
-            return;
-        }
-        if (open) {
-            setMounted(true);
-
-            return;
-        }
-        const idle = window as Window & {
-            requestIdleCallback?: (callback: () => void) => number;
-            cancelIdleCallback?: (handle: number) => void;
-        };
-        if (typeof idle.requestIdleCallback === 'function') {
-            const handle = idle.requestIdleCallback(() => setMounted(true));
-
-            return () => idle.cancelIdleCallback?.(handle);
-        }
-        const handle = window.setTimeout(() => setMounted(true), 500);
-
-        return () => window.clearTimeout(handle);
-    }, [mounted, open]);
-
-    return (
-        <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
-            <PopoverPrimitive.Trigger
-                render={
-                    <button
-                        type="button"
-                        title="Emoji"
-                        data-active={open}
-                        className={cn(
-                            'inline-flex h-8 items-center gap-1.5 rounded-md border border-transparent bg-transparent px-2.5 text-[12px] text-muted-foreground transition-colors sm:h-7',
-                            'hover:border-border hover:bg-background hover:text-foreground',
-                            'data-[active=true]:border-border data-[active=true]:bg-background data-[active=true]:text-foreground data-[active=true]:shadow-[0_1px_2px_0_rgb(0_0_0/0.04)]',
-                        )}
-                    />
-                }
-            >
-                <Smile className="size-3.5" aria-hidden="true" />
-                <span>Emoji</span>
-            </PopoverPrimitive.Trigger>
-            {mounted && (
-                <PopoverPrimitive.Portal keepMounted>
-                    <PopoverPrimitive.Positioner
-                        align="end"
-                        side="top"
-                        sideOffset={8}
-                        // While closed the kept-warm popover stays mounted and
-                        // positioned over the composer; make the positioner
-                        // click-through so it doesn't swallow clicks on the tab
-                        // strip / controls beneath it.
-                        className="isolate z-50 data-closed:pointer-events-none"
-                    >
-                        <PopoverPrimitive.Popup
-                            data-keep-warm=""
-                            initialFocus={false}
-                            className={cn(
-                                'z-50 w-[336px] overflow-hidden rounded-2xl bg-popover text-popover-foreground shadow-lg ring-1 ring-foreground/5 outline-hidden dark:ring-foreground/10',
-                                // Same fade+zoom feel as the notification bell, but
-                                // driven by a CSS transition instead of a keyframe
-                                // animate-in/-out. The picker is kept warm and
-                                // prewarmed while closed, so a keyframe `animate-out`
-                                // would flash it on that first hidden mount; a
-                                // transition only runs on real state changes.
-                                // opacity/transform are GPU-composited, so it stays
-                                // smooth on the heavy virtualized grid.
-                                'origin-(--transform-origin) transition-[opacity,transform] duration-100 ease-out',
-                                'data-open:scale-100 data-open:opacity-100',
-                                'data-closed:pointer-events-none data-closed:scale-95 data-closed:opacity-0',
-                            )}
-                        >
-                            <EmojiPicker
-                                recents={recents}
-                                skinTone={skinTone}
-                                onSkinToneChange={onSkinToneChange}
-                                onSelect={(emoji) => {
-                                    onSelect(emoji);
-                                    setOpen(false);
-                                }}
-                            />
-                        </PopoverPrimitive.Popup>
-                    </PopoverPrimitive.Positioner>
-                </PopoverPrimitive.Portal>
-            )}
-        </PopoverPrimitive.Root>
     );
 }
 

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -37,10 +37,18 @@ import type {
 type EditorBodyProps = {
     value: string[];
     onChange: (segments: string[]) => void;
-    onBlur: () => void;
+    onBlur?: () => void;
     placeholder?: string;
     /** When false, the post is read-only (e.g. already published/scheduled). */
     editable?: boolean;
+    /**
+     * Single-message variant (the engagement reply box): drops the thread and
+     * mention extensions and shrinks the type scale. See `composerExtensions`
+     * for why the extensions must be omitted rather than left unconfigured.
+     */
+    compact?: boolean;
+    /** Fired on ⌘/Ctrl+Enter. Omit to leave the shortcut unhandled. */
+    onSubmit?: () => void;
     /** When true, render the ring-tinted override banner above the editor. */
     overrideBanner?: boolean;
     /** Human label of the active platform for the override banner copy. */
@@ -87,6 +95,10 @@ type EditorBodyProps = {
 export type EditorBodyHandle = {
     /** Insert text (e.g. an emoji) at the current selection and refocus. */
     insertText: (text: string) => void;
+    /** Move focus into the editor with the caret at the end. */
+    focus: () => void;
+    /** Release focus from the editor. */
+    blur: () => void;
 };
 
 export function shouldFocusEditorOnMount(
@@ -106,6 +118,18 @@ export function hasPasteableMedia(files: FileList | null | undefined): boolean {
     return !!files && Array.from(files).some(isPasteableMediaFile);
 }
 
+/**
+ * ⌘/Ctrl+Enter — the send shortcut. Plain Enter is deliberately excluded: it
+ * inserts a newline, and the emoji typeahead claims it while its popover is open.
+ */
+export function isSubmitShortcut(event: {
+    key: string;
+    metaKey: boolean;
+    ctrlKey: boolean;
+}): boolean {
+    return (event.metaKey || event.ctrlKey) && event.key === 'Enter';
+}
+
 function EditorBodyInner(
     {
         value,
@@ -113,6 +137,8 @@ function EditorBodyInner(
         onBlur,
         placeholder,
         autoFocus = false,
+        compact = false,
+        onSubmit,
         onPasteFiles,
         overrideBanner = false,
         activePlatformLabel,
@@ -153,10 +179,15 @@ function EditorBodyInner(
     // a ref so handlePaste always enforces the latest one-video / no-mixing rule.
     const onPasteFilesRef = useRef(onPasteFiles);
     onPasteFilesRef.current = onPasteFiles;
+    // Same reason as onPasteFilesRef: onSubmit reads the caller's current send
+    // state (text, uploads in flight), so it must not be frozen into editorProps.
+    const onSubmitRef = useRef(onSubmit);
+    onSubmitRef.current = onSubmit;
     const editor = useEditor({
         extensions: composerExtensions({
             placeholder,
             emojiOpenRef,
+            compact,
         }),
         content: segmentsToDoc(value) as object,
         editable,
@@ -168,6 +199,15 @@ function EditorBodyInner(
                 }
                 event.preventDefault();
                 onPasteFilesRef.current(files as FileList);
+
+                return true;
+            },
+            handleKeyDown: (_view, event) => {
+                if (!onSubmitRef.current || !isSubmitShortcut(event)) {
+                    return false;
+                }
+                event.preventDefault();
+                onSubmitRef.current();
 
                 return true;
             },
@@ -191,6 +231,12 @@ function EditorBodyInner(
         () => ({
             insertText: (text: string) => {
                 editor?.chain().focus().insertContent(text).run();
+            },
+            focus: () => {
+                editor?.commands.focus('end');
+            },
+            blur: () => {
+                editor?.commands.blur();
             },
         }),
         [editor],
@@ -502,10 +548,26 @@ function EditorBodyInner(
                 activeIndex={emoji.activeIndex}
                 onSelect={emoji.select}
             />
-            <div className="px-4 pt-[22px] pb-[18px] sm:px-[26px]">
+            <div
+                className={cn(
+                    compact
+                        ? 'px-3 py-2'
+                        : 'px-4 pt-[22px] pb-[18px] sm:px-[26px]',
+                )}
+            >
                 <EditorContent
                     editor={editor}
-                    className="max-w-none text-[16px] leading-5 tracking-[-0.005em] text-foreground focus:outline-none [&_.ProseMirror]:outline-none [&_.ProseMirror_p]:m-0 [&_.ProseMirror_p+p]:mt-0.5!"
+                    className={cn(
+                        'max-w-none leading-5 tracking-[-0.005em] text-foreground focus:outline-none [&_.ProseMirror]:outline-none [&_.ProseMirror_p]:m-0 [&_.ProseMirror_p+p]:mt-0.5!',
+                        compact
+                            ? // Replaces the old textarea's rows={3}: roughly three
+                              // lines tall, then scrolls instead of growing the pane.
+                              // The min-height sits on .ProseMirror, not this wrapper,
+                              // so the whole box is clickable-to-focus the way the
+                              // textarea it replaced was.
+                              'max-h-32 overflow-y-auto text-[14px] [&_.ProseMirror]:min-h-[3.75rem]'
+                            : 'text-[16px]',
+                    )}
                 />
             </div>
         </div>

--- a/resources/js/components/compose/emoji-popover.tsx
+++ b/resources/js/components/compose/emoji-popover.tsx
@@ -1,0 +1,127 @@
+import { Popover as PopoverPrimitive } from '@base-ui/react/popover';
+import type { ReactElement, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+
+import EmojiPicker from '@/components/compose/emoji-picker';
+import type { EmojiSkinTone } from '@/lib/compose/emoji/types';
+import { cn } from '@/lib/utils';
+
+type Props = {
+    /** Recently-used emoji, newest first. */
+    recents: string[];
+    skinTone: EmojiSkinTone;
+    onSkinToneChange: (tone: EmojiSkinTone) => void;
+    /** Insert the chosen emoji. The popover closes itself afterwards. */
+    onSelect: (emoji: string) => void;
+    /**
+     * The trigger element, supplied by the caller so each surface owns its own
+     * button shape. Receives the open state, since Base UI leaves it to the
+     * trigger to reflect (the composer tints a pill, the reply box does not).
+     * Pass a childless element and put its content in `children`, per the
+     * Base UI `render` convention used throughout the app.
+     */
+    trigger: (open: boolean) => ReactElement;
+    /** Content of the trigger (icon, label). */
+    children: ReactNode;
+    side?: 'top' | 'bottom';
+    align?: 'start' | 'end';
+};
+
+/**
+ * The emoji picker in a popover, with no knowledge of what it inserts into —
+ * shared by the composer toolbar and the engagement reply box.
+ */
+export function EmojiPopover({
+    recents,
+    skinTone,
+    onSkinToneChange,
+    onSelect,
+    trigger,
+    children,
+    side = 'top',
+    align = 'end',
+}: Props) {
+    const [open, setOpen] = useState(false);
+    // Mount the picker once and keep it alive. Frimousse re-reads and re-parses
+    // the ~775KB emoji dataset and rebuilds its store on every fresh mount, so
+    // unmounting on close (the default) made each reopen — and the select
+    // that closes it — sluggish. We warm it during browser idle (never on the
+    // click, which the parse would block) and Portal `keepMounted` keeps it
+    // alive; when closed it's hidden via a transition, not unmounted.
+    const [mounted, setMounted] = useState(false);
+    useEffect(() => {
+        if (mounted) {
+            return;
+        }
+        if (open) {
+            setMounted(true);
+
+            return;
+        }
+        const idle = window as Window & {
+            requestIdleCallback?: (callback: () => void) => number;
+            cancelIdleCallback?: (handle: number) => void;
+        };
+        if (typeof idle.requestIdleCallback === 'function') {
+            const handle = idle.requestIdleCallback(() => setMounted(true));
+
+            return () => idle.cancelIdleCallback?.(handle);
+        }
+        const handle = window.setTimeout(() => setMounted(true), 500);
+
+        return () => window.clearTimeout(handle);
+    }, [mounted, open]);
+
+    return (
+        <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+            <PopoverPrimitive.Trigger render={trigger(open)}>
+                {children}
+            </PopoverPrimitive.Trigger>
+            {mounted && (
+                <PopoverPrimitive.Portal keepMounted>
+                    <PopoverPrimitive.Positioner
+                        align={align}
+                        side={side}
+                        sideOffset={8}
+                        // While closed the kept-warm popover stays mounted and
+                        // positioned over the composer; make the positioner
+                        // click-through so it doesn't swallow clicks on the tab
+                        // strip / controls beneath it.
+                        className="isolate z-50 data-closed:pointer-events-none"
+                    >
+                        <PopoverPrimitive.Popup
+                            data-keep-warm=""
+                            initialFocus={false}
+                            className={cn(
+                                'z-50 w-[336px] overflow-hidden rounded-2xl bg-popover text-popover-foreground shadow-lg ring-1 ring-foreground/5 outline-hidden dark:ring-foreground/10',
+                                // Same fade+zoom feel as the notification bell, but
+                                // driven by a CSS transition instead of a keyframe
+                                // animate-in/-out. The picker is kept warm and
+                                // prewarmed while closed, so a keyframe `animate-out`
+                                // would flash it on that first hidden mount; a
+                                // transition only runs on real state changes.
+                                // opacity/transform are GPU-composited, so it stays
+                                // smooth on the heavy virtualized grid.
+                                'origin-(--transform-origin) transition-[opacity,transform] duration-100 ease-out',
+                                'data-open:scale-100 data-open:opacity-100',
+                                'data-closed:pointer-events-none data-closed:scale-95 data-closed:opacity-0',
+                            )}
+                        >
+                            <EmojiPicker
+                                recents={recents}
+                                skinTone={skinTone}
+                                onSkinToneChange={onSkinToneChange}
+                                onSelect={(emoji) => {
+                                    onSelect(emoji);
+                                    setOpen(false);
+                                }}
+                            />
+                        </PopoverPrimitive.Popup>
+                    </PopoverPrimitive.Positioner>
+                </PopoverPrimitive.Portal>
+            )}
+        </PopoverPrimitive.Root>
+    );
+}
+
+export default EmojiPopover;

--- a/resources/js/lib/compose/tiptap/__tests__/setup.test.ts
+++ b/resources/js/lib/compose/tiptap/__tests__/setup.test.ts
@@ -1,0 +1,107 @@
+import { getSchema } from '@tiptap/core';
+import { splitBlock } from '@tiptap/pm/commands';
+import { EditorState, TextSelection } from '@tiptap/pm/state';
+import { describe, expect, it } from 'vitest';
+
+import { docToSegments } from '@/lib/compose/tiptap-doc';
+import { composerExtensions } from '@/lib/compose/tiptap/setup';
+
+function names(opts?: Parameters<typeof composerExtensions>[0]): string[] {
+    return composerExtensions(opts).map((extension) => extension.name);
+}
+
+const compactSchema = getSchema(composerExtensions({ compact: true }));
+
+function para(text: string) {
+    return text === ''
+        ? { type: 'paragraph' }
+        : { type: 'paragraph', content: [{ type: 'text', text }] };
+}
+
+/**
+ * Split a paragraph in the compact schema and serialize the result. With
+ * SectionBreak absent nothing overrides Enter, so this is what Enter does.
+ */
+function splitAt(blocks: object[], cursor: number): string[] {
+    const doc = compactSchema.nodeFromJSON({ type: 'doc', content: blocks });
+    let state = EditorState.create({
+        schema: compactSchema,
+        doc,
+        selection: TextSelection.create(doc, cursor),
+    });
+
+    splitBlock(state, (tr) => {
+        state = state.apply(tr);
+    });
+
+    return docToSegments(state.doc.toJSON());
+}
+
+describe('composerExtensions', () => {
+    it('gives the composer the full thread + mention stack', () => {
+        expect(names()).toEqual(
+            expect.arrayContaining([
+                'sectionBreak',
+                'section_markers',
+                'mentionPlaceholders',
+                'emojiSuggest',
+            ]),
+        );
+    });
+
+    // Compact is the composer editor minus thread splitting: only SectionBreak
+    // and SectionMarkers come out. Neither is inert unconfigured (SectionBreak's
+    // keyboard shortcuts are always live; SectionMarkers defaults to
+    // bluesky/300/autoSplit), so a reply must leave them out entirely.
+    it('drops only the thread extensions in compact mode', () => {
+        const compact = names({ compact: true });
+
+        expect(compact).not.toContain('sectionBreak');
+        expect(compact).not.toContain('section_markers');
+    });
+
+    it('keeps the plain-text editor, mentions, and emoji typeahead in compact mode', () => {
+        expect(names({ compact: true })).toEqual(
+            expect.arrayContaining([
+                'doc',
+                'paragraph',
+                'text',
+                'link',
+                'placeholder',
+                'mentionPlaceholders',
+                'emojiSuggest',
+            ]),
+        );
+    });
+
+    it('leaves no sectionBreak node in the compact schema, so a reply is always one segment', () => {
+        expect(getSchema(composerExtensions()).nodes).toHaveProperty(
+            'sectionBreak',
+        );
+        expect(compactSchema.nodes).not.toHaveProperty('sectionBreak');
+    });
+});
+
+// The reply box adapts this editor to a plain string with `segments[0] ?? ''`.
+// That is only safe if a compact doc can never serialize to more than one
+// segment — otherwise the tail of a reply would be silently dropped on send.
+// The schema test above is what rules a second segment out; these cover the
+// everyday editing that produces extra paragraphs.
+describe('compact single-segment adapter', () => {
+    it('keeps a split paragraph in one newline-joined segment', () => {
+        // Caret at the end of "hello" (1 for the doc open + 5 chars).
+        expect(splitAt([para('hello')], 6)).toEqual(['hello\n']);
+    });
+
+    it('keeps a blank line inside the one segment', () => {
+        const blocks = [para('hello'), para('')];
+        const doc = compactSchema.nodeFromJSON({
+            type: 'doc',
+            content: blocks,
+        });
+        // Inside the trailing empty paragraph.
+        const cursor = doc.child(0).nodeSize + 1;
+
+        expect(splitAt(blocks, cursor)).toEqual(['hello\n\n']);
+    });
+});

--- a/resources/js/lib/compose/tiptap/setup.ts
+++ b/resources/js/lib/compose/tiptap/setup.ts
@@ -15,11 +15,20 @@ import { SectionMarkers } from './section-markers';
  * editor (Document/Paragraph/Text/UndoRedo/Placeholder/Link) plus the custom
  * SectionBreak node and SectionMarkers decoration plugin. The old product's
  * Mention/Hashtag extensions are intentionally dropped (out of scope).
+ *
+ * `compact` builds the single-message variant used by the engagement reply box:
+ * the full composer editor minus thread splitting. It drops only SectionBreak and
+ * SectionMarkers — a reply is one message, not a thread — and keeps everything
+ * else, including MentionPlaceholders and the emoji typeahead. Dropping
+ * SectionBreak also means the doc can never hold a `sectionBreak` node, so
+ * `docToSegments` always returns exactly one segment — which is what lets the
+ * reply box adapt this editor to a plain string.
  */
 export function composerExtensions(
     opts: {
         placeholder?: string;
         emojiOpenRef?: { current: boolean } | null;
+        compact?: boolean;
     } = {},
 ): Extensions {
     return [
@@ -35,9 +44,9 @@ export function composerExtensions(
             autolink: true,
             linkOnPaste: true,
         }),
-        SectionBreak,
+        ...(opts.compact ? [] : [SectionBreak]),
         MentionPlaceholders,
         EmojiSuggest.configure({ openRef: opts.emojiOpenRef ?? null }),
-        SectionMarkers,
+        ...(opts.compact ? [] : [SectionMarkers]),
     ];
 }

--- a/resources/js/pages/engagement/components/quick-reply-box.test.ts
+++ b/resources/js/pages/engagement/components/quick-reply-box.test.ts
@@ -13,6 +13,7 @@ vi.mock('./use-reply-media', () => ({
         dropHandlers: {},
         editor: null,
         fileInput: null,
+        handleAddedFiles: vi.fn(),
         isUploading: false,
         openFilePicker: vi.fn(),
     }),
@@ -46,5 +47,5 @@ it('blurs the reply field on Escape so triage shortcuts work again', () => {
     );
 
     expect(source).toContain("e.key === 'Escape'");
-    expect(source).toContain('e.currentTarget.blur()');
+    expect(source).toContain('editorRef.current?.blur()');
 });

--- a/resources/js/pages/engagement/components/quick-reply-box.tsx
+++ b/resources/js/pages/engagement/components/quick-reply-box.tsx
@@ -1,18 +1,37 @@
-import { Paperclip } from 'lucide-react';
-import { useState, type Ref } from 'react';
+import { useHttp } from '@inertiajs/react';
+import { Paperclip, Smile } from 'lucide-react';
+import { useEffect, useRef, useState, type RefObject } from 'react';
 
+import WorkspaceMentionController from '@/actions/App/Http/Controllers/WorkspaceMentionController';
+import EditorBody, {
+    type EditorBodyHandle,
+} from '@/components/compose/editor-body';
+import { EmojiPopover } from '@/components/compose/emoji-popover';
 import { Button } from '@/components/ui/button';
 import { Kbd } from '@/components/ui/kbd';
-import { Textarea } from '@/components/ui/textarea';
 import {
     Tooltip,
     TooltipContent,
     TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { useEmojiPreferences } from '@/hooks/compose/use-emoji-preferences';
+import {
+    replaceMentionLabel,
+    replaceMentionTokens,
+    savedMentionToPlaceholder,
+    syncMentionsFromText,
+    type MentionPlaceholder,
+} from '@/lib/compose/mentions';
 import { cn } from '@/lib/utils';
-import type { MediaView, PlatformName } from '@/types/compose';
+import type {
+    MediaView,
+    PlatformName,
+    WorkspaceMention,
+} from '@/types/compose';
 
 import { useReplyMedia } from './use-reply-media';
+
+const EMPTY_SAVED_MENTIONS: WorkspaceMention[] = [];
 
 const LIMITS: Record<string, number> = { x: 280, bluesky: 300, linkedin: 3000 };
 export const QUICK_REPLY_SEND_SHORTCUT = '⌘/Ctrl↵';
@@ -24,7 +43,9 @@ type Props = {
     maxLength?: number;
     disabled?: boolean;
     disabledReason?: string;
-    textareaRef?: Ref<HTMLTextAreaElement>;
+    editorRef?: RefObject<EditorBodyHandle | null>;
+    /** Workspace saved-mention library, shared with the composer's picker. */
+    savedMentions?: WorkspaceMention[];
     onSend: (text: string, mediaIds: string[]) => Promise<void>;
 };
 
@@ -35,19 +56,90 @@ export function QuickReplyBox({
     maxLength,
     disabled,
     disabledReason,
-    textareaRef,
+    editorRef: editorRefProp,
+    savedMentions: initialSavedMentions = EMPTY_SAVED_MENTIONS,
     onSend,
 }: Props) {
     const [text, setText] = useState('');
     const [sending, setSending] = useState(false);
     const [media, setMedia] = useState<MediaView[]>([]);
+    const [mentions, setMentions] = useState<MentionPlaceholder[]>([]);
+    const [savedMentions, setSavedMentions] = useState(initialSavedMentions);
+    useEffect(() => {
+        setSavedMentions(initialSavedMentions);
+    }, [initialSavedMentions]);
+    const saveMentionHttp = useHttp<
+        Record<string, never>,
+        { mention: WorkspaceMention }
+    >({});
 
     const rm = useReplyMedia({ replyId, platform, media, onChange: setMedia });
 
+    // The parent drives focus (the "r" triage shortcut) through this handle; when
+    // it doesn't pass one we fall back to a local ref so emoji insertion still
+    // works.
+    const fallbackEditorRef = useRef<EditorBodyHandle>(null);
+    const editorRef = editorRefProp ?? fallbackEditorRef;
+    const emojiPrefs = useEmojiPreferences();
+
+    function insertEmoji(emoji: string) {
+        editorRef.current?.insertText(emoji);
+        emojiPrefs.addRecent(emoji);
+    }
+
+    // Keep the mention list reconciled with the text as the user types, mirroring
+    // the composer's syncMentions — minus the segment/override machinery, since a
+    // reply is a single plain string.
+    function handleText(next: string) {
+        setText(next);
+        setMentions((current) =>
+            syncMentionsFromText(next, current, savedMentions),
+        );
+    }
+
+    // Rename a mention (via the picker) in both the text and the mention list.
+    // Setting the text re-drives the editor through EditorBody's external-sync
+    // effect, so no separate editor mutation is needed.
+    function renameMention(
+        mention: MentionPlaceholder,
+        next: MentionPlaceholder,
+    ) {
+        setText((current) =>
+            replaceMentionLabel(current, mention.label, next.label),
+        );
+        setMentions((current) =>
+            current.map((item) => (item.id === mention.id ? next : item)),
+        );
+    }
+
+    async function saveMention(mention: MentionPlaceholder): Promise<void> {
+        saveMentionHttp.transform(() => ({
+            name: mention.label,
+            handles: mention.handles,
+        }));
+        const response = await saveMentionHttp.post(
+            WorkspaceMentionController.store().url,
+        );
+        setSavedMentions((current) => {
+            const others = current.filter(
+                (item) =>
+                    item.id !== response.mention.id &&
+                    item.name !== response.mention.name,
+            );
+
+            return [...others, response.mention].sort((left, right) =>
+                left.name.localeCompare(right.name),
+            );
+        });
+    }
+
+    // What actually gets sent: mention labels resolved to this platform's handle.
+    // Char counting also uses the resolved text so the count matches the payload.
+    const outgoing = replaceMentionTokens(text, mentions, platform);
     const limit = maxLength ?? LIMITS[platform] ?? 280;
-    const remaining = limit - text.length;
+    const remaining = limit - outgoing.length;
     const tooLong = remaining < 0;
-    const empty = text.trim() === '' && media.length === 0;
+    const empty = outgoing.trim() === '' && media.length === 0;
     const canSend = !empty && !tooLong && !sending && !rm.isUploading;
 
     async function send() {
@@ -57,11 +149,12 @@ export function QuickReplyBox({
         setSending(true);
         try {
             await onSend(
-                text,
+                outgoing,
                 media.map((m) => m.id),
             );
             setText('');
             setMedia([]);
+            setMentions([]);
         } finally {
             setSending(false);
         }
@@ -74,27 +167,54 @@ export function QuickReplyBox({
         >
             {rm.fileInput}
 
-            <Textarea
-                ref={textareaRef}
-                value={text}
-                disabled={disabled || sending}
-                onChange={(e) => setText(e.target.value)}
+            {/* The editor is styling-dumb, so the box owns the border/ring the
+                <Textarea> used to bring with it. */}
+            <div
+                className={cn(
+                    'rounded-xl border border-input bg-transparent shadow-xs transition-[color,box-shadow]',
+                    'focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50',
+                    (disabled || sending) && 'cursor-not-allowed opacity-50',
+                )}
                 onKeyDown={(e) => {
+                    // Escape releases the editor so the j/k/r/a triage shortcuts
+                    // work again without a stray keystroke landing in the reply.
                     if (e.key === 'Escape') {
-                        e.currentTarget.blur();
-                        return;
-                    }
-
-                    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-                        void send();
+                        editorRef.current?.blur();
                     }
                 }}
-                placeholder={
-                    replyingTo ? `Reply to ${replyingTo}…` : 'Write a reply…'
-                }
-                rows={3}
-                className="min-h-0 resize-none rounded-xl"
-            />
+            >
+                <EditorBody
+                    ref={editorRef}
+                    compact
+                    // Compact mode drops SectionBreak, so the doc can never hold a
+                    // section break and docToSegments always returns exactly one
+                    // segment — hence the plain-string adapter.
+                    value={[text]}
+                    onChange={(segments) => handleText(segments[0] ?? '')}
+                    editable={!disabled && !sending}
+                    onSubmit={() => void send()}
+                    onPasteFiles={rm.handleAddedFiles}
+                    emojiSkinTone={emojiPrefs.skinTone}
+                    onEmojiInsert={emojiPrefs.addRecent}
+                    // The composer's @-mention picker, scoped to this reply's one
+                    // platform. Resolution happens client-side on send (outgoing).
+                    mentions={mentions}
+                    mentionPlatforms={[platform]}
+                    savedMentions={savedMentions}
+                    onMentionsChange={setMentions}
+                    onMentionNameChange={renameMention}
+                    onApplySavedMention={(mention, saved) =>
+                        renameMention(mention, savedMentionToPlaceholder(saved))
+                    }
+                    onSaveMention={saveMention}
+                    saveMentionProcessing={saveMentionHttp.processing}
+                    placeholder={
+                        replyingTo
+                            ? `Reply to ${replyingTo}…`
+                            : 'Write a reply…'
+                    }
+                />
+            </div>
 
             {rm.chips ? <div className="mt-2">{rm.chips}</div> : null}
 
@@ -111,6 +231,32 @@ export function QuickReplyBox({
                 >
                     <Paperclip className="size-4" aria-hidden="true" />
                 </Button>
+
+                <EmojiPopover
+                    recents={emojiPrefs.recents}
+                    skinTone={emojiPrefs.skinTone}
+                    onSkinToneChange={emojiPrefs.setSkinTone}
+                    onSelect={insertEmoji}
+                    side="top"
+                    align="start"
+                    trigger={(open) => (
+                        <button
+                            type="button"
+                            aria-label="Insert emoji"
+                            title="Insert emoji"
+                            disabled={disabled || sending}
+                            data-active={open}
+                            className={cn(
+                                'inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors',
+                                'hover:bg-accent hover:text-foreground',
+                                'data-[active=true]:bg-accent data-[active=true]:text-foreground',
+                                'disabled:pointer-events-none disabled:opacity-50',
+                            )}
+                        />
+                    )}
+                >
+                    <Smile className="size-4" aria-hidden="true" />
+                </EmojiPopover>
 
                 {rm.isUploading ? (
                     <span className="text-[11px] text-muted-foreground">

--- a/resources/js/pages/engagement/components/use-reply-media.tsx
+++ b/resources/js/pages/engagement/components/use-reply-media.tsx
@@ -61,6 +61,12 @@ type ReplyMedia = {
         onDragOver: (e: React.DragEvent) => void;
         onDrop: (e: React.DragEvent) => void;
     };
+    /**
+     * Validate + attach a batch of files. Exposed for surfaces that source files
+     * themselves rather than through the picker or drop handlers — the editor's
+     * paste-to-upload passes its clipboard FileList straight in.
+     */
+    handleAddedFiles: (files: FileList | File[]) => Promise<void>;
 };
 
 function blobToFile(blob: Blob, name: string): File {
@@ -380,5 +386,6 @@ export function useReplyMedia({
                 }
             },
         },
+        handleAddedFiles,
     };
 }

--- a/resources/js/pages/engagement/index.test.ts
+++ b/resources/js/pages/engagement/index.test.ts
@@ -31,7 +31,7 @@ it('pins the engagement desk to the viewport and keeps the reply box in-flow', (
     expect(source).toContain('h-[calc(100svh-4rem)]');
     expect(source).toContain('overflow-hidden');
     expect(source).toContain('min-h-0 min-w-0 flex-col overflow-hidden');
-    expect(source).toContain('replyTextareaRef');
+    expect(source).toContain('replyEditorRef');
 });
 
 it('wires keyboard shortcuts for triage, archive, open comment, and reply focus', () => {
@@ -42,7 +42,7 @@ it('wires keyboard shortcuts for triage, archive, open comment, and reply focus'
     expect(source).toContain("case 'open'");
     expect(source).toContain("case 'reply'");
     expect(source).toContain('openSelectedComment');
-    expect(source).toContain('replyTextareaRef.current?.focus()');
+    expect(source).toContain('replyEditorRef.current?.focus()');
     expect(source).toContain('<Kbd>A</Kbd>');
     expect(source).toContain("keys={['↑', '↓']}");
     expect(source).toContain("keys={['O']}");

--- a/resources/js/pages/engagement/index.tsx
+++ b/resources/js/pages/engagement/index.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef, useState, type RefObject } from 'react';
 
 import ComposerController from '@/actions/App/Http/Controllers/Posts/ComposerController';
 import { PlatformGlyph } from '@/components/common/platform-glyph';
+import { type EditorBodyHandle } from '@/components/compose/editor-body';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import {
@@ -51,7 +52,7 @@ import {
     thread as threadRoute,
     unlike as unlikeRoute,
 } from '@/routes/engagement';
-import type { PlatformName } from '@/types/compose';
+import type { PlatformName, WorkspaceMention } from '@/types/compose';
 
 import { QuickReplyBox } from './components/quick-reply-box';
 import { ReplyFilters } from './components/reply-filters';
@@ -76,6 +77,7 @@ type PageProps = {
     filters: EngagementFilters;
     facets: { accounts: AccountFacet[]; posts: PostFacet[] };
     engagementEnabled: Record<PlatformName, boolean>;
+    savedMentions: WorkspaceMention[];
 };
 
 function StreamSkeleton() {
@@ -200,14 +202,16 @@ function EngagementDisabledBanner({
 type RightPaneProps = {
     selected: ReplyItem;
     onArchived: () => void;
-    replyTextareaRef?: RefObject<HTMLTextAreaElement | null>;
+    replyEditorRef?: RefObject<EditorBodyHandle | null>;
+    savedMentions: WorkspaceMention[];
     reserveCloseButtonSpace?: boolean;
 };
 
 function RightPane({
     selected,
     onArchived,
-    replyTextareaRef,
+    replyEditorRef,
+    savedMentions,
     reserveCloseButtonSpace = false,
 }: RightPaneProps) {
     const [thread, setThread] = useState<ReplyItem[]>([]);
@@ -491,7 +495,12 @@ function RightPane({
                 onDelete={remove}
             />
 
+            {/* Key by conversation so switching replies gives a fresh draft:
+                remounting clears the editor text, mentions, and in-flight media
+                (all local state, incl. useReplyMedia's) instead of carrying the
+                previous conversation's reply over. */}
             <QuickReplyBox
+                key={selected.id}
                 replyId={selected.id}
                 platform={selected.platform}
                 replyingTo={atHandle(selected.author_handle)}
@@ -502,7 +511,8 @@ function RightPane({
                         ? 'This account is disabled in the workspace. Enable it in Accounts to reply.'
                         : undefined
                 }
-                textareaRef={replyTextareaRef}
+                editorRef={replyEditorRef}
+                savedMentions={savedMentions}
                 onSend={send}
             />
         </div>
@@ -514,10 +524,11 @@ export default function EngagementIndex({
     filters,
     facets,
     engagementEnabled,
+    savedMentions,
 }: PageProps) {
     const isMobile = useIsMobile();
     const [selected, setSelected] = useState<ReplyItem | null>(null);
-    const replyTextareaRef = useRef<HTMLTextAreaElement>(null);
+    const replyEditorRef = useRef<EditorBodyHandle>(null);
 
     const items = replies?.data ?? [];
     const disabledPlatforms = disabledPlatformLabels(engagementEnabled);
@@ -596,7 +607,7 @@ export default function EngagementIndex({
             return;
         }
 
-        replyTextareaRef.current?.focus();
+        replyEditorRef.current?.focus();
     }
 
     function openSelectedComment() {
@@ -711,7 +722,8 @@ export default function EngagementIndex({
                                         ),
                                     )
                                 }
-                                replyTextareaRef={replyTextareaRef}
+                                replyEditorRef={replyEditorRef}
+                                savedMentions={savedMentions}
                             />
                         ) : allEngagementDisabled ? (
                             <EngagementDisabledNotice />
@@ -750,7 +762,8 @@ export default function EngagementIndex({
                                         ),
                                     )
                                 }
-                                replyTextareaRef={replyTextareaRef}
+                                replyEditorRef={replyEditorRef}
+                                savedMentions={savedMentions}
                                 reserveCloseButtonSpace
                             />
                         ) : null}


### PR DESCRIPTION
## Summary
- Replace the quick reply box's plain `<textarea>` with the composer's rich-text editor in a new compact mode, bringing feature parity between composing and replying
- Add an emoji picker to the reply box, extracted from the composer toolbar into a shared `EmojiPopover` component used by both surfaces
- Add @-mention support to replies, including the workspace's saved-mention library (now returned by the engagement index endpoint) and the ability to save new mentions from the reply box
- Add paste-to-upload support for images/video pasted directly into the reply editor
- Keep ⌘/Ctrl+Enter as the send shortcut while leaving plain Enter free for newlines and the emoji typeahead
- Reply drafts (text, mentions, in-flight media) now reset when switching between conversations
