### PR TITLE
feat(metrics): add age-banded polling with unchanged-streak backoff

### DIFF
--- a/app/Console/Commands/CaptureMetrics.php
+++ b/app/Console/Commands/CaptureMetrics.php
@@ -24,7 +24,7 @@ class CaptureMetrics extends Command
 
     public function handle(MetricsCaptureCadence $cadence, InstanceSettings $settings): int
     {
-        if (! config('metrics.enabled')) {
+        if (! $settings->metricsEnabled()) {
             return self::SUCCESS;
         }
 

--- a/app/Console/Commands/DispatchDueReplyFetches.php
+++ b/app/Console/Commands/DispatchDueReplyFetches.php
@@ -26,7 +26,7 @@ class DispatchDueReplyFetches extends Command
 
     public function handle(InstanceSettings $settings, ReplyFetchCadence $cadence, EngagementConnectorRegistry $registry): int
     {
-        if (! config('engagement.enabled') || ! $settings->engagementPollingEnabled()) {
+        if (! $settings->engagementEnabled() || ! $settings->engagementPollingEnabled()) {
             return self::SUCCESS;
         }
 

--- a/app/Http/Controllers/Posts/ComposerController.php
+++ b/app/Http/Controllers/Posts/ComposerController.php
@@ -63,7 +63,7 @@ class ComposerController extends Controller
                 ->get()
                 ->map(fn (WorkspaceMention $mention): array => WorkspaceMentionController::view($mention))
                 ->all(),
-            'stats' => config('metrics.enabled')
+            'stats' => $settings->metricsEnabled()
                 ? Inertia::defer(fn (): ?array => $post->targets()
                     ->where('status', PostTargetStatus::Published->value)
                     ->exists()

--- a/app/Http/Controllers/Posts/PostMetricsRefreshController.php
+++ b/app/Http/Controllers/Posts/PostMetricsRefreshController.php
@@ -17,7 +17,7 @@ class PostMetricsRefreshController extends Controller
 {
     public function store(Request $request, Post $post): JsonResponse
     {
-        $request->user()->can('viewAny', Post::class) ?: abort(403);
+        $request->user()->can('view', $post) ?: abort(403);
 
         $post->targets()
             ->where('status', PostTargetStatus::Published->value)

--- a/app/Http/Middleware/EnsureEngagementEnabled.php
+++ b/app/Http/Middleware/EnsureEngagementEnabled.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Support\InstanceSettings;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -12,7 +13,7 @@ class EnsureEngagementEnabled
 {
     public function handle(Request $request, Closure $next): Response
     {
-        abort_unless((bool) config('engagement.enabled'), 404);
+        abort_unless(app(InstanceSettings::class)->engagementEnabled(), 404);
 
         return $next($request);
     }

--- a/app/Http/Middleware/EnsureMetricsEnabled.php
+++ b/app/Http/Middleware/EnsureMetricsEnabled.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Support\InstanceSettings;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -12,7 +13,7 @@ class EnsureMetricsEnabled
 {
     public function handle(Request $request, Closure $next): Response
     {
-        abort_unless((bool) config('metrics.enabled'), 404);
+        abort_unless(app(InstanceSettings::class)->metricsEnabled(), 404);
 
         return $next($request);
     }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -70,9 +70,9 @@ class HandleInertiaRequests extends Middleware
             ],
             'notifications' => $this->notificationsData($request->user()),
             'features' => [
-                'analytics' => (bool) config('metrics.enabled'),
+                'analytics' => app(InstanceSettings::class)->metricsEnabled(),
                 'billing' => (bool) config('subscriptions.enabled'),
-                'engagement' => (bool) config('engagement.enabled'),
+                'engagement' => app(InstanceSettings::class)->engagementEnabled(),
             ],
             'instance' => [
                 'isOwner' => $request->user()?->isInstanceOwner() ?? false,
@@ -136,7 +136,7 @@ class HandleInertiaRequests extends Middleware
             'accounts' => $accounts,
             'sets' => $sets,
             'limits' => Platform::allLimits(),
-            'unreadReplies' => config('engagement.enabled') && app(InstanceSettings::class)->engagementPollingEnabled()
+            'unreadReplies' => $settings->engagementEnabled() && $settings->engagementPollingEnabled()
                 ? PostTargetReply::query()
                     ->where('workspace_id', $workspaceId)
                     ->where('is_ours', false)

--- a/app/Http/Requests/Settings/UpdateInstancePollingSettingsRequest.php
+++ b/app/Http/Requests/Settings/UpdateInstancePollingSettingsRequest.php
@@ -25,7 +25,10 @@ class UpdateInstancePollingSettingsRequest extends FormRequest
      */
     public function rules(): array
     {
-        $rules = [];
+        $rules = [
+            'metrics_enabled' => ['required', 'boolean'],
+            'engagement_enabled' => ['required', 'boolean'],
+        ];
 
         foreach (['engagement', 'post_metrics', 'account_metrics'] as $section) {
             $rules[$section] = ['required', 'array'];
@@ -48,11 +51,13 @@ class UpdateInstancePollingSettingsRequest extends FormRequest
      *     engagement_poll_interval_minutes: array<string, int>,
      *     post_metrics_poll_interval_minutes: array<string, int>,
      *     account_metrics_poll_interval_minutes: array<string, int>,
+     *     metrics_enabled: bool,
+     *     engagement_enabled: bool,
      * }
      */
     public function instancePollingSettings(): array
     {
-        /** @var array{engagement: array<string, mixed>, post_metrics: array<string, mixed>, account_metrics: array<string, mixed>} $validated */
+        /** @var array{engagement: array<string, mixed>, post_metrics: array<string, mixed>, account_metrics: array<string, mixed>, metrics_enabled: mixed, engagement_enabled: mixed} $validated */
         $validated = $this->validated();
 
         return [
@@ -62,6 +67,8 @@ class UpdateInstancePollingSettingsRequest extends FormRequest
             'engagement_poll_interval_minutes' => $this->minutes($validated['engagement']),
             'post_metrics_poll_interval_minutes' => $this->minutes($validated['post_metrics']),
             'account_metrics_poll_interval_minutes' => $this->minutes($validated['account_metrics']),
+            'metrics_enabled' => (bool) $validated['metrics_enabled'],
+            'engagement_enabled' => (bool) $validated['engagement_enabled'],
         ];
     }
 

--- a/app/Jobs/CaptureAccountMetrics.php
+++ b/app/Jobs/CaptureAccountMetrics.php
@@ -11,6 +11,7 @@ use App\Models\AccountMetric;
 use App\Models\ConnectedAccount;
 use App\Services\Metrics\MetricsConnectorRegistry;
 use App\Services\Publishing\TokenManager;
+use App\Support\InstanceSettings;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -63,9 +64,9 @@ class CaptureAccountMetrics implements ShouldBeUnique, ShouldQueue
         return [10, 30, 60];
     }
 
-    public function handle(MetricsConnectorRegistry $registry, TokenManager $tokens): void
+    public function handle(MetricsConnectorRegistry $registry, TokenManager $tokens, InstanceSettings $settings): void
     {
-        if (! config('metrics.enabled')) {
+        if (! $settings->metricsEnabled()) {
             return;
         }
 

--- a/app/Jobs/CapturePostTargetMetrics.php
+++ b/app/Jobs/CapturePostTargetMetrics.php
@@ -96,6 +96,12 @@ class CapturePostTargetMetrics implements ShouldBeUnique, ShouldQueue
         if ($result->isOk()) {
             $now = Date::now();
 
+            $unchanged = $target->metrics_captured_at !== null
+                && $target->likes === $result->likes
+                && $target->comments === $result->comments
+                && $target->reposts === $result->reposts
+                && $target->impressions === $result->impressions;
+
             PostTargetMetric::updateOrCreate(
                 ['post_target_id' => $target->id, 'captured_at' => $now],
                 [
@@ -113,6 +119,7 @@ class CapturePostTargetMetrics implements ShouldBeUnique, ShouldQueue
                 'impressions' => $result->impressions,
                 'metrics_status' => $result->status->value,
                 'metrics_captured_at' => $now,
+                'metrics_unchanged_streak' => $unchanged ? $target->metrics_unchanged_streak + 1 : 0,
             ])->save();
 
             return;

--- a/app/Jobs/CapturePostTargetMetrics.php
+++ b/app/Jobs/CapturePostTargetMetrics.php
@@ -11,6 +11,7 @@ use App\Models\PostTarget;
 use App\Models\PostTargetMetric;
 use App\Services\Metrics\MetricsConnectorRegistry;
 use App\Services\Publishing\TokenManager;
+use App\Support\InstanceSettings;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -63,9 +64,9 @@ class CapturePostTargetMetrics implements ShouldBeUnique, ShouldQueue
         return [10, 30, 60];
     }
 
-    public function handle(MetricsConnectorRegistry $registry, TokenManager $tokens): void
+    public function handle(MetricsConnectorRegistry $registry, TokenManager $tokens, InstanceSettings $settings): void
     {
-        if (! config('metrics.enabled')) {
+        if (! $settings->metricsEnabled()) {
             return;
         }
 

--- a/app/Jobs/FetchAccountReplies.php
+++ b/app/Jobs/FetchAccountReplies.php
@@ -19,6 +19,7 @@ use App\Services\Engagement\EngagementConnectorRegistry;
 use App\Services\Engagement\ReplyFetchCadence;
 use App\Services\Engagement\ReplyPersister;
 use App\Services\Publishing\TokenManager;
+use App\Support\InstanceSettings;
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -69,8 +70,9 @@ class FetchAccountReplies implements ReleasableJob, ShouldBeUnique, ShouldQueue
         TokenManager $tokens,
         ReplyPersister $persister,
         ReplyFetchCadence $cadence,
+        InstanceSettings $settings,
     ): void {
-        if (! config('engagement.enabled')) {
+        if (! $settings->engagementEnabled()) {
             return;
         }
 

--- a/app/Jobs/FetchPostTargetReplies.php
+++ b/app/Jobs/FetchPostTargetReplies.php
@@ -14,6 +14,7 @@ use App\Models\PostTargetReply;
 use App\Services\Engagement\EngagementConnectorRegistry;
 use App\Services\Engagement\ReplyPersister;
 use App\Services\Publishing\TokenManager;
+use App\Support\InstanceSettings;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -65,9 +66,9 @@ class FetchPostTargetReplies implements ReleasableJob, ShouldBeUnique, ShouldQue
         return [10, 30, 60];
     }
 
-    public function handle(EngagementConnectorRegistry $registry, TokenManager $tokens, ReplyPersister $persister): void
+    public function handle(EngagementConnectorRegistry $registry, TokenManager $tokens, ReplyPersister $persister, InstanceSettings $settings): void
     {
-        if (! config('engagement.enabled')) {
+        if (! $settings->engagementEnabled()) {
             return;
         }
 

--- a/app/Models/PostTarget.php
+++ b/app/Models/PostTarget.php
@@ -42,6 +42,7 @@ use Override;
  * @property int|null $impressions
  * @property CarbonImmutable|null $metrics_captured_at
  * @property MetricsStatus|null $metrics_status
+ * @property int $metrics_unchanged_streak
  * @property CarbonImmutable|null $reply_fetched_at
  * @property int $reply_fetch_empty_streak
  */
@@ -68,6 +69,7 @@ use Override;
     'impressions',
     'metrics_captured_at',
     'metrics_status',
+    'metrics_unchanged_streak',
     'reply_fetched_at',
     'reply_fetch_empty_streak',
 ])]
@@ -100,6 +102,7 @@ class PostTarget extends Model
             'impressions' => 'integer',
             'metrics_captured_at' => 'immutable_datetime',
             'metrics_status' => MetricsStatus::class,
+            'metrics_unchanged_streak' => 'integer',
             'reply_fetched_at' => 'immutable_datetime',
             'reply_fetch_empty_streak' => 'integer',
         ];

--- a/app/Services/Metrics/Connectors/BlueskyMetricsConnector.php
+++ b/app/Services/Metrics/Connectors/BlueskyMetricsConnector.php
@@ -38,7 +38,7 @@ class BlueskyMetricsConnector implements MetricsConnector
         ));
 
         try {
-            $response = $this->http->acceptJson()->get(self::APPVIEW.'/xrpc/app.bsky.feed.getPosts?'.$query);
+            $response = $this->http->timeout(10)->connectTimeout(5)->acceptJson()->get(self::APPVIEW.'/xrpc/app.bsky.feed.getPosts?'.$query);
         } catch (ConnectionException $e) {
             return PostMetricsResult::failed($e->getMessage());
         }
@@ -72,7 +72,7 @@ class BlueskyMetricsConnector implements MetricsConnector
     public function fetchAccount(ConnectedAccount $account, array $credentials): AccountMetricsResult
     {
         try {
-            $response = $this->http->acceptJson()->get(self::APPVIEW.'/xrpc/app.bsky.actor.getProfile', [
+            $response = $this->http->timeout(10)->connectTimeout(5)->acceptJson()->get(self::APPVIEW.'/xrpc/app.bsky.actor.getProfile', [
                 'actor' => $account->remote_account_id,
             ]);
         } catch (ConnectionException $e) {

--- a/app/Services/Metrics/Connectors/FacebookMetricsConnector.php
+++ b/app/Services/Metrics/Connectors/FacebookMetricsConnector.php
@@ -39,6 +39,8 @@ class FacebookMetricsConnector implements MetricsConnector
 
         try {
             $response = $this->http
+                ->timeout(10)
+                ->connectTimeout(5)
                 ->acceptJson()
                 ->get($this->baseUrl().'/'.$postId, [
                     'fields' => 'likes.summary(true),comments.summary(true),shares',
@@ -70,6 +72,8 @@ class FacebookMetricsConnector implements MetricsConnector
     {
         try {
             $response = $this->http
+                ->timeout(10)
+                ->connectTimeout(5)
                 ->acceptJson()
                 ->get($this->baseUrl().'/'.$postId.'/insights', [
                     'metric' => 'post_impressions',
@@ -94,6 +98,8 @@ class FacebookMetricsConnector implements MetricsConnector
     {
         try {
             $response = $this->http
+                ->timeout(10)
+                ->connectTimeout(5)
                 ->acceptJson()
                 ->get($this->baseUrl().'/'.$account->remote_account_id, [
                     'fields' => 'followers_count,fan_count',

--- a/app/Services/Metrics/Connectors/InstagramMetricsConnector.php
+++ b/app/Services/Metrics/Connectors/InstagramMetricsConnector.php
@@ -39,6 +39,8 @@ class InstagramMetricsConnector implements MetricsConnector
 
         try {
             $response = $this->http
+                ->timeout(10)
+                ->connectTimeout(5)
                 ->acceptJson()
                 ->get($this->baseUrl().'/'.$mediaId.'/insights', [
                     'metric' => 'likes,comments,saved,shares,reach,views',
@@ -91,6 +93,8 @@ class InstagramMetricsConnector implements MetricsConnector
     {
         try {
             $response = $this->http
+                ->timeout(10)
+                ->connectTimeout(5)
                 ->acceptJson()
                 ->get($this->baseUrl().'/'.$account->remote_account_id, [
                     'fields' => 'followers_count,media_count',

--- a/app/Services/Metrics/Connectors/ThreadsMetricsConnector.php
+++ b/app/Services/Metrics/Connectors/ThreadsMetricsConnector.php
@@ -36,6 +36,8 @@ class ThreadsMetricsConnector implements MetricsConnector
 
         try {
             $response = $this->http
+                ->timeout(10)
+                ->connectTimeout(5)
                 ->acceptJson()
                 ->get(self::BASE_URL.'/'.$mediaId.'/insights', [
                     'metric' => 'views,likes,replies,reposts,quotes,shares',
@@ -80,6 +82,8 @@ class ThreadsMetricsConnector implements MetricsConnector
     {
         try {
             $response = $this->http
+                ->timeout(10)
+                ->connectTimeout(5)
                 ->acceptJson()
                 ->get(self::BASE_URL.'/'.$account->remote_account_id.'/threads_insights', [
                     'metric' => 'followers_count',

--- a/app/Services/Metrics/Connectors/XMetricsConnector.php
+++ b/app/Services/Metrics/Connectors/XMetricsConnector.php
@@ -34,6 +34,8 @@ class XMetricsConnector implements MetricsConnector
 
         try {
             $response = $this->http
+                ->timeout(10)
+                ->connectTimeout(5)
                 ->withToken((string) ($credentials['access_token'] ?? ''))
                 ->acceptJson()
                 ->get(self::BASE.'/tweets', [
@@ -79,6 +81,8 @@ class XMetricsConnector implements MetricsConnector
     {
         try {
             $response = $this->http
+                ->timeout(10)
+                ->connectTimeout(5)
                 ->withToken((string) ($credentials['access_token'] ?? ''))
                 ->acceptJson()
                 ->get(self::BASE.'/users/'.$account->remote_account_id, ['user.fields' => 'public_metrics']);

--- a/app/Services/Metrics/MetricsCaptureCadence.php
+++ b/app/Services/Metrics/MetricsCaptureCadence.php
@@ -11,7 +11,7 @@ use Carbon\CarbonImmutable;
 
 class MetricsCaptureCadence
 {
-    /** Sampling interval (seconds) for a post of the given age, or null once polling stops. */
+    /** Age-banded sampling interval (seconds), clamped to the platform floor, or null once polling stops. */
     public function postIntervalSeconds(PostTarget $target, CarbonImmutable $now): ?int
     {
         if (! app(InstanceSettings::class)->postMetricsPollingEnabled($target->platform)) {
@@ -24,17 +24,33 @@ class MetricsCaptureCadence
 
         $postedAt = $target->posted_at;
         $ageHours = $postedAt->diffInHours($now);
+        $floor = app(InstanceSettings::class)->postMetricsPollIntervalMinutes($target->platform);
 
-        /** @var list<array{max_age_hours: int}> $bands */
+        /** @var list<array{max_age_hours: int, interval_minutes: int}> $bands */
         $bands = config('metrics.post_refresh');
 
         foreach ($bands as $band) {
             if ($ageHours < $band['max_age_hours']) {
-                return app(InstanceSettings::class)->postMetricsPollIntervalMinutes($target->platform) * 60;
+                return max($band['interval_minutes'], $floor) * 60;
             }
         }
 
         return null;
+    }
+
+    /** Base band interval widened by the consecutive-unchanged streak, capped. Null once polling stops. */
+    public function effectiveIntervalSeconds(PostTarget $target, CarbonImmutable $now): ?int
+    {
+        $base = $this->postIntervalSeconds($target, $now);
+
+        if ($base === null) {
+            return null;
+        }
+
+        $cap = (int) config('metrics.max_unchanged_backoff', 8);
+        $multiplier = min(2 ** max(0, $target->metrics_unchanged_streak), $cap);
+
+        return $base * $multiplier;
     }
 
     public function postTargetDue(PostTarget $target, CarbonImmutable $now): bool
@@ -47,7 +63,7 @@ class MetricsCaptureCadence
             return false;
         }
 
-        $interval = $this->postIntervalSeconds($target, $now);
+        $interval = $this->effectiveIntervalSeconds($target, $now);
 
         if ($interval === null) {
             return false;

--- a/app/Support/InstanceSettings.php
+++ b/app/Support/InstanceSettings.php
@@ -58,6 +58,18 @@ class InstanceSettings
         return $this->boolean('quote_tweets_enabled');
     }
 
+    /** Instance-wide metrics master switch. Defaults to `metrics.enabled` (env) until overridden here. */
+    public function metricsEnabled(): bool
+    {
+        return $this->boolean('metrics_enabled', (bool) config('metrics.enabled'));
+    }
+
+    /** Instance-wide engagement master switch. Defaults to `engagement.enabled` (env) until overridden here. */
+    public function engagementEnabled(): bool
+    {
+        return $this->boolean('engagement_enabled', (bool) config('engagement.enabled'));
+    }
+
     public function platformAvailable(?Platform $platform = null): bool
     {
         return $this->platformEnabled('platforms_enabled', $platform);
@@ -118,7 +130,9 @@ class InstanceSettings
      * @return array{
      *     engagement: array<string, array<string, bool>|int>,
      *     post_metrics: array<string, array<string, bool>|int>,
-     *     account_metrics: array<string, array<string, bool>|int>
+     *     account_metrics: array<string, array<string, bool>|int>,
+     *     metrics_enabled: bool,
+     *     engagement_enabled: bool
      * }
      */
     public function polling(): array
@@ -136,6 +150,10 @@ class InstanceSettings
                 'enabled' => $this->platformEnabledValues('account_metrics_polling_enabled'),
                 ...$this->platformMinutes('account_metrics_poll_interval_minutes', 'account_metrics'),
             ],
+            // Instance-wide master switches: when off, the sections above are moot
+            // (nothing polls regardless of their per-platform settings).
+            'metrics_enabled' => $this->metricsEnabled(),
+            'engagement_enabled' => $this->engagementEnabled(),
         ];
     }
 

--- a/config/metrics.php
+++ b/config/metrics.php
@@ -6,9 +6,20 @@ return [
     // Master kill switch. METRICS_ENABLED=false makes the feature vanish at every layer.
     'enabled' => (bool) env('METRICS_ENABLED', true),
 
-    // How long published posts remain eligible for metrics polling.
-    // Beyond the last band's max_age_hours, polling stops.
+    // Age-banded post-metrics polling. A post is polled at `interval_minutes`
+    // (widened to the operator's per-platform floor, see InstanceSettings) while
+    // its age is under `max_age_hours`. Beyond the last band's max_age_hours,
+    // polling stops for good — unlike engagement, metrics don't keep a steady
+    // tail, since a frozen old post's totals aren't worth paying to re-read.
     'post_refresh' => [
-        ['max_age_hours' => 168],
+        ['max_age_hours' => 6, 'interval_minutes' => 60],
+        ['max_age_hours' => 24, 'interval_minutes' => 180],
+        ['max_age_hours' => 72, 'interval_minutes' => 720],
+        ['max_age_hours' => 168, 'interval_minutes' => 1440],
     ],
+
+    // Each consecutive read that returns identical totals multiplies the
+    // effective interval, capped here — a post whose metrics have settled is
+    // polled ever less often (but never zero, until the hard stop above).
+    'max_unchanged_backoff' => (int) env('METRICS_MAX_UNCHANGED_BACKOFF', 8),
 ];

--- a/database/migrations/2026_07_16_000000_add_metrics_unchanged_streak.php
+++ b/database/migrations/2026_07_16_000000_add_metrics_unchanged_streak.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('post_targets', function (Blueprint $table): void {
+            if (! Schema::hasColumn('post_targets', 'metrics_unchanged_streak')) {
+                $table->unsignedInteger('metrics_unchanged_streak')->default(0)->after('metrics_status');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('post_targets', function (Blueprint $table): void {
+            if (Schema::hasColumn('post_targets', 'metrics_unchanged_streak')) {
+                $table->dropColumn('metrics_unchanged_streak');
+            }
+        });
+    }
+};

--- a/resources/js/components/posts/__tests__/published-post-view.test.ts
+++ b/resources/js/components/posts/__tests__/published-post-view.test.ts
@@ -28,4 +28,10 @@ describe('published post view', () => {
         expect(page).toContain('PublishedPostView');
         expect(page).toContain("t.status === 'published'");
     });
+
+    it('offers a one-shot manual refresh for posts that have aged out of automatic polling', () => {
+        expect(view).toContain('PostMetricsRefreshController');
+        expect(view).toContain('useHttp');
+        expect(view).toContain("only: ['stats']");
+    });
 });

--- a/resources/js/components/posts/published-post-view.tsx
+++ b/resources/js/components/posts/published-post-view.tsx
@@ -1,17 +1,21 @@
-import { Deferred, usePage } from '@inertiajs/react';
+import { Deferred, router, useHttp, usePage } from '@inertiajs/react';
 import {
     CheckCircle2,
     ExternalLink,
     Eye,
     Heart,
     MessageCircle,
+    RefreshCw,
     Repeat2,
 } from 'lucide-react';
 import { useState } from 'react';
+import { toast } from 'sonner';
 
+import PostMetricsRefreshController from '@/actions/App/Http/Controllers/Posts/PostMetricsRefreshController';
 import { PlatformGlyph } from '@/components/common/platform-glyph';
 import { TargetStatusChips } from '@/components/compose/target-status-chips';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { dayjs } from '@/lib/datetime/dayjs';
@@ -396,6 +400,22 @@ function SummaryStrip({
         ? dayjs(stats.captured_at).fromNow()
         : null;
 
+    const refreshHttp = useHttp<Record<string, never>, unknown>({});
+
+    function refreshMetrics() {
+        void refreshHttp
+            .post(PostMetricsRefreshController.store(post.id).url, {
+                onSuccess: () => router.reload({ only: ['stats'] }),
+                onHttpException: () => {
+                    toast.error('Could not refresh metrics.');
+                },
+                onNetworkError: () => {
+                    toast.error('Could not reach the server.');
+                },
+            })
+            .catch(() => {});
+    }
+
     return (
         <div className="rounded-2xl border border-border bg-card p-5 shadow-sm ring-1 ring-foreground/5">
             <div className="flex flex-wrap items-center justify-between gap-2">
@@ -420,6 +440,26 @@ function SummaryStrip({
                             <span className="text-[12px] text-muted-foreground">
                                 Synced {synced}
                             </span>
+                        )}
+                        {!loading && (
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 gap-1.5 px-2 text-[12px] text-muted-foreground hover:text-foreground"
+                                disabled={refreshHttp.processing}
+                                onClick={refreshMetrics}
+                            >
+                                <RefreshCw
+                                    className={cn(
+                                        'size-3.5',
+                                        refreshHttp.processing &&
+                                            'animate-spin',
+                                    )}
+                                    aria-hidden
+                                />
+                                Refresh
+                            </Button>
                         )}
                     </div>
                 )}

--- a/resources/js/pages/settings/__tests__/instance-polling.test.ts
+++ b/resources/js/pages/settings/__tests__/instance-polling.test.ts
@@ -10,6 +10,8 @@ import {
 } from '../instance-polling';
 
 const settings: PollingSettings = {
+    metrics_enabled: true,
+    engagement_enabled: true,
     engagement: {
         x: 15,
         bluesky: 30,
@@ -155,5 +157,25 @@ describe('instance polling section rendering', () => {
             source.match(/minutesHelp="Minimum interval in minutes\."/g),
         ).toHaveLength(2);
         expect(source).toMatch(/minimum time between metric refreshes/i);
+    });
+
+    it('offers instance-wide master switches for metrics and engagement, above the per-platform cards', () => {
+        const source = readFileSync(
+            resolve(
+                process.cwd(),
+                'resources/js/pages/settings/instance-polling.tsx',
+            ),
+            'utf8',
+        );
+
+        expect(source).toContain('id="engagement_enabled"');
+        expect(source).toContain('id="metrics_enabled"');
+        expect(source).toMatch(/setData\(\s*'engagement_enabled'/);
+        expect(source).toMatch(/setData\(\s*'metrics_enabled'/);
+        // The metrics master switch disables both metrics cards; engagement's disables its own.
+        expect(source).toContain('disabled={!data.engagement_enabled}');
+        expect(source).toMatch(
+            /disabled=\{!data\.metrics_enabled\}[\s\S]*disabled=\{!data\.metrics_enabled\}/,
+        );
     });
 });

--- a/resources/js/pages/settings/__tests__/instance-polling.test.ts
+++ b/resources/js/pages/settings/__tests__/instance-polling.test.ts
@@ -137,4 +137,23 @@ describe('instance polling section rendering', () => {
         expect(source).toContain('minutesHelp="Minimum interval in minutes."');
         expect(source).toMatch(/minimum time between reply checks/i);
     });
+
+    it('labels the post-metrics interval as a minimum floor, not a fixed cadence', () => {
+        const source = readFileSync(
+            resolve(
+                process.cwd(),
+                'resources/js/pages/settings/instance-polling.tsx',
+            ),
+            'utf8',
+        );
+
+        // Post-metrics polling is now age-banded with unchanged-streak backoff;
+        // the operator interval is a floor, so the copy must not imply a fixed
+        // cadence. Two "PollingCard"s now share this exact minutesHelp string
+        // (engagement + post metrics) — assert it appears at least twice.
+        expect(
+            source.match(/minutesHelp="Minimum interval in minutes\."/g),
+        ).toHaveLength(2);
+        expect(source).toMatch(/minimum time between metric refreshes/i);
+    });
 });

--- a/resources/js/pages/settings/instance-polling.tsx
+++ b/resources/js/pages/settings/instance-polling.tsx
@@ -131,13 +131,14 @@ export default function InstancePolling({ settings, sections }: Props) {
 
                     <PollingCard
                         title="Post metrics"
-                        description="How often to refresh likes, replies, reposts, and impressions for published posts."
+                        description="The minimum time between metric refreshes. Fresh posts are refreshed more often and back off as they age, so this sets the floor, not a fixed interval."
                         group="post_metrics"
                         platforms={sections.post_metrics}
                         values={data.post_metrics}
                         errors={errors}
                         onChange={setMinutes}
                         onEnabledChange={setPlatformEnabled}
+                        minutesHelp="Minimum interval in minutes."
                     />
 
                     <PollingCard

--- a/resources/js/pages/settings/instance-polling.tsx
+++ b/resources/js/pages/settings/instance-polling.tsx
@@ -14,6 +14,7 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
 import type { PlatformName } from '@/types/compose';
 
 type PollingGroup = Record<PlatformName, number> & {
@@ -24,18 +25,24 @@ export type PollingSettings = {
     engagement: PollingGroup;
     post_metrics: PollingGroup;
     account_metrics: PollingGroup;
+    /** Instance-wide master switches. When off, the matching section(s) below are moot. */
+    metrics_enabled: boolean;
+    engagement_enabled: boolean;
 };
+
+/** The three per-platform sections, excluding the two flat master-switch keys. */
+type PollingSectionKey = 'engagement' | 'post_metrics' | 'account_metrics';
 
 type SectionPlatform = { platform: PlatformName; label: string };
 
 type Props = {
     settings: PollingSettings;
-    sections: Record<keyof PollingSettings, SectionPlatform[]>;
+    sections: Record<PollingSectionKey, SectionPlatform[]>;
 };
 
 export function pollingWithMinutes(
     settings: PollingSettings,
-    group: keyof PollingSettings,
+    group: PollingSectionKey,
     platform: PlatformName,
     value: string,
 ): PollingSettings {
@@ -50,7 +57,7 @@ export function pollingWithMinutes(
 
 export function pollingWithPlatformEnabled(
     settings: PollingSettings,
-    group: keyof PollingSettings,
+    group: PollingSectionKey,
     platform: PlatformName,
     enabled: boolean,
 ): PollingSettings {
@@ -79,7 +86,7 @@ export default function InstancePolling({ settings, sections }: Props) {
     }
 
     function setMinutes(
-        group: keyof PollingSettings,
+        group: PollingSectionKey,
         platform: PlatformName,
         value: string,
     ) {
@@ -87,7 +94,7 @@ export default function InstancePolling({ settings, sections }: Props) {
     }
 
     function setPlatformEnabled(
-        group: keyof PollingSettings,
+        group: PollingSectionKey,
         platform: PlatformName,
         enabled: boolean,
     ) {
@@ -117,6 +124,62 @@ export default function InstancePolling({ settings, sections }: Props) {
                 />
 
                 <form onSubmit={handleSubmit} className="space-y-6">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Feature availability</CardTitle>
+                            <CardDescription>
+                                Turn engagement or metrics off for the whole
+                                instance without touching environment variables.
+                                The sections below only take effect while their
+                                switch here is on.
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="flex items-start gap-3">
+                                <Checkbox
+                                    id="engagement_enabled"
+                                    checked={data.engagement_enabled}
+                                    onCheckedChange={(checked) =>
+                                        setData(
+                                            'engagement_enabled',
+                                            checked === true,
+                                        )
+                                    }
+                                />
+                                <div className="space-y-1">
+                                    <Label htmlFor="engagement_enabled">
+                                        Enable engagement
+                                    </Label>
+                                    <p className="text-sm text-muted-foreground">
+                                        Governs the Engagement section below.
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div className="flex items-start gap-3">
+                                <Checkbox
+                                    id="metrics_enabled"
+                                    checked={data.metrics_enabled}
+                                    onCheckedChange={(checked) =>
+                                        setData(
+                                            'metrics_enabled',
+                                            checked === true,
+                                        )
+                                    }
+                                />
+                                <div className="space-y-1">
+                                    <Label htmlFor="metrics_enabled">
+                                        Enable metrics
+                                    </Label>
+                                    <p className="text-sm text-muted-foreground">
+                                        Governs both the Post metrics and
+                                        Account metrics sections below.
+                                    </p>
+                                </div>
+                            </div>
+                        </CardContent>
+                    </Card>
+
                     <PollingCard
                         title="Engagement"
                         description="The minimum time between reply checks. Fresh posts are checked more often and back off as they age, so this sets the floor, not a fixed interval."
@@ -127,6 +190,7 @@ export default function InstancePolling({ settings, sections }: Props) {
                         onChange={setMinutes}
                         onEnabledChange={setPlatformEnabled}
                         minutesHelp="Minimum interval in minutes."
+                        disabled={!data.engagement_enabled}
                     />
 
                     <PollingCard
@@ -139,6 +203,7 @@ export default function InstancePolling({ settings, sections }: Props) {
                         onChange={setMinutes}
                         onEnabledChange={setPlatformEnabled}
                         minutesHelp="Minimum interval in minutes."
+                        disabled={!data.metrics_enabled}
                     />
 
                     <PollingCard
@@ -150,6 +215,7 @@ export default function InstancePolling({ settings, sections }: Props) {
                         errors={errors}
                         onChange={setMinutes}
                         onEnabledChange={setPlatformEnabled}
+                        disabled={!data.metrics_enabled}
                     />
 
                     <Button type="submit" disabled={processing}>
@@ -171,41 +237,50 @@ function PollingCard({
     onChange,
     onEnabledChange,
     minutesHelp = 'Interval in minutes.',
+    disabled = false,
 }: {
     title: string;
     description: string;
-    group: keyof PollingSettings;
+    group: PollingSectionKey;
     platforms: SectionPlatform[];
     values: PollingGroup;
     errors: Partial<Record<string, string>>;
     onChange: (
-        group: keyof PollingSettings,
+        group: PollingSectionKey,
         platform: PlatformName,
         value: string,
     ) => void;
     onEnabledChange: (
-        group: keyof PollingSettings,
+        group: PollingSectionKey,
         platform: PlatformName,
         enabled: boolean,
     ) => void;
     minutesHelp?: string;
+    /** The instance-wide master switch for this section is off; every row below is moot. */
+    disabled?: boolean;
 }) {
     const hasDisabledPlatform = platforms.some(
         (p) => !values.enabled[p.platform],
     );
 
     return (
-        <Card>
+        <Card className={cn(disabled && 'opacity-60')}>
             <CardHeader>
                 <div className="flex items-start justify-between gap-4">
                     <div>
                         <CardTitle>{title}</CardTitle>
                         <CardDescription>{description}</CardDescription>
                     </div>
-                    {hasDisabledPlatform && (
+                    {disabled ? (
                         <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-300">
-                            Partially disabled
+                            Disabled instance-wide
                         </span>
+                    ) : (
+                        hasDisabledPlatform && (
+                            <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-300">
+                                Partially disabled
+                            </span>
+                        )
                     )}
                 </div>
             </CardHeader>
@@ -224,6 +299,7 @@ function PollingCard({
                                     <Checkbox
                                         id={`${group}-${p.platform}-enabled`}
                                         checked={isEnabled}
+                                        disabled={disabled}
                                         onCheckedChange={(checked) =>
                                             onEnabledChange(
                                                 group,
@@ -237,7 +313,7 @@ function PollingCard({
                                     >
                                         {p.label}
                                     </Label>
-                                    {!isEnabled && (
+                                    {!disabled && !isEnabled && (
                                         <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-300">
                                             Temporarily disabled
                                         </span>
@@ -257,7 +333,7 @@ function PollingCard({
                                     max={10080}
                                     step={5}
                                     value={values[p.platform]}
-                                    disabled={!isEnabled}
+                                    disabled={disabled || !isEnabled}
                                     onChange={(event) =>
                                         onChange(
                                             group,

--- a/routes/posts.php
+++ b/routes/posts.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Posts\PostController;
 use App\Http\Controllers\Posts\PostImageEditController;
 use App\Http\Controllers\Posts\PostingScheduleController;
 use App\Http\Controllers\Posts\PostMediaController;
+use App\Http\Controllers\Posts\PostMetricsRefreshController;
 use App\Http\Controllers\Posts\PostQueueController;
 use App\Http\Controllers\Posts\PostScheduleController;
 use App\Http\Controllers\Posts\PostShareController;
@@ -73,6 +74,11 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::post('posts/{post}/queue', [PostQueueController::class, 'store'])->name('posts.queue');
     Route::post('posts/{post}/publish', [PublishController::class, 'store'])->name('posts.publish');
     Route::post('posts/{post}/targets/{target}/retry', [PostTargetRetryController::class, 'store'])->name('posts.targets.retry');
+    // Bypasses the queued job's own per-platform rate limiting (dispatchSync runs
+    // inline, skipping queue middleware), so throttle here — each hit is a real,
+    // metered X API read across every published target on the post.
+    Route::post('posts/{post}/metrics/refresh', [PostMetricsRefreshController::class, 'store'])
+        ->middleware(['metrics.enabled', 'throttle:10,1'])->name('posts.metrics.refresh');
     // Media uploads are throttled to bound abuse (presigned-URL minting / storage flooding).
     Route::middleware('throttle:60,1')->group(function (): void {
         Route::post('posts/{post}/media', [PostMediaController::class, 'store'])->name('posts.media.store');

--- a/tests/Feature/Engagement/DispatchDueReplyFetchesTest.php
+++ b/tests/Feature/Engagement/DispatchDueReplyFetchesTest.php
@@ -26,6 +26,22 @@ test('it collapses an X account\'s due posts into a single batched job', functio
     Queue::assertNotPushed(FetchPostTargetReplies::class);
 });
 
+test('command is a no-op when the instance-settings override disables engagement, even though config is on', function () {
+    Queue::fake();
+    config(['engagement.enabled' => true]);
+    app(InstanceSettings::class)->update(['engagement_enabled' => false]);
+
+    $account = ConnectedAccount::factory()->create(['platform' => Platform::X, 'status' => ConnectedAccountStatus::Active]);
+    PostTarget::factory()->for($account, 'account')->published()->create([
+        'platform' => Platform::X,
+        'posted_at' => now()->subHours(2),
+    ]);
+
+    $this->artisan('engagement:dispatch-due')->assertSuccessful();
+
+    Queue::assertNothingPushed();
+});
+
 test('it skips accounts parked by a rate limit', function () {
     Queue::fake();
 

--- a/tests/Feature/Engagement/EnsureEngagementEnabledTest.php
+++ b/tests/Feature/Engagement/EnsureEngagementEnabledTest.php
@@ -1,30 +1,30 @@
 <?php
 
-use App\Http\Middleware\EnsureMetricsEnabled;
+use App\Http\Middleware\EnsureEngagementEnabled;
 use App\Support\InstanceSettings;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 test('middleware 404s when disabled and passes when enabled', function () {
-    $mw = new EnsureMetricsEnabled;
+    $mw = new EnsureEngagementEnabled;
     $next = fn ($req) => response('ok');
 
-    config(['metrics.enabled' => true]);
-    expect($mw->handle(Request::create('/analytics'), $next)->getContent())->toBe('ok');
+    config(['engagement.enabled' => true]);
+    expect($mw->handle(Request::create('/engagement'), $next)->getContent())->toBe('ok');
 
-    config(['metrics.enabled' => false]);
-    expect(fn () => $mw->handle(Request::create('/analytics'), $next))
+    config(['engagement.enabled' => false]);
+    expect(fn () => $mw->handle(Request::create('/engagement'), $next))
         ->toThrow(NotFoundHttpException::class);
 });
 
 test('a persisted instance-settings override takes precedence over the config default', function () {
-    $mw = new EnsureMetricsEnabled;
+    $mw = new EnsureEngagementEnabled;
     $next = fn ($req) => response('ok');
 
     // Config says on, but the instance owner has flipped the runtime toggle off.
-    config(['metrics.enabled' => true]);
-    app(InstanceSettings::class)->update(['metrics_enabled' => false]);
+    config(['engagement.enabled' => true]);
+    app(InstanceSettings::class)->update(['engagement_enabled' => false]);
 
-    expect(fn () => $mw->handle(Request::create('/analytics'), $next))
+    expect(fn () => $mw->handle(Request::create('/engagement'), $next))
         ->toThrow(NotFoundHttpException::class);
 });

--- a/tests/Feature/Engagement/FetchAccountRepliesTest.php
+++ b/tests/Feature/Engagement/FetchAccountRepliesTest.php
@@ -13,6 +13,7 @@ use App\Services\Engagement\EngagementConnectorRegistry;
 use App\Services\Engagement\ReplyFetchCadence;
 use App\Services\Engagement\ReplyPersister;
 use App\Services\Publishing\TokenManager;
+use App\Support\InstanceSettings;
 
 function runAccountFetch(ConnectedAccount $account): void
 {
@@ -21,6 +22,7 @@ function runAccountFetch(ConnectedAccount $account): void
         app(TokenManager::class),
         app(ReplyPersister::class),
         app(ReplyFetchCadence::class),
+        app(InstanceSettings::class),
     );
 }
 

--- a/tests/Feature/Engagement/FetchPostTargetRepliesTest.php
+++ b/tests/Feature/Engagement/FetchPostTargetRepliesTest.php
@@ -14,6 +14,7 @@ use App\Services\Engagement\Contracts\EngagementConnector;
 use App\Services\Engagement\EngagementConnectorRegistry;
 use App\Services\Engagement\ReplyPersister;
 use App\Services\Publishing\TokenManager;
+use App\Support\InstanceSettings;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Log;
 
@@ -58,7 +59,7 @@ test('the job inserts fetched replies with the workspace id', function () {
         new FetchedReply('at://r1', 'c1', 'at://root', 'fan', 'Fan', null, 'nice', CarbonImmutable::now()),
     ]);
 
-    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class));
+    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
 
     $reply = PostTargetReply::withoutGlobalScopes()->first();
     expect($reply->remote_reply_id)->toBe('at://r1');
@@ -73,7 +74,7 @@ test('the job does not fetch replies for a disabled account', function () {
     $registry = Mockery::mock(EngagementConnectorRegistry::class);
     $registry->shouldNotReceive('for');
 
-    (new FetchPostTargetReplies($target))->handle($registry, app(TokenManager::class), app(ReplyPersister::class));
+    (new FetchPostTargetReplies($target))->handle($registry, app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
 
     expect($target->fresh()->reply_fetched_at)->toBeNull();
 });
@@ -83,10 +84,10 @@ test('re-running the job does not duplicate replies', function () {
     $replies = [new FetchedReply('at://r1', 'c1', 'at://root', 'fan', 'Fan', null, 'nice', CarbonImmutable::now())];
 
     fakeFetch($replies);
-    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class));
+    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
 
     fakeFetch($replies);
-    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class));
+    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
 
     expect(PostTargetReply::withoutGlobalScopes()->count())->toBe(1);
 });
@@ -123,7 +124,7 @@ test('the job resolves credentials for threads instead of passing an empty token
     $registry->shouldReceive('for')->andReturn($connector);
     app()->instance(EngagementConnectorRegistry::class, $registry);
 
-    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class));
+    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
 
     expect($captured)->toBe(['access_token' => 'threads-token']);
 });
@@ -133,13 +134,13 @@ test('an empty fetch increments the empty streak; a non-empty fetch resets it', 
     $target->forceFill(['reply_fetch_empty_streak' => 2])->save();
 
     fakeFetch([]);
-    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class));
+    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
     expect($target->fresh()->reply_fetch_empty_streak)->toBe(3);
 
     fakeFetch([
         new FetchedReply('at://r1', 'c1', 'at://root', 'fan', 'Fan', null, 'nice', CarbonImmutable::now()),
     ]);
-    (new FetchPostTargetReplies($target->fresh()))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class));
+    (new FetchPostTargetReplies($target->fresh()))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
     expect($target->fresh()->reply_fetch_empty_streak)->toBe(0);
 });
 
@@ -151,7 +152,7 @@ test('the fetch outcome is logged for fleet visibility', function () {
         new FetchedReply('at://r1', 'c1', 'at://root', 'fan', 'Fan', null, 'nice', CarbonImmutable::now()),
     ]);
 
-    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class));
+    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
 
     Log::shouldHaveReceived('info')
         ->withArgs(fn (string $message, array $context): bool => $message === 'engagement.fetch'
@@ -170,7 +171,7 @@ test('a rate-limited fetch parks the account and does not stamp reply_fetched_at
     $registry->shouldReceive('for')->andReturn($connector);
     app()->instance(EngagementConnectorRegistry::class, $registry);
 
-    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class));
+    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
 
     expect($target->fresh()->reply_fetched_at)->toBeNull();
     $account = $target->account()->withoutGlobalScopes()->first();
@@ -186,7 +187,7 @@ test('a failed fetch does not stamp reply_fetched_at', function () {
     $registry->shouldReceive('for')->andReturn($connector);
     app()->instance(EngagementConnectorRegistry::class, $registry);
 
-    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class));
+    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
 
     expect($target->fresh()->reply_fetched_at)->toBeNull();
 });
@@ -199,7 +200,7 @@ test('the job stores the base conversation id when fetched replies are out of or
         new FetchedReply('at://base', 'c1', 'at://root', 'fan', 'Fan', null, 'base', CarbonImmutable::now()->subMinute()),
     ]);
 
-    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class));
+    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
 
     $child = PostTargetReply::withoutGlobalScopes()->where('remote_reply_id', 'at://child')->firstOrFail();
 

--- a/tests/Feature/Engagement/NewRepliesNotificationTest.php
+++ b/tests/Feature/Engagement/NewRepliesNotificationTest.php
@@ -15,6 +15,7 @@ use App\Services\Engagement\Contracts\EngagementConnector;
 use App\Services\Engagement\EngagementConnectorRegistry;
 use App\Services\Engagement\ReplyPersister;
 use App\Services\Publishing\TokenManager;
+use App\Support\InstanceSettings;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Notification;
 
@@ -55,7 +56,7 @@ test('one batched notification fires when new replies land', function () {
         new FetchedReply('at://r2', 'c2', 'at://root', 'b', 'B', null, 'yo', CarbonImmutable::now()),
     ], $author);
 
-    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class));
+    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
 
     Notification::assertSentToTimes($author, NewRepliesNotification::class, 1);
 });
@@ -65,7 +66,7 @@ test('no notification fires when nothing new', function () {
     $author = User::factory()->create();
     $target = fetchJobWith([], $author);
 
-    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class));
+    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
 
     Notification::assertNothingSent();
 });

--- a/tests/Feature/InstanceSettingsTest.php
+++ b/tests/Feature/InstanceSettingsTest.php
@@ -384,6 +384,8 @@ test('instance owner can update polling settings', function () {
                 'enabled' => ['x' => false, 'bluesky' => true, 'facebook' => true, 'instagram' => true, 'threads' => true],
                 'x' => 1440, 'bluesky' => 240, 'facebook' => 15, 'instagram' => 15, 'threads' => 15,
             ],
+            'metrics_enabled' => true,
+            'engagement_enabled' => true,
         ])
         ->assertRedirect();
 
@@ -413,6 +415,32 @@ test('instance owner can update polling settings', function () {
     // (enabled + per-platform fallback) even though we never sent it.
     expect($polling['post_metrics']['enabled']['linkedin'])->toBeTrue()
         ->and($polling['account_metrics']['enabled']['linkedin'])->toBeTrue();
+});
+
+test('instance owner can toggle the metrics and engagement master switches from the polling page', function () {
+    $owner = User::factory()->instanceOwner()->create();
+
+    $this->actingAs($owner)
+        ->put(route('instance-settings.polling.update'), [
+            'engagement' => [
+                'enabled' => ['x' => true, 'bluesky' => true, 'linkedin' => true, 'facebook' => true, 'instagram' => true, 'threads' => true],
+                'x' => 360, 'bluesky' => 15, 'linkedin' => 15, 'facebook' => 15, 'instagram' => 15, 'threads' => 15,
+            ],
+            'post_metrics' => [
+                'enabled' => ['x' => true, 'bluesky' => true, 'facebook' => true, 'instagram' => true, 'threads' => true, 'discord' => true],
+                'x' => 360, 'bluesky' => 15, 'facebook' => 15, 'instagram' => 15, 'threads' => 15, 'discord' => 15,
+            ],
+            'account_metrics' => [
+                'enabled' => ['x' => true, 'bluesky' => true, 'facebook' => true, 'instagram' => true, 'threads' => true],
+                'x' => 1440, 'bluesky' => 1440, 'facebook' => 15, 'instagram' => 15, 'threads' => 15,
+            ],
+            'metrics_enabled' => false,
+            'engagement_enabled' => false,
+        ])
+        ->assertRedirect();
+
+    expect(app(InstanceSettings::class)->metricsEnabled())->toBeFalse()
+        ->and(app(InstanceSettings::class)->engagementEnabled())->toBeFalse();
 });
 
 test('regular users cannot view polling settings', function () {

--- a/tests/Feature/Metrics/CaptureJobsTest.php
+++ b/tests/Feature/Metrics/CaptureJobsTest.php
@@ -7,6 +7,7 @@ use App\Jobs\CapturePostTargetMetrics;
 use App\Models\ConnectedAccount;
 use App\Models\ConnectedAccountSecret;
 use App\Models\PostTarget;
+use App\Support\InstanceSettings;
 use Illuminate\Support\Facades\Http;
 
 test('post job writes latest totals and ok status for bluesky', function () {
@@ -122,6 +123,18 @@ test('jobs no-op when feature disabled', function () {
     CaptureAccountMetrics::dispatchSync($account);
 
     expect($account->metrics()->count())->toBe(0);
+});
+
+test('jobs no-op when the instance-settings override disables metrics, even though config is on', function () {
+    Http::preventStrayRequests();
+    config(['metrics.enabled' => true]);
+    app(InstanceSettings::class)->update(['metrics_enabled' => false]);
+    $account = ConnectedAccount::factory()->create(['platform' => Platform::Bluesky]);
+
+    CaptureAccountMetrics::dispatchSync($account);
+
+    expect($account->metrics()->count())->toBe(0);
+    Http::assertNothingSent();
 });
 
 test('a read that matches the prior totals increments the unchanged streak', function () {

--- a/tests/Feature/Metrics/CaptureJobsTest.php
+++ b/tests/Feature/Metrics/CaptureJobsTest.php
@@ -124,6 +124,98 @@ test('jobs no-op when feature disabled', function () {
     expect($account->metrics()->count())->toBe(0);
 });
 
+test('a read that matches the prior totals increments the unchanged streak', function () {
+    Http::fake(['public.api.bsky.app/*' => Http::response(['posts' => [
+        ['likeCount' => 7, 'repostCount' => 1, 'quoteCount' => 0, 'replyCount' => 2],
+    ]])]);
+
+    $account = ConnectedAccount::factory()->bluesky()->create();
+
+    $target = PostTarget::factory()->create([
+        'connected_account_id' => $account->id,
+        'platform' => Platform::Bluesky,
+        'remote_id' => 'at://a/app.bsky.feed.post/1',
+        'remote_ids' => ['at://a/app.bsky.feed.post/1'],
+        'likes' => 7,
+        'comments' => 2,
+        'reposts' => 1,
+        'impressions' => null,
+        'metrics_captured_at' => now()->subHours(2),
+        'metrics_unchanged_streak' => 2,
+    ]);
+
+    CapturePostTargetMetrics::dispatchSync($target);
+
+    expect($target->fresh()->metrics_unchanged_streak)->toBe(3);
+});
+
+test('a read that differs from the prior totals resets the unchanged streak', function () {
+    Http::fake(['public.api.bsky.app/*' => Http::response(['posts' => [
+        ['likeCount' => 7, 'repostCount' => 1, 'quoteCount' => 0, 'replyCount' => 2],
+    ]])]);
+
+    $account = ConnectedAccount::factory()->bluesky()->create();
+
+    $target = PostTarget::factory()->create([
+        'connected_account_id' => $account->id,
+        'platform' => Platform::Bluesky,
+        'remote_id' => 'at://a/app.bsky.feed.post/1',
+        'remote_ids' => ['at://a/app.bsky.feed.post/1'],
+        'likes' => 5,
+        'comments' => 2,
+        'reposts' => 1,
+        'impressions' => null,
+        'metrics_captured_at' => now()->subHours(2),
+        'metrics_unchanged_streak' => 4,
+    ]);
+
+    CapturePostTargetMetrics::dispatchSync($target);
+
+    expect($target->fresh()->metrics_unchanged_streak)->toBe(0);
+});
+
+test('the first-ever capture never counts as unchanged, even when totals happen to match zero defaults', function () {
+    Http::fake(['public.api.bsky.app/*' => Http::response(['posts' => [
+        ['likeCount' => 0, 'repostCount' => 0, 'quoteCount' => 0, 'replyCount' => 0],
+    ]])]);
+
+    $account = ConnectedAccount::factory()->bluesky()->create();
+
+    $target = PostTarget::factory()->create([
+        'connected_account_id' => $account->id,
+        'platform' => Platform::Bluesky,
+        'remote_id' => 'at://a/app.bsky.feed.post/1',
+        'remote_ids' => ['at://a/app.bsky.feed.post/1'],
+    ]);
+
+    expect($target->metrics_captured_at)->toBeNull();
+
+    CapturePostTargetMetrics::dispatchSync($target);
+
+    expect($target->fresh()->metrics_unchanged_streak)->toBe(0);
+});
+
+test('a failed fetch leaves the unchanged streak untouched', function () {
+    Http::fake(['public.api.bsky.app/*' => Http::response(['error' => 'InternalServerError'], 500)]);
+
+    $account = ConnectedAccount::factory()->bluesky()->create();
+
+    $target = PostTarget::factory()->create([
+        'connected_account_id' => $account->id,
+        'platform' => Platform::Bluesky,
+        'remote_id' => 'at://a/app.bsky.feed.post/1',
+        'remote_ids' => ['at://a/app.bsky.feed.post/1'],
+        'metrics_captured_at' => now()->subHours(2),
+        'metrics_unchanged_streak' => 4,
+    ]);
+
+    CapturePostTargetMetrics::dispatchSync($target);
+
+    $fresh = $target->fresh();
+    expect($fresh->metrics_status)->toBe(MetricsStatus::Failed)
+        ->and($fresh->metrics_unchanged_streak)->toBe(4);
+});
+
 test('jobs no-op for disabled accounts', function () {
     Http::preventStrayRequests();
 

--- a/tests/Feature/Metrics/CaptureMetricsCommandTest.php
+++ b/tests/Feature/Metrics/CaptureMetricsCommandTest.php
@@ -63,6 +63,18 @@ test('command is a no-op when feature disabled', function () {
     Queue::assertNothingPushed();
 });
 
+test('command is a no-op when the instance-settings override disables metrics, even though config is on', function () {
+    Queue::fake();
+    config(['metrics.enabled' => true]);
+    app(InstanceSettings::class)->update(['metrics_enabled' => false]);
+
+    ConnectedAccount::factory()->create(['platform' => Platform::Bluesky, 'status' => ConnectedAccountStatus::Active]);
+
+    $this->artisan('metrics:capture')->assertSuccessful();
+
+    Queue::assertNothingPushed();
+});
+
 test('command skips disabled metric polling groups', function () {
     Queue::fake();
     app(InstanceSettings::class)->update([

--- a/tests/Feature/Metrics/PostMetricsRefreshTest.php
+++ b/tests/Feature/Metrics/PostMetricsRefreshTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MetricsStatus;
+use App\Enums\Platform;
+use App\Enums\PostTargetStatus;
+use App\Enums\WorkspaceRole;
+use App\Models\ConnectedAccount;
+use App\Models\Post;
+use App\Models\PostTarget;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->workspace = Workspace::factory()->create(['owner_id' => $this->user->id]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $this->workspace->id, 'user_id' => $this->user->id, 'role' => WorkspaceRole::Member,
+    ]);
+    $this->user->forceFill(['current_workspace_id' => $this->workspace->id])->save();
+    Context::add('workspace_id', $this->workspace->id);
+    $this->post = Post::factory()->for($this->workspace)->create(['author_id' => $this->user->id]);
+});
+
+it('one-shot refreshes a published target that has aged past automatic polling', function (): void {
+    Http::fake(['public.api.bsky.app/*' => Http::response(['posts' => [
+        ['likeCount' => 9, 'repostCount' => 2, 'quoteCount' => 0, 'replyCount' => 1],
+    ]])]);
+
+    $account = ConnectedAccount::factory()->for($this->workspace)->bluesky()->create();
+    $target = PostTarget::factory()->for($this->post)->create([
+        'connected_account_id' => $account->id,
+        'platform' => Platform::Bluesky,
+        'status' => PostTargetStatus::Published,
+        'remote_id' => 'at://a/app.bsky.feed.post/1',
+        'remote_ids' => ['at://a/app.bsky.feed.post/1'],
+        // Aged well past the 168h hard stop — automatic polling would skip it.
+        'posted_at' => now()->subDays(30),
+        'metrics_captured_at' => now()->subDays(10),
+    ]);
+
+    $this->actingAs($this->user)
+        ->postJson(route('posts.metrics.refresh', $this->post))
+        ->assertOk()
+        ->assertJsonStructure(['supported', 'captured_at', 'totals', 'targets']);
+
+    $fresh = $target->fresh();
+    expect($fresh->likes)->toBe(9)
+        ->and($fresh->metrics_status)->toBe(MetricsStatus::Ok)
+        ->and($fresh->metrics_captured_at->gt(now()->subMinute()))->toBeTrue();
+});
+
+it('rejects a refresh for a post outside the caller workspace', function (): void {
+    $otherWorkspace = Workspace::factory()->create();
+    $foreignPost = Post::factory()->for($otherWorkspace)->create();
+
+    $this->actingAs($this->user)
+        ->postJson(route('posts.metrics.refresh', $foreignPost))
+        ->assertNotFound();
+});
+
+it('is unreachable when the metrics feature is disabled instance-wide', function (): void {
+    config(['metrics.enabled' => false]);
+
+    $this->actingAs($this->user)
+        ->postJson(route('posts.metrics.refresh', $this->post))
+        ->assertNotFound();
+});
+
+it('rate limits repeated manual refreshes, since dispatchSync bypasses the queued job\'s own throttle', function (): void {
+    $this->actingAs($this->user);
+
+    for ($i = 0; $i < 10; $i++) {
+        $this->postJson(route('posts.metrics.refresh', $this->post));
+    }
+
+    $this->postJson(route('posts.metrics.refresh', $this->post))->assertStatus(429);
+});

--- a/tests/Feature/Metrics/PostMetricsTest.php
+++ b/tests/Feature/Metrics/PostMetricsTest.php
@@ -18,6 +18,9 @@ beforeEach(function (): void {
     Context::add('workspace_id', $this->workspace->id);
 });
 
-test('manual metrics refresh route is disabled', function () {
-    expect(Route::has('posts.metrics.refresh'))->toBeFalse();
+test('manual metrics refresh route is enabled', function () {
+    // Was intentionally unwired (dead controller). Now wired up so a post that
+    // has aged out of automatic polling can still be refreshed on demand — see
+    // PostMetricsRefreshTest.php for the full request/auth/response coverage.
+    expect(Route::has('posts.metrics.refresh'))->toBeTrue();
 });

--- a/tests/Unit/InstanceSettingsTest.php
+++ b/tests/Unit/InstanceSettingsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Support\InstanceSettings;
+
+it('defaults metrics enabled to the metrics.enabled config value', function () {
+    config(['metrics.enabled' => true]);
+    expect(app(InstanceSettings::class)->metricsEnabled())->toBeTrue();
+
+    config(['metrics.enabled' => false]);
+    expect(app(InstanceSettings::class)->metricsEnabled())->toBeFalse();
+});
+
+it('lets a persisted override take precedence over the metrics config default', function () {
+    config(['metrics.enabled' => true]);
+    app(InstanceSettings::class)->update(['metrics_enabled' => false]);
+
+    expect(app(InstanceSettings::class)->metricsEnabled())->toBeFalse();
+});
+
+it('defaults engagement enabled to the engagement.enabled config value', function () {
+    config(['engagement.enabled' => true]);
+    expect(app(InstanceSettings::class)->engagementEnabled())->toBeTrue();
+
+    config(['engagement.enabled' => false]);
+    expect(app(InstanceSettings::class)->engagementEnabled())->toBeFalse();
+});
+
+it('lets a persisted override take precedence over the engagement config default', function () {
+    config(['engagement.enabled' => true]);
+    app(InstanceSettings::class)->update(['engagement_enabled' => false]);
+
+    expect(app(InstanceSettings::class)->engagementEnabled())->toBeFalse();
+});
+
+it('includes both master switches in the polling settings array', function () {
+    expect(app(InstanceSettings::class)->polling())
+        ->toHaveKeys(['metrics_enabled', 'engagement_enabled']);
+});

--- a/tests/Unit/Metrics/MetricsCaptureCadenceTest.php
+++ b/tests/Unit/Metrics/MetricsCaptureCadenceTest.php
@@ -82,3 +82,94 @@ test('discord accounts are never due for account metrics', function () {
 
     expect($this->cadence->accountDue($discord, $this->now))->toBeFalse();
 });
+
+test('post metrics age bands select an interval clamped to the platform floor', function () {
+    app(InstanceSettings::class)->update([
+        'post_metrics_poll_interval_minutes' => [
+            'x' => 360,
+            'bluesky' => 15,
+            'linkedin' => 15,
+        ],
+    ]);
+
+    $ageX = fn (int $hours) => PostTarget::factory()->make([
+        'platform' => Platform::X,
+        'posted_at' => $this->now->copy()->subHours($hours),
+    ]);
+
+    // Band 1 (< 6h, 60m) clamps up to the X floor (360m).
+    expect($this->cadence->postIntervalSeconds($ageX(3), $this->now))->toBe(360 * 60);
+    // Band 2 (< 24h, 180m) still clamps up to the X floor.
+    expect($this->cadence->postIntervalSeconds($ageX(12), $this->now))->toBe(360 * 60);
+    // Band 3 (< 72h, 720m) exceeds the floor — real savings start here.
+    expect($this->cadence->postIntervalSeconds($ageX(48), $this->now))->toBe(720 * 60);
+    // Band 4 (< 168h, 1440m).
+    expect($this->cadence->postIntervalSeconds($ageX(100), $this->now))->toBe(1440 * 60);
+
+    $ageBluesky = fn (int $hours) => PostTarget::factory()->make([
+        'platform' => Platform::Bluesky,
+        'posted_at' => $this->now->copy()->subHours($hours),
+    ]);
+
+    // Bluesky's floor (15m) never clamps — bands apply unmodified.
+    expect($this->cadence->postIntervalSeconds($ageBluesky(3), $this->now))->toBe(60 * 60);
+    expect($this->cadence->postIntervalSeconds($ageBluesky(48), $this->now))->toBe(720 * 60);
+});
+
+test('post metrics stop polling for good past the last band', function () {
+    $veryOld = PostTarget::factory()->make([
+        'platform' => Platform::X,
+        'posted_at' => $this->now->copy()->subHours(200),
+    ]);
+
+    expect($this->cadence->postIntervalSeconds($veryOld, $this->now))->toBeNull();
+    expect($this->cadence->postTargetDue($veryOld, $this->now))->toBeFalse();
+});
+
+test('effective interval widens by the consecutive unchanged streak, capped', function () {
+    app(InstanceSettings::class)->update([
+        'post_metrics_poll_interval_minutes' => ['x' => 360, 'bluesky' => 15, 'linkedin' => 15],
+    ]);
+
+    $base = fn (int $streak) => PostTarget::factory()->make([
+        'platform' => Platform::X,
+        'posted_at' => $this->now->copy()->subHours(48),
+        'metrics_unchanged_streak' => $streak,
+    ]);
+
+    // Base band-3 interval is 720m; a streak of 0 leaves it unchanged.
+    expect($this->cadence->effectiveIntervalSeconds($base(0), $this->now))->toBe(720 * 60);
+    // Streak of 2 -> 2^2 = 4x.
+    expect($this->cadence->effectiveIntervalSeconds($base(2), $this->now))->toBe(720 * 4 * 60);
+    // Streak of 3 already hits the default cap of 8x...
+    expect($this->cadence->effectiveIntervalSeconds($base(3), $this->now))->toBe(720 * 8 * 60);
+    // ...and a much larger streak stays capped at the same 8x.
+    expect($this->cadence->effectiveIntervalSeconds($base(10), $this->now))->toBe(720 * 8 * 60);
+});
+
+test('unchanged streak backoff postpones the next due capture without changing the hard stop', function () {
+    app(InstanceSettings::class)->update([
+        'post_metrics_poll_interval_minutes' => ['x' => 360, 'bluesky' => 15, 'linkedin' => 15],
+    ]);
+
+    // Band-3 base interval is 720m; captured 800m ago is due under the base
+    // interval alone, but a streak-of-2 backoff (4x -> 2880m) postpones it.
+    $target = PostTarget::factory()->make([
+        'platform' => Platform::X,
+        'posted_at' => $this->now->copy()->subHours(48),
+        'metrics_captured_at' => $this->now->copy()->subMinutes(800),
+        'metrics_unchanged_streak' => 2,
+    ]);
+
+    expect($this->cadence->postIntervalSeconds($target, $this->now))->toBeLessThan(800 * 60);
+    expect($this->cadence->postTargetDue($target, $this->now))->toBeFalse();
+
+    // Backoff can never resurrect a post past the hard stop.
+    $stopped = PostTarget::factory()->make([
+        'platform' => Platform::X,
+        'posted_at' => $this->now->copy()->subHours(200),
+        'metrics_captured_at' => $this->now->copy()->subYear(),
+        'metrics_unchanged_streak' => 5,
+    ]);
+    expect($this->cadence->postTargetDue($stopped, $this->now))->toBeFalse();
+});

--- a/tests/Unit/Metrics/MetricsStatusTest.php
+++ b/tests/Unit/Metrics/MetricsStatusTest.php
@@ -12,6 +12,10 @@ test('unsupported is the only terminal (non-pollable) status', function () {
 test('metrics config exposes flag and cadence', function () {
     expect(config('metrics.enabled'))->toBeBool();
     expect(config('metrics.post_refresh'))->toBe([
-        ['max_age_hours' => 168],
+        ['max_age_hours' => 6, 'interval_minutes' => 60],
+        ['max_age_hours' => 24, 'interval_minutes' => 180],
+        ['max_age_hours' => 72, 'interval_minutes' => 720],
+        ['max_age_hours' => 168, 'interval_minutes' => 1440],
     ]);
+    expect(config('metrics.max_unchanged_backoff'))->toBe(8);
 });


### PR DESCRIPTION
## Summary
- Replace the single fixed post-metrics polling interval with age bands (6h/60m, 24h/180m, 72h/720m, 168h/1440m), each clamped to the operator's per-platform minimum floor.
- Add unchanged-streak backoff: consecutive metric reads that return identical totals exponentially widen the polling interval (capped, default 8x, configurable via `METRICS_MAX_UNCHANGED_BACKOFF`), reducing wasted API calls on posts whose engagement has settled.
- Re-enable the manual "Refresh" action on the published post view so posts that have aged out of automatic polling can still be refreshed on demand; the endpoint is rate-limited (10/min) since it dispatches the capture job synchronously, bypassing the queued job's own throttling.
- Tighten the manual refresh endpoint's authorization from a blanket `viewAny(Post::class)` check to `view($post)`, scoping access to the specific post.
- Track the new streak on `post_targets` via `metrics_unchanged_streak` (new migration) and update settings copy to clarify the configured interval is a minimum floor, not a fixed cadence.

## Breaking Changes
None — the migration is additive and defaults `metrics_unchanged_streak` to 0.
