### PR TITLE
feat(publishing): instagram/threads image conversion and fixes

### DIFF
--- a/app/Models/PostMedia.php
+++ b/app/Models/PostMedia.php
@@ -75,9 +75,7 @@ class PostMedia extends Model
 
             // Publish-time format conversions (JPEG for Meta, MP4 for GIFs) live
             // beside the original and would otherwise be left behind.
-            foreach (DerivedMedia::pathsFor($media) as $derived) {
-                FileStorage::disk($media->disk)->delete($derived);
-            }
+            FileStorage::disk($media->disk)->delete(DerivedMedia::pathsFor($media));
 
             if ($media->source_path !== null) {
                 FileStorage::disk($media->source_disk ?? $media->disk)->delete($media->source_path);

--- a/app/Models/PostMedia.php
+++ b/app/Models/PostMedia.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Concerns\HasWorkspaceScope;
+use App\Services\Media\DerivedMedia;
 use App\Support\FileStorage;
 use Database\Factories\PostMediaFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -71,6 +72,12 @@ class PostMedia extends Model
     {
         static::deleting(function (PostMedia $media): void {
             FileStorage::disk($media->disk)->delete($media->path);
+
+            // Publish-time format conversions (JPEG for Meta, MP4 for GIFs) live
+            // beside the original and would otherwise be left behind.
+            foreach (DerivedMedia::pathsFor($media) as $derived) {
+                FileStorage::disk($media->disk)->delete($derived);
+            }
 
             if ($media->source_path !== null) {
                 FileStorage::disk($media->source_disk ?? $media->disk)->delete($media->source_path);

--- a/app/Services/Media/ConvertedImage.php
+++ b/app/Services/Media/ConvertedImage.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Media;
+
+final readonly class ConvertedImage
+{
+    public function __construct(
+        public string $disk,
+        public string $path,
+    ) {}
+}

--- a/app/Services/Media/DerivedMedia.php
+++ b/app/Services/Media/DerivedMedia.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Media;
+
+use App\Models\PostMedia;
+
+/**
+ * The shared naming convention for files derived from a PostMedia at publish time,
+ * when a platform needs the media in a format the stored original isn't in
+ * (GifToMp4Converter, ImageToJpegConverter).
+ *
+ * Derived files sit beside the original on the same disk and are keyed by media id,
+ * so a retry reuses the existing one and deleting the media can clean them up.
+ */
+final class DerivedMedia
+{
+    /** Extensions the converters write; kept here so deletion can find them all. */
+    private const array EXTENSIONS = ['jpg', 'mp4'];
+
+    public static function path(PostMedia $media, string $extension): string
+    {
+        return 'media/'.$media->workspace_id.'/derived/'.$media->id.'.'.$extension;
+    }
+
+    /**
+     * Every path a converter could have written for this media.
+     *
+     * @return list<string>
+     */
+    public static function pathsFor(PostMedia $media): array
+    {
+        return array_map(
+            static fn (string $extension): string => self::path($media, $extension),
+            self::EXTENSIONS,
+        );
+    }
+}

--- a/app/Services/Media/GifToMp4Converter.php
+++ b/app/Services/Media/GifToMp4Converter.php
@@ -107,7 +107,7 @@ class GifToMp4Converter
 
     private function derivedPath(PostMedia $media): string
     {
-        return 'media/'.$media->workspace_id.'/derived/'.$media->id.'.mp4';
+        return DerivedMedia::path($media, 'mp4');
     }
 
     private function encode(string $ffmpeg, string $input, string $output, int $maxBytes): void

--- a/app/Services/Media/ImageConversionFailed.php
+++ b/app/Services/Media/ImageConversionFailed.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Media;
+
+use RuntimeException;
+
+class ImageConversionFailed extends RuntimeException {}

--- a/app/Services/Media/ImageToJpegConverter.php
+++ b/app/Services/Media/ImageToJpegConverter.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Media;
+
+use App\Models\PostMedia;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Format;
+use Intervention\Image\ImageManager;
+use Throwable;
+
+/**
+ * Re-encodes a stored image to JPEG alongside the original, for the URL-fetch platforms
+ * (Instagram, Threads) that reject the source format.
+ *
+ * Those platforms publish by handing Meta a public URL it fetches server-side, so unlike
+ * the byte-upload connectors they cannot convert in flight — the bytes Meta reads are
+ * whatever is on disk. The derived file is written next to the original (mirroring
+ * GifToMp4Converter) and reused on a later publish attempt or retry.
+ */
+class ImageToJpegConverter
+{
+    private const int QUALITY = 90;
+
+    /**
+     * @param  int  $maxPixels  Decode guard mirroring ImageCompressor: refuse to decode a
+     *                          pathologically large canvas rather than OOM the worker.
+     */
+    public function __construct(private readonly int $maxPixels = ImageCompressor::DEFAULT_MAX_PIXELS) {}
+
+    public function convert(PostMedia $media): ConvertedImage
+    {
+        $disk = Storage::disk($media->disk);
+        $derivedPath = $this->derivedPath($media);
+
+        if ($disk->exists($derivedPath)) {
+            return new ConvertedImage($media->disk, $derivedPath);
+        }
+
+        $bytes = $disk->get($media->path);
+
+        if ($bytes === null || $bytes === '') {
+            throw new ImageConversionFailed('Could not read the image to convert it to JPEG.');
+        }
+
+        $info = @getimagesizefromstring($bytes);
+
+        if (is_array($info) && ($info[0] * $info[1]) > $this->maxPixels) {
+            throw new ImageConversionFailed('The image resolution is too large to convert to JPEG.');
+        }
+
+        try {
+            // JPEG has no alpha; the GD JPEG encoder flattens onto the driver's
+            // configured background (white), so transparent PNGs keep a white
+            // backdrop rather than picking up black fringing.
+            $image = ImageManager::usingDriver(GdDriver::class)->decodeBinary($bytes);
+            $encoded = (string) $image->encodeUsingFormat(Format::JPEG, quality: self::QUALITY);
+        } catch (Throwable $e) {
+            throw new ImageConversionFailed('Could not convert the image to JPEG.', previous: $e);
+        }
+
+        $disk->put($derivedPath, $encoded);
+
+        return new ConvertedImage($media->disk, $derivedPath);
+    }
+
+    private function derivedPath(PostMedia $media): string
+    {
+        return DerivedMedia::path($media, 'jpg');
+    }
+}

--- a/app/Services/Media/PublicMediaUrl.php
+++ b/app/Services/Media/PublicMediaUrl.php
@@ -4,21 +4,62 @@ declare(strict_types=1);
 
 namespace App\Services\Media;
 
+use App\Enums\Platform;
 use App\Models\PostMedia;
 use App\Support\FileStorage;
+use Illuminate\Support\Facades\URL;
 
 /**
  * Resolves a publicly reachable HTTPS URL for a stored media file, for
  * platforms (Instagram, Threads) that publish by handing Meta a URL it
  * fetches server-side rather than accepting an uploaded byte stream.
  *
- * Uses the shared storage URL resolver: public disks receive plain URLs while
- * private disks receive signed URLs with enough time for container processing.
+ * Two things make this different from the URL the browser loads (PostMedia::url):
+ *
+ *  - It must be absolute. The `public` disk is configured host-relative
+ *    ('url' => '/storage') so an <img> resolves it against the current origin;
+ *    Meta fetches from its own servers and has no origin to resolve against.
+ *  - It must point at bytes in a format the platform accepts. The byte-upload
+ *    connectors re-encode in flight, but Meta reads whatever is on disk, so a
+ *    non-conforming image is converted to a derived JPEG first.
  */
 class PublicMediaUrl
 {
-    public function for(PostMedia $media): string
+    public function __construct(private readonly ImageToJpegConverter $converter) {}
+
+    /**
+     * @param  Platform|null  $platform  The destination whose accepted image formats apply.
+     *                                   Omitted, the stored file is used as-is.
+     *
+     * @throws ImageConversionFailed
+     */
+    public function for(PostMedia $media, ?Platform $platform = null): string
     {
-        return FileStorage::url($media->path, $media->disk);
+        $disk = $media->disk;
+        $path = $media->path;
+
+        if ($this->needsConversion($media, $platform)) {
+            $converted = $this->converter->convert($media);
+            $disk = $converted->disk;
+            $path = $converted->path;
+        }
+
+        return $this->absolute(FileStorage::url($path, $disk));
+    }
+
+    private function needsConversion(PostMedia $media, ?Platform $platform): bool
+    {
+        return $platform !== null
+            && ! $media->isVideo()
+            && ! in_array($media->mime, $platform->allowedMime(), true);
+    }
+
+    /**
+     * Host-relative disk URLs are correct for the browser but unfetchable by Meta, so
+     * resolve them against the app's own origin.
+     */
+    private function absolute(string $url): string
+    {
+        return parse_url($url, PHP_URL_SCHEME) === null ? URL::to($url) : $url;
     }
 }

--- a/app/Services/Publishing/Connectors/InstagramConnector.php
+++ b/app/Services/Publishing/Connectors/InstagramConnector.php
@@ -12,6 +12,7 @@ use App\Enums\Platform;
 use App\Enums\UsageCategory;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
+use App\Services\Media\ImageConversionFailed;
 use App\Services\Media\PublicMediaUrl;
 use App\Services\Publishing\Connectors\Concerns\MapsHttpErrors;
 use App\Services\Publishing\Contracts\PublishConnector;
@@ -99,6 +100,10 @@ class InstagramConnector implements PublishConnector
             $mediaId = (string) $publish->json('id');
         } catch (InstagramRequestFailed $e) {
             return $this->mapFailure($e->response);
+        } catch (ImageConversionFailed $e) {
+            // The image can't be re-encoded to the JPEG Instagram requires; retrying
+            // won't change that, so fail with the reason rather than looping.
+            return PublishResult::failure(ErrorKind::Unsupported, $e->getMessage());
         } catch (ConnectionException $e) {
             return PublishResult::failure(ErrorKind::Network, $e->getMessage());
         }
@@ -143,9 +148,9 @@ class InstagramConnector implements PublishConnector
 
         if ($media->isVideo()) {
             $body['media_type'] = 'REELS';
-            $body['video_url'] = $this->publicMediaUrl->for($media);
+            $body['video_url'] = $this->publicMediaUrl->for($media, Platform::Instagram);
         } else {
-            $body['image_url'] = $this->publicMediaUrl->for($media);
+            $body['image_url'] = $this->publicMediaUrl->for($media, Platform::Instagram);
         }
 
         $response = $this->http->asForm()->post($this->baseUrl().'/'.$igUserId.'/media', $body);
@@ -203,7 +208,7 @@ class InstagramConnector implements PublishConnector
             'is_carousel_item' => 'true',
             'access_token' => $token,
         ];
-        $body[$media->isVideo() ? 'video_url' : 'image_url'] = $this->publicMediaUrl->for($media);
+        $body[$media->isVideo() ? 'video_url' : 'image_url'] = $this->publicMediaUrl->for($media, Platform::Instagram);
 
         $response = $this->http->asForm()->post($this->baseUrl().'/'.$igUserId.'/media', $body);
 

--- a/app/Services/Publishing/Connectors/ThreadsConnector.php
+++ b/app/Services/Publishing/Connectors/ThreadsConnector.php
@@ -12,6 +12,7 @@ use App\Enums\Platform;
 use App\Enums\UsageCategory;
 use App\Models\PostMedia;
 use App\Models\PostTarget;
+use App\Services\Media\ImageConversionFailed;
 use App\Services\Media\PublicMediaUrl;
 use App\Services\Publishing\Connectors\Concerns\MapsHttpErrors;
 use App\Services\Publishing\Contracts\PublishConnector;
@@ -117,6 +118,10 @@ class ThreadsConnector implements PublishConnector
             }
         } catch (ThreadsRequestFailed $e) {
             return $this->mapFailure($e->response);
+        } catch (ImageConversionFailed $e) {
+            // The image can't be re-encoded to a format Threads accepts; retrying
+            // won't change that, so fail with the reason rather than looping.
+            return PublishResult::failure(ErrorKind::Unsupported, $e->getMessage());
         } catch (ConnectionException $e) {
             return PublishResult::failure(ErrorKind::Network, $e->getMessage());
         }
@@ -188,7 +193,7 @@ class ThreadsConnector implements PublishConnector
             'text' => $text,
             'access_token' => $token,
         ];
