### PR TITLE
fix(publishing): escape LinkedIn Little Text Format reserved chars

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -1,0 +1,16 @@
+# Lessons
+
+## Don't chase dev-environment test failures as if they were regressions
+
+**Pattern:** While fixing a prod bug report, the local Docker PHP image lacks the GD
+extension, so ~30 image/media tests (`ImageEditApiTest`, `MediaApiTest`,
+`MediaStorageServiceTest`) fail regardless of the change. I started investigating the
+failure count instead of the reported bug.
+
+**Rule:** Prove the *delta*, not the absolute count. Stash the change, run the same
+suite, compare. Same failures before and after = environment noise; state that once and
+move on. Never report an environment failure as if it were caused by the change, and
+never let it derail the actual investigation.
+
+**Rule:** A user's bug report is about *their* environment. Reproduce against the code
+path and the vendor API contract, not against local suite health.

--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -8,9 +8,12 @@ extension, so ~30 image/media tests (`ImageEditApiTest`, `MediaApiTest`,
 failure count instead of the reported bug.
 
 **Rule:** Prove the *delta*, not the absolute count. Stash the change, run the same
-suite, compare. Same failures before and after = environment noise; state that once and
-move on. Never report an environment failure as if it were caused by the change, and
-never let it derail the actual investigation.
+suite, compare. Compare failure *identities* — which tests, which assertion, which
+message — not just how many: an already-red test can start failing for a new reason and
+mask a real regression behind an unchanged count. Same tests failing the same way before
+and after = environment noise; state that once and move on. Never report an environment
+failure as if it were caused by the change, and never let it derail the actual
+investigation.
 
 **Rule:** A user's bug report is about *their* environment. Reproduce against the code
 path and the vendor API contract, not against local suite health.

--- a/app/Services/Publishing/Connectors/LinkedInConnector.php
+++ b/app/Services/Publishing/Connectors/LinkedInConnector.php
@@ -185,10 +185,14 @@ class LinkedInConnector implements PublishConnector
 
     private function escapePlainText(string $text): string
     {
-        return (string) preg_replace_callback(
-            '/[\\\\|{}@\[\]()<>#*_~]/u',
+        $escaped = preg_replace_callback(
+            '/#[\p{L}\p{N}_]+|[\\\\|{}@\[\]()<>#*_~]/u',
             static fn (array $matches): string => mb_strlen($matches[0]) > 1 ? $matches[0] : '\\'.$matches[0],
             $text,
+        );
+
+        return $escaped ?? throw new RuntimeException(
+            'Failed to escape LinkedIn commentary: '.preg_last_error_msg()
         );
     }
 
@@ -198,12 +202,25 @@ class LinkedInConnector implements PublishConnector
      */
     private function escapeMention(string $mention): string
     {
-        return (string) preg_replace_callback(
+        $escaped = preg_replace_callback(
             '/^@\[([^\]]*)\]\((.+)\)$/',
             fn (array $matches): string => '@['
-                .preg_replace('/[\\\\|{}@\[\]()<>#*_~]/u', '\\\\$0', $matches[1])
+                .$this->escapeMentionName($matches[1])
                 .']('.$matches[2].')',
             $mention,
+        );
+
+        return $escaped ?? throw new RuntimeException(
+            'Failed to escape LinkedIn mention: '.preg_last_error_msg()
+        );
+    }
+
+    private function escapeMentionName(string $name): string
+    {
+        $escaped = preg_replace('/[\\\\|{}@\[\]()<>#*_~]/u', '\\\\$0', $name);
+
+        return $escaped ?? throw new RuntimeException(
+            'Failed to escape LinkedIn mention name: '.preg_last_error_msg()
         );
     }
 

--- a/app/Services/Publishing/Connectors/LinkedInConnector.php
+++ b/app/Services/Publishing/Connectors/LinkedInConnector.php
@@ -88,7 +88,7 @@ class LinkedInConnector implements PublishConnector
         try {
             $body = [
                 'author' => $author,
-                'commentary' => $text,
+                'commentary' => $this->escapeCommentary($text),
                 'visibility' => 'PUBLIC',
                 'lifecycleState' => 'PUBLISHED',
                 'distribution' => [
@@ -147,6 +147,64 @@ class LinkedInConnector implements PublishConnector
         }
 
         return PublishResult::success([$urn]);
+    }
+
+    /**
+     * `commentary` is little Text Format, not plain text. Every reserved character
+     * must be backslash-escaped; an unescaped one (a `(` is the common case) makes
+     * LinkedIn's parser silently drop the rest of the post body rather than reject
+     * the request, so posts publish looking truncated.
+     *
+     * Two constructs are deliberately left intact because they are real little
+     * elements the app relies on:
+     *  - `@[Name](urn:li:...)` mention annotations emitted by DraftService.
+     *  - `#hashtag`, which LinkedIn links only while the `#` stays unescaped.
+     *
+     * @see https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/little-text-format
+     */
+    private function escapeCommentary(string $text): string
+    {
+        $parts = preg_split(
+            '/(@\[[^\]]*\]\(urn:li:(?:organization|person):\d+\))/',
+            $text,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE,
+        ) ?: [$text];
+
+        $escaped = array_map(function (string $part, int $index): string {
+            // preg_split with DELIM_CAPTURE puts the captured mentions at odd offsets.
+            if ($index % 2 === 1) {
+                return $this->escapeMention($part);
+            }
+
+            return $this->escapePlainText($part);
+        }, $parts, array_keys($parts));
+
+        return implode('', $escaped);
+    }
+
+    private function escapePlainText(string $text): string
+    {
+        return (string) preg_replace_callback(
+            '/#[\p{L}\p{N}_]+|[\\\\|{}@\[\]()<>#*_~]/u',
+            static fn (array $matches): string => mb_strlen($matches[0]) > 1 ? $matches[0] : '\\'.$matches[0],
+            $text,
+        );
+    }
+
+    /**
+     * Keep a mention's `@[...](urn)` scaffolding but escape reserved characters in
+     * the display name, which is free-form and would otherwise break the element.
+     */
+    private function escapeMention(string $mention): string
+    {
+        return (string) preg_replace_callback(
+            '/^@\[([^\]]*)\]\((.+)\)$/',
+            fn (array $matches): string => '@['
+                .preg_replace('/[\\\\|{}@\[\]()<>#*_~]/u', '\\\\$0', $matches[1])
+                .']('.$matches[2].')',
+            $mention,
+        );
     }
 
     /**

--- a/app/Services/Publishing/Connectors/LinkedInConnector.php
+++ b/app/Services/Publishing/Connectors/LinkedInConnector.php
@@ -171,22 +171,22 @@ class LinkedInConnector implements PublishConnector
             PREG_SPLIT_DELIM_CAPTURE,
         ) ?: [$text];
 
-        $escaped = array_map(function (string $part, int $index): string {
+        $escaped = '';
+
+        foreach ($parts as $index => $part) {
             // preg_split with DELIM_CAPTURE puts the captured mentions at odd offsets.
-            if ($index % 2 === 1) {
-                return $this->escapeMention($part);
-            }
+            $escaped .= $index % 2 === 1
+                ? $this->escapeMention($part)
+                : $this->escapePlainText($part);
+        }
 
-            return $this->escapePlainText($part);
-        }, $parts, array_keys($parts));
-
-        return implode('', $escaped);
+        return $escaped;
     }
 
     private function escapePlainText(string $text): string
     {
         return (string) preg_replace_callback(
-            '/#[\p{L}\p{N}_]+|[\\\\|{}@\[\]()<>#*_~]/u',
+            '/[\\\\|{}@\[\]()<>#*_~]/u',
             static fn (array $matches): string => mb_strlen($matches[0]) > 1 ? $matches[0] : '\\'.$matches[0],
             $text,
         );

--- a/tests/Feature/Publishing/LinkedInConnectorTest.php
+++ b/tests/Feature/Publishing/LinkedInConnectorTest.php
@@ -219,6 +219,16 @@ test('linkedin preserves mention annotations while escaping surrounding text', f
     Http::assertSent(fn ($request) => $request['commentary'] === 'Built with @[coolLabs](urn:li:organization:2414183) \(open source\)');
 });
 
+test('linkedin leaves hashtags unescaped so LinkedIn links them', function () {
+    Http::fake([
+        'https://api.linkedin.com/rest/posts' => Http::response([], 201, ['x-restli-id' => 'urn:li:share:1']),
+    ]);
+
+    app(LinkedInConnector::class)->publish(liContext(['Shipping #v2 today (really) in C# too']));
+
+    Http::assertSent(fn ($request) => $request['commentary'] === 'Shipping #v2 today \(really\) in C\# too');
+});
+
 test('linkedin maps 401 to AuthExpired', function () {
     Http::fake(['https://api.linkedin.com/rest/posts' => Http::response(['message' => 'expired'], 401)]);
 

--- a/tests/Feature/Publishing/LinkedInConnectorTest.php
+++ b/tests/Feature/Publishing/LinkedInConnectorTest.php
@@ -197,6 +197,28 @@ test('linkedin joins every segment into one post', function () {
         && $request['commentary'] === "first\nsecond");
 });
 
+test('linkedin escapes little-text reserved characters in commentary', function () {
+    Http::fake([
+        'https://api.linkedin.com/rest/posts' => Http::response([], 201, ['x-restli-id' => 'urn:li:share:1']),
+    ]);
+
+    app(LinkedInConnector::class)->publish(liContext(['We shipped v2 (finally). Read more_here!']));
+
+    Http::assertSent(fn ($request) => $request['commentary'] === 'We shipped v2 \(finally\). Read more\_here!');
+});
+
+test('linkedin preserves mention annotations while escaping surrounding text', function () {
+    Http::fake([
+        'https://api.linkedin.com/rest/posts' => Http::response([], 201, ['x-restli-id' => 'urn:li:share:1']),
+    ]);
+
+    app(LinkedInConnector::class)->publish(liContext([
+        'Built with @[coolLabs](urn:li:organization:2414183) (open source)',
+    ]));
+
+    Http::assertSent(fn ($request) => $request['commentary'] === 'Built with @[coolLabs](urn:li:organization:2414183) \(open source\)');
+});
+
 test('linkedin maps 401 to AuthExpired', function () {
     Http::fake(['https://api.linkedin.com/rest/posts' => Http::response(['message' => 'expired'], 401)]);
 

--- a/tests/Feature/Publishing/LinkedInConnectorTest.php
+++ b/tests/Feature/Publishing/LinkedInConnectorTest.php
@@ -229,6 +229,18 @@ test('linkedin leaves hashtags unescaped so LinkedIn links them', function () {
     Http::assertSent(fn ($request) => $request['commentary'] === 'Shipping #v2 today \(really\) in C\# too');
 });
 
+test('linkedin throws rather than publishing empty commentary when escaping fails', function () {
+    Http::fake([
+        'https://api.linkedin.com/rest/posts' => Http::response([], 201, ['x-restli-id' => 'urn:li:share:1']),
+    ]);
+
+    // Truncated multibyte sequence: the /u escape pattern bails with PREG_BAD_UTF8_ERROR.
+    expect(fn () => app(LinkedInConnector::class)->publish(liContext(["broken \xC3 text"])))
+        ->toThrow(RuntimeException::class, 'Failed to escape LinkedIn commentary');
+
+    Http::assertNothingSent();
+});
+
 test('linkedin maps 401 to AuthExpired', function () {
     Http::fake(['https://api.linkedin.com/rest/posts' => Http::response(['message' => 'expired'], 401)]);
 


### PR DESCRIPTION
## Summary
- LinkedIn's `commentary` field uses Little Text Format, not plain text; unescaped reserved characters (e.g. `(`) caused LinkedIn to silently drop the rest of the post body, making published posts appear truncated
- Escape reserved Little Text Format characters in post commentary before sending to LinkedIn's API
- Preserve `@[Name](urn:li:...)` mention annotations and `#hashtag` linking, which must stay unescaped to keep working, while still escaping reserved characters inside a mention's display name
- Add tests covering reserved-character escaping and mention preservation
