### PR TITLE
fix(sentry): skip initialization when window is undefined

### DIFF
--- a/resources/js/lib/sentry.ts
+++ b/resources/js/lib/sentry.ts
@@ -23,6 +23,10 @@ declare global {
  * so instances without Sentry configured pay nothing beyond the guard.
  */
 export function initSentry(): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
     const config = window.__sentry;
 
     if (!config?.dsn) {


### PR DESCRIPTION
## Summary
- Guards `initSentry()` to no-op when `window` is undefined, preventing SSR crashes when the Sentry init code runs in a non-browser environment