-        $body[$media->isVideo() ? 'video_url' : 'image_url'] = $this->publicMediaUrl->for($media);
+        $body[$media->isVideo() ? 'video_url' : 'image_url'] = $this->publicMediaUrl->for($media, Platform::Threads);
 
         if ($replyToId !== null) {
             $body['reply_to_id'] = $replyToId;
@@ -240,7 +245,7 @@ class ThreadsConnector implements PublishConnector
             'media_type' => $media->isVideo() ? 'VIDEO' : 'IMAGE',
             'access_token' => $token,
         ];
-        $body[$media->isVideo() ? 'video_url' : 'image_url'] = $this->publicMediaUrl->for($media);
+        $body[$media->isVideo() ? 'video_url' : 'image_url'] = $this->publicMediaUrl->for($media, Platform::Threads);
 
         return $this->createContainer($context, $threadsUserId, $body);
     }

--- a/tests/Feature/Publishing/InstagramConnectorTest.php
+++ b/tests/Feature/Publishing/InstagramConnectorTest.php
@@ -10,6 +10,16 @@ use App\Services\Publishing\Connectors\InstagramConnector;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 
+/** A real, decodable 2x2 PNG so the JPEG conversion path has actual bytes to work on. */
+function pngBytes(): string
+{
+    $image = imagecreatetruecolor(2, 2);
+    ob_start();
+    imagepng($image);
+
+    return (string) ob_get_clean();
+}
+
 /**
  * @param  list<PostMedia>  $media
  * @param  array<string, mixed>  $targetOverrides
@@ -66,6 +76,30 @@ test('instagram publishes a single image through the container flow', function (
 
     Http::assertSent(fn ($request) => str_contains($request->url(), '/ig123/media_publish')
         && $request['creation_id'] === 'container-1');
+});
+
+test('instagram converts a non-jpeg image and hands Meta the derived jpeg url', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/pic.png', pngBytes());
+
+    $media = PostMedia::factory()->create(['disk' => 'public', 'path' => 'media/pic.png', 'mime' => 'image/png']);
+
+    Http::fake([
+        'https://graph.facebook.com/*/ig123/media' => Http::response(['id' => 'container-png']),
+        'https://graph.facebook.com/*/container-png*' => Http::response(['status_code' => 'FINISHED']),
+        'https://graph.facebook.com/*/ig123/media_publish' => Http::response(['id' => 'media-png']),
+    ]);
+
+    $result = app(InstagramConnector::class)->publish(igContext(['a png'], [$media]));
+
+    expect($result->isSuccessful())->toBeTrue();
+
+    // Instagram accepts JPEG only (Platform::Instagram->allowedMime()); a .png url is
+    // rejected by Meta with "Only image and video media type is allowed".
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/ig123/media')
+        && ! str_contains($request->url(), 'media_publish')
+        && ! str_contains((string) $request['image_url'], '.png')
+        && str_contains((string) $request['image_url'], '.jpg'));
 });
 
 test('instagram returns a MediaProcessing failure and persists the container id while the status is IN_PROGRESS', function () {

--- a/tests/Unit/Media/ImageToJpegConverterTest.php
+++ b/tests/Unit/Media/ImageToJpegConverterTest.php
@@ -18,7 +18,7 @@ function transparentPng(int $width = 4, int $height = 4): string
 
 function mimeOf(string $bytes): string
 {
-    return (new finfo(FILEINFO_MIME_TYPE))->buffer($bytes);
+    return (new \finfo(FILEINFO_MIME_TYPE))->buffer($bytes);
 }
 
 it('re-encodes a png to a real jpeg stored alongside the original', function () {

--- a/tests/Unit/Media/ImageToJpegConverterTest.php
+++ b/tests/Unit/Media/ImageToJpegConverterTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use App\Models\PostMedia;
+use App\Services\Media\ImageConversionFailed;
+use App\Services\Media\ImageToJpegConverter;
+use Illuminate\Support\Facades\Storage;
+
+function transparentPng(int $width = 4, int $height = 4): string
+{
+    $image = imagecreatetruecolor($width, $height);
+    imagesavealpha($image, true);
+    imagefill($image, 0, 0, imagecolorallocatealpha($image, 0, 0, 0, 127));
+    ob_start();
+    imagepng($image);
+
+    return (string) ob_get_clean();
+}
+
+function mimeOf(string $bytes): string
+{
+    return (new finfo(FILEINFO_MIME_TYPE))->buffer($bytes);
+}
+
+it('re-encodes a png to a real jpeg stored alongside the original', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/ws/pic.png', transparentPng());
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/ws/pic.png',
+        'mime' => 'image/png',
+    ]);
+
+    $converted = app(ImageToJpegConverter::class)->convert($media);
+
+    expect($converted->disk)->toBe('public')
+        ->and($converted->path)->toBe('media/'.$media->workspace_id.'/derived/'.$media->id.'.jpg');
+
+    Storage::disk('public')->assertExists($converted->path);
+
+    // The URL ending in .jpg is not enough — Meta reads the bytes, so assert the
+    // stored file really is JPEG-encoded.
+    expect(mimeOf((string) Storage::disk('public')->get($converted->path)))->toBe('image/jpeg');
+
+    // The original is left untouched for the other destinations sharing this file.
+    Storage::disk('public')->assertExists('media/ws/pic.png');
+});
+
+it('reuses an already-derived jpeg instead of re-encoding on a retry', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/ws/pic.png', transparentPng());
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/ws/pic.png',
+        'mime' => 'image/png',
+    ]);
+
+    $converter = app(ImageToJpegConverter::class);
+    $first = $converter->convert($media);
+
+    Storage::disk('public')->put($first->path, 'sentinel-bytes');
+
+    $second = $converter->convert($media);
+
+    expect($second->path)->toBe($first->path)
+        ->and(Storage::disk('public')->get($second->path))->toBe('sentinel-bytes');
+});
+
+it('deletes the derived jpeg when the media row is removed', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/ws/pic.png', transparentPng());
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/ws/pic.png',
+        'mime' => 'image/png',
+    ]);
+
+    $derived = app(ImageToJpegConverter::class)->convert($media)->path;
+    Storage::disk('public')->assertExists($derived);
+
+    $media->delete();
+
+    Storage::disk('public')->assertMissing($derived);
+    Storage::disk('public')->assertMissing('media/ws/pic.png');
+});
+
+it('fails with an actionable error when the bytes cannot be decoded', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/ws/pic.png', 'not-an-image');
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/ws/pic.png',
+        'mime' => 'image/png',
+    ]);
+
+    app(ImageToJpegConverter::class)->convert($media);
+})->throws(ImageConversionFailed::class);
+
+it('refuses to decode a canvas beyond the pixel ceiling', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/ws/huge.png', transparentPng(50, 50));
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/ws/huge.png',
+        'mime' => 'image/png',
+    ]);
+
+    (new ImageToJpegConverter(maxPixels: 100))->convert($media);
+})->throws(ImageConversionFailed::class);

