### PR TITLE
fix(engagement): stop linkedIn reply fetch from 403ing on missing scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ frankenphp-worker.php
 
 # Transient Claude Code agent worktrees
 /.claude/worktrees
+
+# Per-task scratchpad, not tracked
+/.ai/todo.md

--- a/app/Http/Controllers/ConnectedAccounts/OAuthConnectionController.php
+++ b/app/Http/Controllers/ConnectedAccounts/OAuthConnectionController.php
@@ -28,6 +28,7 @@ class OAuthConnectionController extends Controller
         private readonly AccountConnectionService $connections,
         private readonly XAccountCapabilities $xCapabilities,
         private readonly ThreadsTokenExchanger $threadsExchanger,
+        private readonly InstanceSettings $settings,
     ) {}
 
     public function redirect(Request $request, string $platform): Response
@@ -36,7 +37,7 @@ class OAuthConnectionController extends Controller
 
         $request->user()->can('create', ConnectedAccount::class) ?: abort(403);
 
-        return $this->driver($resolved)->setScopes($resolved->scopes())->redirect();
+        return $this->driver($resolved)->setScopes($this->scopesFor($resolved))->redirect();
     }
 
     public function callback(Request $request, string $platform): RedirectResponse
@@ -83,6 +84,17 @@ class OAuthConnectionController extends Controller
 
         if ($resolved === Platform::X) {
             $data = $data->withCapabilities($this->xCapabilities->forAccessToken($data->accessToken));
+        }
+
+        if ($resolved === Platform::LinkedIn) {
+            // Record whether LinkedIn actually granted the restricted Community
+            // Management read scope, so the engagement inbox only polls accounts
+            // that can read replies (others 403). `approvedScopes` comes from the
+            // token response's `scope` field.
+            $granted = (array) $oauthUser->approvedScopes;
+            $data = $data->withCapabilities([
+                'linkedin_engagement' => in_array('r_member_social_feed', $granted, true),
+            ]);
         }
 
         if ($resolved === Platform::Threads) {
@@ -148,6 +160,25 @@ class OAuthConnectionController extends Controller
             str_contains($message, '401'), str_contains($message, '403'), str_contains($message, 'Unauthorized'), str_contains($message, 'Forbidden') => "{$platform->label()} refused the request. Check your {$platform->label()} app's credentials and permissions, then try again.",
             default => "We couldn't connect your {$platform->label()} account. Please try again.",
         };
+    }
+
+    /**
+     * OAuth scopes to request for a platform. LinkedIn's engagement inbox needs
+     * the restricted Community Management feed scopes; they are only appended
+     * when the operator has declared the app is approved for them, because
+     * requesting a scope an app lacks makes LinkedIn reject the whole authorize.
+     *
+     * @return list<string>
+     */
+    private function scopesFor(Platform $platform): array
+    {
+        $scopes = $platform->scopes();
+
+        if ($platform === Platform::LinkedIn && $this->settings->linkedinCommunityManagementEnabled()) {
+            $scopes = [...$scopes, 'r_member_social_feed', 'w_member_social_feed'];
+        }
+
+        return $scopes;
     }
 
     private function resolveOAuthPlatform(string $platform): Platform

--- a/app/Http/Requests/Settings/UpdateInstanceSettingsRequest.php
+++ b/app/Http/Requests/Settings/UpdateInstanceSettingsRequest.php
@@ -31,15 +31,16 @@ class UpdateInstanceSettingsRequest extends FormRequest
             'workspace_creation_enabled' => ['required', 'boolean'],
             'usage_tracking_enabled' => ['required', 'boolean'],
             'quote_tweets_enabled' => ['required', 'boolean'],
