### PR TITLE
fix(engagement): fix author name truncation in reply views

### DIFF
--- a/resources/js/pages/engagement/components/reply-stream.tsx
+++ b/resources/js/pages/engagement/components/reply-stream.tsx
@@ -58,7 +58,7 @@ export function ReplyStream({ replies, selectedId, onSelect }: Props) {
                                 <div className="flex items-baseline gap-1.5">
                                     <span
                                         className={cn(
-                                            'truncate text-sm',
+                                            'min-w-0 truncate text-sm',
                                             unread
                                                 ? 'font-semibold text-foreground'
                                                 : 'font-medium text-foreground/90',
@@ -68,7 +68,7 @@ export function ReplyStream({ replies, selectedId, onSelect }: Props) {
                                             atHandle(reply.author_handle)}
                                     </span>
                                     {reply.author_name ? (
-                                        <span className="truncate text-xs text-muted-foreground">
+                                        <span className="min-w-0 truncate text-xs text-muted-foreground">
                                             {atHandle(reply.author_handle)}
                                         </span>
                                     ) : null}

--- a/resources/js/pages/engagement/components/reply-thread.tsx
+++ b/resources/js/pages/engagement/components/reply-thread.tsx
@@ -138,13 +138,13 @@ export function ReplyThread({
                                     !reply.is_read && 'border-primary/40',
                                 )}
                             >
-                                <div className="mb-0.5 flex min-w-0 flex-wrap items-baseline gap-1.5">
-                                    <span className="truncate text-xs font-semibold">
+                                <div className="mb-0.5 flex min-w-0 items-baseline gap-1.5">
+                                    <span className="min-w-0 truncate text-xs font-semibold">
                                         {reply.author_name ??
                                             atHandle(reply.author_handle)}
                                     </span>
                                     {reply.author_name ? (
-                                        <span className="truncate text-[11px] text-muted-foreground">
+                                        <span className="min-w-0 truncate text-[11px] text-muted-foreground">
                                             {atHandle(reply.author_handle)}
                                         </span>
                                     ) : null}


### PR DESCRIPTION
## Summary
- Fixed author names and handles not truncating properly in the engagement reply stream and reply thread views, which could cause text overflow
- Added `min-w-0` to the truncating name/handle spans so they respect their flex container width
- Removed `flex-wrap` from the reply thread header so overflowing text truncates instead of wrapping to a new line