--- a/tests/Unit/Media/PublicMediaUrlTest.php
+++ b/tests/Unit/Media/PublicMediaUrlTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\Platform;
 use App\Models\PostMedia;
 use App\Services\Media\PublicMediaUrl;
 use Illuminate\Support\Facades\Storage;
@@ -17,6 +18,71 @@ it('returns a url containing the path for media on the public disk', function ()
 
     expect($url)->toContain('media/ws/pic.jpg')
         ->and($url)->not->toContain('signature=');
+});
+
+it('returns an absolute url for public-disk media so Meta can fetch it server-side', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/ws/pic.jpg', 'contents');
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/ws/pic.jpg',
+    ]);
+
+    $url = app(PublicMediaUrl::class)->for($media);
+
+    // The `public` disk is configured host-relative ('url' => '/storage') so the
+    // browser resolves it against the current origin. Meta fetches server-side and
+    // has no origin, so a relative path is unfetchable.
+    expect(parse_url($url, PHP_URL_SCHEME))->not->toBeNull()
+        ->and(parse_url($url, PHP_URL_HOST))->not->toBeNull();
+});
+
+it('leaves an already-conforming jpeg untouched rather than deriving a copy', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/ws/pic.jpg', 'jpg-bytes');
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/ws/pic.jpg',
+        'mime' => 'image/jpeg',
+    ]);
+
+    $url = app(PublicMediaUrl::class)->for($media, Platform::Instagram);
+
+    expect($url)->toContain('media/ws/pic.jpg')
+        ->and($url)->not->toContain('/derived/');
+});
+
+it('does not run a video through the image converter', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/ws/clip.mp4', 'mp4-bytes');
+
+    $media = PostMedia::factory()->video()->create([
+        'disk' => 'public',
+        'path' => 'media/ws/clip.mp4',
+    ]);
+
+    $url = app(PublicMediaUrl::class)->for($media, Platform::Instagram);
+
+    expect($url)->toContain('media/ws/clip.mp4')
+        ->and($url)->not->toContain('/derived/');
+});
+
+it('converts a webp for Threads, which accepts jpeg and png only', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/ws/pic.webp', transparentPng());
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/ws/pic.webp',
+        'mime' => 'image/webp',
+    ]);
+
+    $url = app(PublicMediaUrl::class)->for($media, Platform::Threads);
+
+    expect($url)->toContain('/derived/')
+        ->and($url)->toContain('.jpg');
 });
 
 it('signs the url for media on a private disk so Meta can fetch it over a real HTTPS endpoint', function () {


### PR DESCRIPTION
## Summary
- Instagram and Threads publish media by handing Meta a URL it fetches server-side, so images in formats those platforms reject (e.g. PNG, WebP) now fail with "media type error". Adds an `ImageToJpegConverter` that re-encodes such images to JPEG before generating the public URL.
- `PublicMediaUrl` now accepts an optional `Platform` and only converts when the stored image's mime type isn't in that platform's allowed list; videos and already-conforming images are left untouched.
- The derived JPEG is written alongside the original (same convention as the existing GIF→MP4 conversion), reused on retries, and cleaned up automatically when the `PostMedia` row is deleted.
- If conversion fails (undecodable bytes, oversized canvas), Instagram/Threads publishing now fails immediately with a clear error instead of retrying indefinitely.

## Breaking Changes
None — `PublicMediaUrl::for()` remains backward-compatible with a single argument; existing callers are unaffected.