+            'linkedin_community_management_enabled' => ['required', 'boolean'],
         ];
     }
 
     /**
-     * @return array{registrations_enabled: bool, workspace_creation_enabled: bool, usage_tracking_enabled: bool, quote_tweets_enabled: bool}
+     * @return array{registrations_enabled: bool, workspace_creation_enabled: bool, usage_tracking_enabled: bool, quote_tweets_enabled: bool, linkedin_community_management_enabled: bool}
      */
     public function instanceSettings(): array
     {
-        /** @var array{registrations_enabled: bool, workspace_creation_enabled: bool, usage_tracking_enabled: bool, quote_tweets_enabled: bool} $settings */
+        /** @var array{registrations_enabled: bool, workspace_creation_enabled: bool, usage_tracking_enabled: bool, quote_tweets_enabled: bool, linkedin_community_management_enabled: bool} $settings */
         $settings = $this->validated();
 
         if (! (bool) config('kit.workspaces.enabled')) {

--- a/app/Jobs/FetchPostTargetReplies.php
+++ b/app/Jobs/FetchPostTargetReplies.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\Enums\EngagementStatus;
+use App\Enums\Platform;
 use App\Exceptions\TokenRefreshException;
 use App\Jobs\Concerns\ReportsReplyFetch;
 use App\Jobs\Contracts\ReleasableJob;
@@ -87,6 +88,16 @@ class FetchPostTargetReplies implements ReleasableJob, ShouldBeUnique, ShouldQue
 
         $scope = "target:{$target->id}";
 
+        // Skip accounts whose credentials can't read replies (LinkedIn without the
+        // restricted Community Management scope), so we never issue a call we know
+        // will 403 — the dispatcher's platform gate stops most of this, but old
+        // LinkedIn accounts linger until they reconnect.
+        if (! $account->canFetchEngagement()) {
+            $this->logFetchOutcome($target->platform->value, $account->id, $scope, EngagementStatus::Unsupported->value);
+
+            return;
+        }
+
         try {
             $credentials = $tokens->fresh($account);
         } catch (TokenRefreshException) {
@@ -110,6 +121,15 @@ class FetchPostTargetReplies implements ReleasableJob, ShouldBeUnique, ShouldQue
         if (! $result->isOk()) {
             if ($result->status === EngagementStatus::RateLimited) {
                 $this->release($this->parkForRateLimit($account, $result->retryAfterSeconds));
+            }
+
+            // A LinkedIn 403 despite a positive capability means the restricted
+            // scope was revoked (or never truly effective) — record it so the
+            // account stops being polled until it reconnects.
+            if ($result->status === EngagementStatus::Unsupported && $target->platform === Platform::LinkedIn) {
+                $account->forceFill([
+                    'capabilities' => [...($account->capabilities ?? []), 'linkedin_engagement' => false],
+                ])->save();
             }
 
             $this->logFetchOutcome($target->platform->value, $account->id, $scope, $result->status->value, 0, $result->retryAfterSeconds);

--- a/app/Models/ConnectedAccount.php
+++ b/app/Models/ConnectedAccount.php
@@ -103,6 +103,22 @@ class ConnectedAccount extends Model
     }
 
     /**
+     * Whether this account's credentials can read replies for the engagement
+     * inbox. Only LinkedIn is capability-gated: reading member comments needs the
+     * restricted `r_member_social_feed` scope, recorded at connect. Accounts
+     * connected before that grant (null capability) — or whose grant lacked it —
+     * are skipped so we don't hammer LinkedIn with calls that 403.
+     */
+    public function canFetchEngagement(): bool
+    {
+        if ($this->platform !== Platform::LinkedIn) {
+            return true;
+        }
+
+        return (bool) ($this->capabilities['linkedin_engagement'] ?? false);
+    }
+
+    /**
      * @param  Builder<ConnectedAccount>  $query
      */
     public function scopeEnabled(Builder $query): void

--- a/app/Support/InstanceSettings.php
+++ b/app/Support/InstanceSettings.php
@@ -37,6 +37,13 @@ class InstanceSettings
             return false;
         }
 
+        // LinkedIn reply-fetching needs the restricted `r_member_social_feed`
+        // Community Management scope. Unless the operator declares their app is
+        // approved for it, never poll LinkedIn — otherwise every fetch 403s.
+        if ($platform === Platform::LinkedIn && ! $this->linkedinCommunityManagementEnabled()) {
+            return false;
+        }
+
         return $this->platformAvailable($platform)
             && $this->platformEnabled('engagement_polling_enabled', $platform);
     }
@@ -56,6 +63,18 @@ class InstanceSettings
     public function quoteTweetsEnabled(): bool
     {
         return $this->boolean('quote_tweets_enabled');
+    }
+
+    /**
+     * Whether the operator has declared this instance's LinkedIn app is approved
+     * for the Community Management API. Gates requesting the restricted
+     * `r_member_social_feed`/`w_member_social_feed` scopes at connect and polling
+     * LinkedIn for replies. Off by default — the scopes are a closed LinkedIn
+     * product, so requesting them on an unapproved app breaks the connect flow.
+     */
+    public function linkedinCommunityManagementEnabled(): bool
+    {
+        return $this->boolean('linkedin_community_management_enabled');
     }
 
     /** Instance-wide metrics master switch. Defaults to `metrics.enabled` (env) until overridden here. */
@@ -111,7 +130,7 @@ class InstanceSettings
     }
 
     /**
-     * @return array{registrations_enabled: bool, workspace_creation_enabled: bool, usage_tracking_enabled: bool, quote_tweets_enabled: bool}
+     * @return array{registrations_enabled: bool, workspace_creation_enabled: bool, usage_tracking_enabled: bool, quote_tweets_enabled: bool, linkedin_community_management_enabled: bool}
      */
     public function all(): array
     {
@@ -120,6 +139,7 @@ class InstanceSettings
             'workspace_creation_enabled' => $this->workspaceCreationEnabled(),
             'usage_tracking_enabled' => $this->usageTrackingEnabled(),
             'quote_tweets_enabled' => $this->quoteTweetsEnabled(),
+            'linkedin_community_management_enabled' => $this->linkedinCommunityManagementEnabled(),
         ];
     }
 
