### PR TITLE
feat(posts): show media thumbnails in post list rows

### DIFF
--- a/app/Http/Controllers/Api/V1/CalendarController.php
+++ b/app/Http/Controllers/Api/V1/CalendarController.php
@@ -27,7 +27,7 @@ class CalendarController extends Controller
         $end = $start->addDays(41)->endOfDay();
 
         $posts = Post::query()
-            ->with(['author:id,name', 'targets'])
+            ->with(['author:id,name', 'targets', 'media'])
             ->whereIn('status', [
                 PostStatus::Scheduled->value, PostStatus::Published->value,
                 PostStatus::Partial->value, PostStatus::Failed->value,

--- a/app/Http/Controllers/Api/V1/PostsController.php
+++ b/app/Http/Controllers/Api/V1/PostsController.php
@@ -35,7 +35,7 @@ class PostsController extends Controller
         ]);
 
         $paginator = Post::query()
-            ->with(['author:id,name', 'targets'])
+            ->with(['author:id,name', 'targets', 'media'])
             ->when($validated['status'] ?? null, fn ($query, $status) => $query->where('status', $status))
             ->when($validated['q'] ?? null, fn ($query, $q) => $query->whereLike('base_text', "%{$q}%"))
             ->orderBy('id', 'desc')

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -36,7 +36,7 @@ class DashboardController extends Controller
                     ->all()
                 : [],
             'posts' => Inertia::defer(fn (): array => Post::query()
-                ->with(['author:id,name', 'targets'])
+                ->with(['author:id,name', 'targets', 'media'])
                 ->latest('updated_at')
                 ->limit(25)
                 ->get()

--- a/app/Http/Controllers/Posts/CalendarController.php
+++ b/app/Http/Controllers/Posts/CalendarController.php
@@ -37,7 +37,7 @@ class CalendarController extends Controller
             'yyyymm' => $yyyymm,
             'view' => $view,
             'posts' => Inertia::defer(fn (): array => Post::query()
-                ->with(['author:id,name', 'targets'])
+                ->with(['author:id,name', 'targets', 'media'])
                 ->whereIn('status', [
                     PostStatus::Scheduled->value, PostStatus::Published->value,
                     PostStatus::Partial->value, PostStatus::Failed->value,

--- a/app/Http/Controllers/Posts/PostController.php
+++ b/app/Http/Controllers/Posts/PostController.php
@@ -71,7 +71,7 @@ class PostController extends Controller
         return Inertia::render('posts/index', [
             'posts' => Inertia::scroll(fn () => $applyFilters(
                 Post::query()
-                    ->with(['author:id,name', 'targets'])
+                    ->with(['author:id,name', 'targets', 'media'])
                     ->where('status', '!=', PostStatus::Deleted->value)
                     ->when($status !== '' && $status !== 'all', fn ($query) => $query->where('status', $status))
             )

--- a/app/Mcp/Tools/GetCalendarTool.php
+++ b/app/Mcp/Tools/GetCalendarTool.php
@@ -35,7 +35,7 @@ class GetCalendarTool extends WorkspaceTool
         $end = $start->addDays(41)->endOfDay();
 
         $posts = Post::query()
-            ->with(['author:id,name', 'targets'])
+            ->with(['author:id,name', 'targets', 'media'])
             ->whereIn('status', [
                 PostStatus::Scheduled->value, PostStatus::Published->value,
                 PostStatus::Partial->value, PostStatus::Failed->value,

--- a/app/Mcp/Tools/ListPostsTool.php
+++ b/app/Mcp/Tools/ListPostsTool.php
@@ -29,7 +29,7 @@ class ListPostsTool extends WorkspaceTool
         ]);
 
         $posts = Post::query()
-            ->with(['author:id,name', 'targets'])
+            ->with(['author:id,name', 'targets', 'media'])
             ->when($validated['status'] ?? null, fn ($query, $status) => $query->where('status', $status))
             ->when($validated['q'] ?? null, fn ($query, $q) => $query->whereLike('base_text', "%{$q}%"))
             ->latest()

--- a/app/Support/PostListItem.php
+++ b/app/Support/PostListItem.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Support;
 
 use App\Models\Post;
+use App\Models\PostMedia;
 use App\Models\PostTarget;
 
 final class PostListItem
@@ -21,6 +22,8 @@ final class PostListItem
             'status_label' => $post->status->label(),
             'author' => $post->author?->name,
             'target_count' => $post->targets->count(),
+            'media_count' => $post->media->count(),
+            'media_preview' => self::mediaPreview($post),
             'updated_at' => $post->updated_at->toIso8601String(),
             'scheduled_at' => $post->scheduled_at?->toIso8601String(),
             'published_at' => $post->published_at?->toIso8601String(),
@@ -34,6 +37,26 @@ final class PostListItem
                 'error_message' => $t->error_message,
                 'attempts' => $t->attempts,
             ])->all(),
+        ];
+    }
+
+    /**
+     * The first attachment, used for a glanceable list thumbnail. Videos live on
+     * a private disk behind a signed, expiring URL that an `<img>` can't render,
+     * so they carry no URL — the list shows an icon tile for them instead.
+     *
+     * @return array{kind: string, url: string|null}|null
+     */
+    private static function mediaPreview(Post $post): ?array
+    {
+        $first = $post->media->first();
+        if (! $first instanceof PostMedia) {
+            return null;
+        }
+
+        return [
+            'kind' => $first->kind,
+            'url' => $first->isVideo() ? null : $first->url(),
         ];
     }
 }

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -119,6 +119,8 @@ type ComposerProps = {
     /** Focus the editor as soon as it mounts. */
     autoFocusEditor?: boolean;
     initialSavedMentions?: WorkspaceMention[];
+    /** Fired after each successful autosave (create or update). */
+    onSaved?: () => void;
 };
 
 const EMPTY_SAVED_MENTIONS: WorkspaceMention[] = [];
@@ -160,6 +162,7 @@ export default function Composer({
     initialDestination = null,
     autoFocusEditor = false,
     initialSavedMentions = EMPTY_SAVED_MENTIONS,
+    onSaved,
 }: ComposerProps) {
     const schedulingTz = useSchedulingTimezone();
     const saveMentionHttp = useHttp<
@@ -219,6 +222,7 @@ export default function Composer({
         state,
         accountIds: destinationAccountIds,
         dispatch,
+        onSaved,
     });
     const publishStatus = usePublishStatus({ pagePost: post });
 

--- a/resources/js/components/posts/calendar/__tests__/agenda-list.test.ts
+++ b/resources/js/components/posts/calendar/__tests__/agenda-list.test.ts
@@ -20,6 +20,8 @@ function post(overrides: Partial<PostRowData>): PostRowData {
         published_at: null,
         platforms: [],
         targets: [],
+        media_count: 0,
+        media_preview: null,
         ...overrides,
     };
 }

--- a/resources/js/components/posts/post-row.tsx
+++ b/resources/js/components/posts/post-row.tsx
@@ -1,4 +1,5 @@
 import { router } from '@inertiajs/react';
+import { Film, Image as ImageIcon } from 'lucide-react';
 import { Fragment } from 'react';
 
 import ComposerController from '@/actions/App/Http/Controllers/Posts/ComposerController';
@@ -26,6 +27,8 @@ export type PostRowData = {
     published_at: string | null;
     platforms: PlatformName[];
     targets: ChipTarget[];
+    media_count: number;
+    media_preview: { kind: 'image' | 'video'; url: string | null } | null;
 };
 
 function formatWhen(dateStr: string): { when: string; time: string } {
@@ -49,6 +52,53 @@ function formatWhen(dateStr: string): { when: string; time: string } {
 function StatusBadge({ status }: { status: PostStatus }) {
     const meta = postStatusMeta[status] ?? postStatusMeta.draft;
     return <Badge variant={meta.variant}>{meta.label}</Badge>;
+}
+
+/**
+ * A glanceable attachment preview so a row reveals whether media is attached
+ * without opening the post. Images render their own thumbnail; videos (served
+ * from a private, signed URL an <img> can't load) fall back to an icon tile. A
+ * "+N" badge marks additional attachments beyond the first.
+ */
+function MediaThumb({
+    preview,
+    count,
+}: {
+    preview: NonNullable<PostRowData['media_preview']>;
+    count: number;
+}) {
+    const extra = count - 1;
+    const showImage = preview.kind === 'image' && preview.url !== null;
+
+    return (
+        <div
+            role="img"
+            aria-label={`${count} ${count === 1 ? 'attachment' : 'attachments'}`}
+            className="relative size-11 shrink-0 overflow-hidden rounded-lg bg-muted ring-1 ring-border/60"
+        >
+            {showImage ? (
+                <img
+                    src={preview.url ?? ''}
+                    alt=""
+                    loading="lazy"
+                    className="size-full object-cover"
+                />
+            ) : (
+                <div className="grid size-full place-items-center text-muted-foreground">
+                    {preview.kind === 'video' ? (
+                        <Film size={16} strokeWidth={1.75} />
+                    ) : (
+                        <ImageIcon size={16} strokeWidth={1.75} />
+                    )}
+                </div>
+            )}
+            {extra > 0 && (
+                <span className="absolute right-0.5 bottom-0.5 rounded bg-background/85 px-1 text-[10px] font-medium text-foreground tabular-nums backdrop-blur-sm">
+                    +{extra}
+                </span>
+            )}
+        </div>
+    );
 }
 
 /**
@@ -78,6 +128,8 @@ export function PostRow({ post }: { post: PostRowData }) {
     // page loaded before the index exposed per-target data) must not crash the row.
     const platforms = post.platforms ?? [];
     const accounts = post.target_count ?? 0;
+    const mediaCount = post.media_count ?? 0;
+    const mediaPreview = post.media_preview ?? null;
     const failedCount = (post.targets ?? []).filter(
         (t: ChipTarget) => t.status === 'failed',
     ).length;
@@ -153,29 +205,35 @@ export function PostRow({ post }: { post: PostRowData }) {
                     <div className="mt-0.5">{time}</div>
                 </div>
 
-                {/* Middle: text + meta. The text block reserves two lines so
+                {/* Middle: text + meta, with an optional attachment thumbnail
+                    pinned to the right. The text block reserves two lines so
                     every row lines up regardless of status or content length. */}
-                <div className="min-w-0">
-                    <p className="line-clamp-2 min-h-[2.75em] text-[13.5px] leading-snug tracking-tight text-foreground">
-                        {post.base_text.trim() || (
-                            <span className="text-muted-foreground">
-                                Untitled draft
-                            </span>
-                        )}
-                    </p>
-                    <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-[11.5px] text-muted-foreground">
-                        {metaParts.map((part, i) => (
-                            <Fragment key={part.key}>
-                                {i > 0 && (
-                                    <span
-                                        className="size-[3px] rounded-full bg-muted-foreground/50"
-                                        aria-hidden="true"
-                                    />
-                                )}
-                                {part.node}
-                            </Fragment>
-                        ))}
+                <div className="flex min-w-0 items-start gap-3">
+                    <div className="min-w-0 flex-1">
+                        <p className="line-clamp-2 min-h-[2.75em] text-[13.5px] leading-snug tracking-tight text-foreground">
+                            {post.base_text.trim() || (
+                                <span className="text-muted-foreground">
+                                    Untitled draft
+                                </span>
+                            )}
+                        </p>
+                        <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-[11.5px] text-muted-foreground">
+                            {metaParts.map((part, i) => (
+                                <Fragment key={part.key}>
+                                    {i > 0 && (
+                                        <span
+                                            className="size-[3px] rounded-full bg-muted-foreground/50"
+                                            aria-hidden="true"
+                                        />
+                                    )}
+                                    {part.node}
+                                </Fragment>
+                            ))}
+                        </div>
                     </div>
+                    {mediaPreview && (
+                        <MediaThumb preview={mediaPreview} count={mediaCount} />
+                    )}
                 </div>
 
                 {/* Right: badge + actions */}

--- a/resources/js/hooks/compose/__tests__/autosave.test.ts
+++ b/resources/js/hooks/compose/__tests__/autosave.test.ts
@@ -1,9 +1,148 @@
-import { describe, expect, it } from 'vitest';
+/** @vitest-environment jsdom */
 
-import { AUTOSAVE_DEBOUNCE_MS } from '../use-autosave';
+import { useHttp } from '@inertiajs/react';
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    initialComposerState,
+    type ComposerState,
+} from '@/lib/compose/composer-state';
+import type { PostView } from '@/types/compose';
+
+import { AUTOSAVE_DEBOUNCE_MS, useAutosave } from '../use-autosave';
+
+vi.mock('@inertiajs/react', () => ({
+    useHttp: vi.fn(),
+}));
+
+vi.mock('@/actions/App/Http/Controllers/Posts/PostController', () => ({
+    default: {
+        store: () => ({ url: '/posts' }),
+        update: (id: string) => ({ url: `/posts/${id}` }),
+    },
+}));
+
+const post: PostView = {
+    id: 'post-1',
+    base_text: 'Hello',
+    segments: ['Hello'],
+    status: 'draft',
+    published_at: null,
+    updated_at: '2026-07-17T10:00:00+00:00',
+    scheduled_at: null,
+    destination: { kind: 'all', id: null },
+    targets: [],
+    media: [],
+};
+
+const transform = vi.fn();
+const httpPost = vi.fn();
+const httpPut = vi.fn();
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+let flushRef: (() => Promise<void>) | null = null;
+
+function draftState(overrides: Partial<ComposerState> = {}): ComposerState {
+    return {
+        ...initialComposerState(),
+        saveState: 'dirty',
+        segments: ['Hello'],
+        ...overrides,
+    };
+}
+
+function Harness({
+    state,
+    onSaved,
+}: {
+    state: ComposerState;
+    onSaved: () => void;
+}) {
+    const { flush } = useAutosave({
+        state,
+        accountIds: [],
+        dispatch: vi.fn(),
+        onSaved,
+    });
+    flushRef = flush;
+
+    return null;
+}
+
+beforeEach(() => {
+    transform.mockReset();
+    httpPost.mockReset().mockResolvedValue({ post });
+    httpPut.mockReset().mockImplementation((_url, opts) => {
+        opts?.onSuccess?.({ post });
+
+        return Promise.resolve();
+    });
+    vi.mocked(useHttp).mockReturnValue({
+        transform,
+        post: httpPost,
+        put: httpPut,
+        processing: false,
+    } as unknown as ReturnType<typeof useHttp>);
+    container = document.createElement('div');
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root?.unmount());
+    root = null;
+    container = null;
+    flushRef = null;
+    vi.clearAllMocks();
+});
 
 describe('autosave debounce', () => {
     it('waits 500ms after draft edits before saving', () => {
         expect(AUTOSAVE_DEBOUNCE_MS).toBe(500);
+    });
+});
+
+describe('useAutosave onSaved', () => {
+    it('fires after a successful create (POST)', async () => {
+        const onSaved = vi.fn();
+        act(() => {
+            root?.render(
+                createElement(Harness, {
+                    state: draftState({ postId: null }),
+                    onSaved,
+                }),
+            );
+        });
+
+        await act(async () => {
+            await flushRef?.();
+        });
+
+        expect(httpPost).toHaveBeenCalledOnce();
+        expect(onSaved).toHaveBeenCalledOnce();
+    });
+
+    it('fires after a successful update (PUT)', async () => {
+        const onSaved = vi.fn();
+        act(() => {
+            root?.render(
+                createElement(Harness, {
+                    state: draftState({
+                        postId: 'post-1',
+                        baselineUpdatedAt: post.updated_at,
+                    }),
+                    onSaved,
+                }),
+            );
+        });
+
+        await act(async () => {
+            await flushRef?.();
+        });
+
+        expect(httpPut).toHaveBeenCalledOnce();
+        expect(onSaved).toHaveBeenCalledOnce();
     });
 });

--- a/resources/js/hooks/compose/use-autosave.ts
+++ b/resources/js/hooks/compose/use-autosave.ts
@@ -18,6 +18,12 @@ type UseAutosave = {
     state: ComposerState;
     accountIds: string[];
     dispatch: (action: ComposerAction) => void;
+    /**
+     * Called after each successful create/update so the host page can refresh
+     * anything derived from the saved draft (e.g. the dashboard's recent-posts
+     * feed, which is a deferred prop and otherwise stays stale until reload).
+     */
+    onSaved?: () => void;
 };
 
 /**
@@ -28,7 +34,12 @@ type UseAutosave = {
  * inject the dynamic payload via `transform()`, which runs at submit time (so it
  * always reflects the latest reducer state, avoiding React state-timing bugs).
  */
-export function useAutosave({ state, accountIds, dispatch }: UseAutosave) {
+export function useAutosave({
+    state,
+    accountIds,
+    dispatch,
+    onSaved,
+}: UseAutosave) {
     // TForm must satisfy FormDataType; the hook's own data is unused (we submit
     // via transform), so Record<string, never> is the minimal valid shape.
     const http = useHttp<Record<string, never>, SaveResponse>({});
@@ -72,6 +83,7 @@ export function useAutosave({ state, accountIds, dispatch }: UseAutosave) {
             updatedAt: created.post.updated_at,
         });
         dispatch({ type: 'saveSucceeded', post: created.post });
+        onSaved?.();
 
         return created.post.id;
     }
@@ -103,6 +115,7 @@ export function useAutosave({ state, accountIds, dispatch }: UseAutosave) {
             onSuccess: (data) => {
                 baselineRef.current = data.post.updated_at;
                 dispatch({ type: 'saveSucceeded', post: data.post });
+                onSaved?.();
             },
             // onHttpException's response.data is typed `string` but may arrive
             // parsed at runtime — handle both.

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,5 +1,6 @@
-import { Deferred, Head, Link, usePage } from '@inertiajs/react';
+import { Deferred, Head, Link, router, usePage } from '@inertiajs/react';
 import { Plug } from 'lucide-react';
+import { useEffect, useRef } from 'react';
 
 import Composer from '@/components/compose/composer';
 import { DashboardAura } from '@/components/dashboard/dashboard-aura';
@@ -75,6 +76,28 @@ export default function Dashboard({ posts, onboarding, savedMentions }: Props) {
         workspaces.current?.permissions ?? [],
     );
 
+    // Autosave persists drafts via a standalone XHR that never triggers an
+    // Inertia visit, so the deferred `posts` feed below would stay stale after a
+    // save. Refresh just that prop when the composer reports a save, debounced so
+    // a burst of keystroke-driven saves coalesces into one partial reload.
+    const reloadTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    function refreshRecentPosts() {
+        if (reloadTimer.current) {
+            clearTimeout(reloadTimer.current);
+        }
+        reloadTimer.current = setTimeout(() => {
+            router.reload({ only: ['posts'] });
+        }, 600);
+    }
+    useEffect(
+        () => () => {
+            if (reloadTimer.current) {
+                clearTimeout(reloadTimer.current);
+            }
+        },
+        [],
+    );
+
     // A calendar slot click opens the composer here with a pre-set schedule time.
     const initialScheduleAt = new URL(
         page.url,
@@ -120,6 +143,7 @@ export default function Dashboard({ posts, onboarding, savedMentions }: Props) {
                     initialDestination={initialDestination}
                     initialSavedMentions={savedMentions}
                     autoFocusEditor
+                    onSaved={refreshRecentPosts}
                 />
 
                 <Deferred data="posts" fallback={<RecentFeedSkeleton />}>

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\WorkspaceRole;
 use App\Models\Post;
+use App\Models\PostMedia;
 use App\Models\PostTarget;
 use App\Models\User;
 use App\Models\Workspace;
@@ -44,6 +45,67 @@ test('the recent feed exposes full row data including targets', function () {
             ->loadDeferredProps(fn ($reload) => $reload
                 ->has('posts.0.targets')
                 ->has('posts.0.published_at')));
+});
+
+test('the recent feed exposes attached media for a row thumbnail', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'role' => WorkspaceRole::Member,
+    ]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    Context::add('workspace_id', $workspace->id);
+
+    $post = Post::factory()->for($workspace)->create(['author_id' => $user->id]);
+    PostTarget::factory()->for($post)->create();
+    PostMedia::factory()->for($post)->create([
+        'workspace_id' => $workspace->id,
+        'position' => 0,
+        'kind' => 'image',
+    ]);
+    PostMedia::factory()->for($post)->video()->create([
+        'workspace_id' => $workspace->id,
+        'position' => 1,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertInertia(fn ($page) => $page
+            ->component('dashboard')
+            ->loadDeferredProps(fn ($reload) => $reload
+                ->where('posts.0.media_count', 2)
+                ->where('posts.0.media_preview.kind', 'image')
+                ->has('posts.0.media_preview.url')));
+});
+
+test('a video-only post exposes no preview url so the list shows an icon tile', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'role' => WorkspaceRole::Member,
+    ]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    Context::add('workspace_id', $workspace->id);
+
+    $post = Post::factory()->for($workspace)->create(['author_id' => $user->id]);
+    PostTarget::factory()->for($post)->create();
+    PostMedia::factory()->for($post)->video()->create([
+        'workspace_id' => $workspace->id,
+        'position' => 0,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertInertia(fn ($page) => $page
+            ->component('dashboard')
+            ->loadDeferredProps(fn ($reload) => $reload
+                ->where('posts.0.media_count', 1)
+                ->where('posts.0.media_preview.kind', 'video')
+                ->where('posts.0.media_preview.url', null)));
 });
 
 test('the dashboard includes saved workspace mentions for the composer', function () {


### PR DESCRIPTION
## Summary
- Post list rows (dashboard recent feed, posts index, calendar) now show a thumbnail preview of the first attached image; videos fall back to an icon tile since their private signed URLs can't be rendered in an `<img>`, and a "+N" badge marks additional attachments.
- Added `media` eager loading and `media_count`/`media_preview` fields to `PostListItem` across the affected controllers and MCP tools (`GetCalendarTool`, `ListPostsTool`).
- The dashboard's recent-posts feed now auto-refreshes after the composer autosaves a draft, since autosave runs over a standalone request that never triggers an Inertia visit and previously left the deferred `posts` prop stale until a full reload. Refreshes are debounced to coalesce bursts of keystroke-driven saves into a single partial reload.
- Added feature/unit test coverage for the new media preview fields and the autosave `onSaved` callback.
</body>
</StructuredOutput>

