### PR TITLE
fix(engagement): only treat pasted images as images

### DIFF
--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -42,8 +42,8 @@ type EditorBodyProps = {
     /** When false, the post is read-only (e.g. already published/scheduled). */
     editable?: boolean;
     /**
-     * Single-message variant (the engagement reply box): drops the thread and
-     * mention extensions and shrinks the type scale. See `composerExtensions`
+     * Single-message variant (the engagement reply box): drops the thread
+     * extensions and shrinks the type scale. See `composerExtensions`
      * for why the extensions must be omitted rather than left unconfigured.
      */
     compact?: boolean;

--- a/resources/js/pages/engagement/components/use-reply-media.tsx
+++ b/resources/js/pages/engagement/components/use-reply-media.tsx
@@ -248,7 +248,10 @@ export function useReplyMedia({
         }
 
         const videos = all.filter((f) => f.type.startsWith('video/'));
-        const images = all.filter((f) => !f.type.startsWith('video/'));
+        // The paste path supplies raw clipboard batches, so filter to real images
+        // rather than "anything non-video" — otherwise a pasted PDF is queued into
+        // the crop/beautify editor as if it were an image.
+        const images = all.filter((f) => f.type.startsWith('image/'));
 
         if (wouldMixVideoAndImages(media, all)) {
             toast.error('A reply can contain one video or images, not both.');


### PR DESCRIPTION


Address CodeRabbit review on #93:
- use-reply-media: filter pasted clipboard batches to image/* instead of non-video/*, so a pasted PDF is no longer queued into the crop editor
- editor-body: compact mode keeps MentionPlaceholders (mentions were added in #93); drop the stale 'and mention' claim from the JSDoc