@@ -173,7 +193,7 @@ class InstanceSettings
     }
 
     /**
-     * @param  array{registrations_enabled?: bool, workspace_creation_enabled?: bool, usage_tracking_enabled?: bool, quote_tweets_enabled?: bool, engagement_polling_enabled?: bool|array<string, bool>, post_metrics_polling_enabled?: bool|array<string, bool>, account_metrics_polling_enabled?: bool|array<string, bool>, engagement_poll_interval_minutes?: array<string, int>, post_metrics_poll_interval_minutes?: array<string, int>, account_metrics_poll_interval_minutes?: array<string, int>}  $values
+     * @param  array{registrations_enabled?: bool, workspace_creation_enabled?: bool, usage_tracking_enabled?: bool, quote_tweets_enabled?: bool, linkedin_community_management_enabled?: bool, engagement_polling_enabled?: bool|array<string, bool>, post_metrics_polling_enabled?: bool|array<string, bool>, account_metrics_polling_enabled?: bool|array<string, bool>, engagement_poll_interval_minutes?: array<string, int>, post_metrics_poll_interval_minutes?: array<string, int>, account_metrics_poll_interval_minutes?: array<string, int>}  $values
      */
     public function update(array $values): void
     {

--- a/config/instance.php
+++ b/config/instance.php
@@ -18,6 +18,7 @@ return [
         ),
         'usage_tracking_enabled' => env('INSTANCE_USAGE_TRACKING_ENABLED', false),
         'quote_tweets_enabled' => env('INSTANCE_QUOTE_TWEETS_ENABLED', false),
+        'linkedin_community_management_enabled' => env('INSTANCE_LINKEDIN_COMMUNITY_MANAGEMENT_ENABLED', false),
         'polling' => [
             'engagement' => [
                 'x' => 360,

--- a/resources/js/pages/settings/instance.tsx
+++ b/resources/js/pages/settings/instance.tsx
@@ -11,6 +11,7 @@ type InstanceSettings = {
     workspace_creation_enabled: boolean;
     usage_tracking_enabled: boolean;
     quote_tweets_enabled: boolean;
+    linkedin_community_management_enabled: boolean;
 };
 
 type PageProps = {
@@ -25,6 +26,8 @@ export default function Instance({ settings, workspaces_enabled }: PageProps) {
             workspaces_enabled && settings.workspace_creation_enabled,
         usage_tracking_enabled: settings.usage_tracking_enabled,
         quote_tweets_enabled: settings.quote_tweets_enabled,
+        linkedin_community_management_enabled:
+            settings.linkedin_community_management_enabled,
     });
 
     function handleSubmit(event: React.FormEvent) {
@@ -139,6 +142,38 @@ export default function Instance({ settings, workspaces_enabled }: PageProps) {
                                     becomes a quote tweet instead of a plain
                                     link. Requires X Enterprise API access;
                                     leave off on other tiers. Off by default.
+                                </p>
+                            </div>
+                        </div>
+
+                        <div className="flex items-start gap-3">
+                            <Checkbox
+                                id="linkedin_community_management_enabled"
+                                checked={
+                                    data.linkedin_community_management_enabled
+                                }
+                                onCheckedChange={(checked) =>
+                                    setData(
+                                        'linkedin_community_management_enabled',
+                                        checked === true,
+                                    )
+                                }
+                            />
+                            <div className="space-y-1">
+                                <Label htmlFor="linkedin_community_management_enabled">
+                                    LinkedIn engagement inbox (Community
+                                    Management API)
+                                </Label>
+                                <p className="text-sm text-muted-foreground">
+                                    When enabled, connecting LinkedIn requests
+                                    the restricted{' '}
+                                    <code>r_member_social_feed</code> scope so
+                                    the engagement inbox can read replies.
+                                    Requires your LinkedIn app to be approved
+                                    for the Community Management API — leave off
+                                    otherwise, or LinkedIn will reject the
+                                    connection. Reconnect existing LinkedIn
+                                    accounts after enabling. Off by default.
                                 </p>
                             </div>
                         </div>

--- a/tests/Feature/ConnectedAccounts/ConnectOAuthTest.php
+++ b/tests/Feature/ConnectedAccounts/ConnectOAuthTest.php
@@ -47,6 +47,10 @@ function fakeOAuthUser(string $driver, array $data): SocialiteUser
         $user->setExpiresIn($data['expiresIn']);
     }
 
+    if (array_key_exists('approvedScopes', $data)) {
+        $user->setApprovedScopes($data['approvedScopes']);
+    }
+
     $provider = Mockery::mock(AbstractProvider::class);
     $provider->shouldReceive('setScopes')->andReturnSelf();
     $provider->shouldReceive('redirectUrl')->andReturnSelf();
@@ -181,6 +185,72 @@ test('callback maps a linkedin-openid user', function () {
     expect($account->platform)->toBe(Platform::LinkedIn)
         ->and($account->handle)->toBe('Grace Hopper')
         ->and($account->token_expires_at)->not->toBeNull();
+});
+
+test('linkedin connect requests the community management feed scopes only when enabled', function () {
+    config()->set('services.linkedin-openid.client_id', 'cid');
+    config()->set('services.linkedin-openid.client_secret', 'secret');
+    config()->set('services.linkedin-openid.redirect', 'https://app.test/accounts/callback/linkedin');
+    ownerActingIn();
+
+    $captured = [];
+    $provider = Mockery::mock(AbstractProvider::class);
+    $provider->shouldReceive('setScopes')->andReturnUsing(function (array $scopes) use ($provider, &$captured) {
+        $captured = $scopes;
+
+        return $provider;
+    });
+    $provider->shouldReceive('redirectUrl')->andReturnSelf();
+    $provider->shouldReceive('redirect')->andReturn(redirect('https://provider.test/oauth'));
+    Socialite::shouldReceive('driver')->with('linkedin-openid')->andReturn($provider);
+
+    // Off by default: never request the restricted scope (it would break authorize).
+    test()->get('/accounts/connect/linkedin')->assertRedirect('https://provider.test/oauth');
+    expect($captured)->not->toContain('r_member_social_feed');
+
+    app(App\Support\InstanceSettings::class)->update(['linkedin_community_management_enabled' => true]);
+
+    test()->get('/accounts/connect/linkedin')->assertRedirect('https://provider.test/oauth');
+    expect($captured)->toContain('r_member_social_feed')
+        ->and($captured)->toContain('w_member_social_feed');
+});
+
+test('linkedin connect records the engagement capability from the granted scopes', function () {
+    config()->set('services.linkedin-openid.client_id', 'cid');
+    config()->set('services.linkedin-openid.client_secret', 'secret');
+    config()->set('services.linkedin-openid.redirect', 'https://app.test/accounts/callback/linkedin');
+    ownerActingIn();
+    fakeOAuthUser('linkedin-openid', [
+        'id' => 'sub-cap',
+        'name' => 'Ada Lovelace',
+        'expiresIn' => 5184000,
+        'approvedScopes' => ['openid', 'profile', 'email', 'w_member_social', 'r_member_social_feed'],
+    ]);
+
+    test()->get('/accounts/callback/linkedin')->assertRedirect(route('accounts.index'));
+
+    $account = ConnectedAccount::withoutGlobalScopes()->firstWhere('remote_account_id', 'sub-cap');
+    expect($account->capabilities['linkedin_engagement'])->toBeTrue()
+        ->and($account->canFetchEngagement())->toBeTrue();
+});
+
+test('linkedin connect marks engagement unavailable when the feed scope is not granted', function () {
+    config()->set('services.linkedin-openid.client_id', 'cid');
+    config()->set('services.linkedin-openid.client_secret', 'secret');
+    config()->set('services.linkedin-openid.redirect', 'https://app.test/accounts/callback/linkedin');
+    ownerActingIn();
+    fakeOAuthUser('linkedin-openid', [
+        'id' => 'sub-nocap',
+        'name' => 'Alan Turing',
+        'expiresIn' => 5184000,
+        'approvedScopes' => ['openid', 'profile', 'email', 'w_member_social'],
+    ]);
+
+    test()->get('/accounts/callback/linkedin')->assertRedirect(route('accounts.index'));
+
+    $account = ConnectedAccount::withoutGlobalScopes()->firstWhere('remote_account_id', 'sub-nocap');
+    expect($account->capabilities['linkedin_engagement'])->toBeFalse()
+        ->and($account->canFetchEngagement())->toBeFalse();
 });
 
 test('duplicate callback after a successful OAuth connection keeps the success flash', function () {

--- a/tests/Feature/Engagement/EngagementIndexTest.php
+++ b/tests/Feature/Engagement/EngagementIndexTest.php
@@ -70,6 +70,9 @@ test('the inbox exposes which engagement platforms are disabled', function (): v
             'bluesky' => true,
             'linkedin' => true,
         ],
+        // LinkedIn reply-fetching also requires the Community Management gate;
+        // without it LinkedIn stays disabled regardless of the polling toggle.
+        'linkedin_community_management_enabled' => true,
     ]);
 
     $this->actingAs($this->user)

--- a/tests/Feature/Engagement/FetchPostTargetRepliesTest.php
+++ b/tests/Feature/Engagement/FetchPostTargetRepliesTest.php
@@ -206,3 +206,51 @@ test('the job stores the base conversation id when fetched replies are out of or
 
     expect($child->conversation_remote_id)->toBe('at://base');
 });
+
+function linkedInTargetWithCapability(?bool $capable): PostTarget
+{
+    $post = Post::factory()->create();
+
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::LinkedIn,
+        'token_expires_at' => now()->addHour(),
+        'capabilities' => $capable === null ? null : ['linkedin_engagement' => $capable],
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'access_token' => 'li-token',
+    ]);
+
+    return PostTarget::factory()->for($post)->create([
+        'connected_account_id' => $account->id,
+        'platform' => Platform::LinkedIn,
+        'remote_id' => 'urn:li:share:1',
+        'remote_ids' => ['urn:li:share:1'],
+    ]);
+}
+
+test('linkedin reply fetch is skipped for an account without the engagement capability', function () {
+    $target = linkedInTargetWithCapability(null);
+
+    // The connector must never be reached — we know the call would 403.
+    $registry = Mockery::mock(EngagementConnectorRegistry::class);
+    $registry->shouldNotReceive('for');
+
+    (new FetchPostTargetReplies($target))->handle($registry, app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
+
+    expect($target->fresh()->reply_fetched_at)->toBeNull();
+});
+
+test('a linkedin unsupported fetch disables the account engagement capability', function () {
+    $target = linkedInTargetWithCapability(true);
+
+    $connector = Mockery::mock(EngagementConnector::class);
+    $connector->shouldReceive('fetchReplies')->andReturn(ReplyFetchResult::unsupported('no access'));
+    $registry = Mockery::mock(EngagementConnectorRegistry::class);
+    $registry->shouldReceive('for')->andReturn($connector);
+    app()->instance(EngagementConnectorRegistry::class, $registry);
+
+    (new FetchPostTargetReplies($target))->handle(app(EngagementConnectorRegistry::class), app(TokenManager::class), app(ReplyPersister::class), app(InstanceSettings::class));
+
+    expect($target->account->fresh()->capabilities['linkedin_engagement'])->toBeFalse();
+});

--- a/tests/Feature/InstanceSettingsTest.php
+++ b/tests/Feature/InstanceSettingsTest.php
@@ -39,11 +39,13 @@ test('instance owner can update instance settings', function () {
             'workspace_creation_enabled' => false,
             'usage_tracking_enabled' => false,
             'quote_tweets_enabled' => false,
+            'linkedin_community_management_enabled' => true,
         ])
         ->assertRedirect();
 
     expect(app(InstanceSettings::class)->registrationsEnabled())->toBeFalse()
-        ->and(app(InstanceSettings::class)->workspaceCreationEnabled())->toBeFalse();
+        ->and(app(InstanceSettings::class)->workspaceCreationEnabled())->toBeFalse()
+        ->and(app(InstanceSettings::class)->linkedinCommunityManagementEnabled())->toBeTrue();
 });
 
 test('workspace creation setting is disabled when workspaces are globally disabled', function () {
@@ -72,10 +74,23 @@ test('workspace creation setting cannot be enabled when workspaces are globally 
             'workspace_creation_enabled' => true,
             'usage_tracking_enabled' => false,
             'quote_tweets_enabled' => false,
+            'linkedin_community_management_enabled' => false,
         ])
         ->assertRedirect();
 
     expect(app(InstanceSettings::class)->workspaceCreationEnabled())->toBeFalse();
+});
+
+test('linkedin engagement polling is gated on the community management setting', function () {
+    $settings = app(InstanceSettings::class);
+
+    // Off by default: LinkedIn must never be polled for replies (every fetch 403s
+    // without the restricted r_member_social_feed scope).
+    expect($settings->engagementPollingEnabled(Platform::LinkedIn))->toBeFalse();
+
+    $settings->update(['linkedin_community_management_enabled' => true]);
+
+    expect($settings->engagementPollingEnabled(Platform::LinkedIn))->toBeTrue();
 });
 
 test('instance owner can view polling settings', function () {

--- a/tests/Feature/Publishing/QuoteTweetSettingUpdateTest.php
+++ b/tests/Feature/Publishing/QuoteTweetSettingUpdateTest.php
@@ -16,6 +16,7 @@ it('lets an instance owner enable quote tweets', function () {
         'workspace_creation_enabled' => true,
         'usage_tracking_enabled' => false,
         'quote_tweets_enabled' => true,
+        'linkedin_community_management_enabled' => false,
     ])->assertRedirect();
 
     expect(app(InstanceSettings::class)->quoteTweetsEnabled())->toBeTrue();

--- a/tests/Feature/Usage/UsageSettingUpdateTest.php
+++ b/tests/Feature/Usage/UsageSettingUpdateTest.php
@@ -12,6 +12,7 @@ it('lets an instance owner enable usage tracking', function () {
         'workspace_creation_enabled' => true,
         'usage_tracking_enabled' => true,
         'quote_tweets_enabled' => false,
+        'linkedin_community_management_enabled' => false,
     ])->assertRedirect();
 
     expect(app(InstanceSettings::class)->usageTrackingEnabled())->toBeTrue();


### PR DESCRIPTION
## Summary
- Fixes the endless 403 flood from LinkedIn "Replies Fetch": reading member comments requires the restricted `r_member_social_feed` scope (LinkedIn Community Management API), which the connect flow never requested.
- Adds an instance setting `linkedin_community_management_enabled` (off by default) that operators can enable only if their LinkedIn app is approved for the Community Management API. LinkedIn engagement polling is disabled unless this is on.
- When enabled, the OAuth connect flow requests the `r_member_social_feed`/`w_member_social_feed` scopes and records whether they were actually granted as a per-account capability.
- Reply-fetch jobs skip LinkedIn accounts lacking the capability, and flip it off automatically if a fetch still comes back `Unsupported`/403, so polling self-heals without manual intervention.
- Adds the new toggle to the instance settings UI with explanatory copy about the Community Management API requirement.
- Adds test coverage for the settings gate, OAuth scope/capability recording, and the reply-fetch job's skip/backstop behavior.
