### PR TITLE
feat(compose): show both mention modes and keep cleared handles blank

### DIFF
--- a/resources/js/components/compose/__tests__/mention-picker.test.ts
+++ b/resources/js/components/compose/__tests__/mention-picker.test.ts
@@ -102,6 +102,14 @@ describe('linkedin mention field', () => {
         expect(source).toContain('Plain text');
     });
 
+    it('uses a segmented control that shows both modes at once', () => {
+        // Both options are rendered side by side (not one action-labeled
+        // button) so the active mode is always visible.
+        expect(source).toContain('MentionModeToggle');
+        expect(source).toContain('role="radiogroup"');
+        expect(source).toContain('aria-checked={active}');
+    });
+
     it('confirms a linked company instead of showing dev jargon', () => {
         expect(source).toContain('Company linked');
         expect(source).not.toContain('php artisan');

--- a/resources/js/components/compose/__tests__/mention-picker.test.ts
+++ b/resources/js/components/compose/__tests__/mention-picker.test.ts
@@ -106,8 +106,8 @@ describe('linkedin mention field', () => {
         // Both options are rendered side by side (not one action-labeled
         // button) so the active mode is always visible.
         expect(source).toContain('MentionModeToggle');
-        expect(source).toContain('role="radiogroup"');
-        expect(source).toContain('aria-checked={active}');
+        expect(source).toContain('role="group"');
+        expect(source).toContain('aria-pressed={active}');
     });
 
     it('confirms a linked company instead of showing dev jargon', () => {

--- a/resources/js/components/compose/__tests__/mention-picker.test.ts
+++ b/resources/js/components/compose/__tests__/mention-picker.test.ts
@@ -110,6 +110,18 @@ describe('linkedin mention field', () => {
         expect(source).toContain('aria-pressed={active}');
     });
 
+    it('holds each platform mode in local state so clearing cannot flip it', () => {
+        // The '@' prefix, toggle, and placeholder all read one local state var
+        // instead of re-deriving the mode from the handle on every keystroke.
+        expect(source).toContain('function PlatformMentionField');
+        expect(source).toContain('setUseMention');
+        expect(source).toContain('supportsMention && useMention');
+    });
+
+    it('labels mention-incapable platforms as plain text instead of leaving them bare', () => {
+        expect(source).toContain('supportsMention ? (');
+    });
+
     it('confirms a linked company instead of showing dev jargon', () => {
         expect(source).toContain('Company linked');
         expect(source).not.toContain('php artisan');

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -521,7 +521,7 @@ function EditorBodyInner(
                         align="start"
                         side="bottom"
                         sideOffset={8}
-                        className="w-80 gap-0 rounded-2xl p-2"
+                        className="w-96 gap-0 rounded-2xl p-3"
                         initialFocus={false}
                     >
                         <MentionPicker

--- a/resources/js/components/compose/mention-picker.tsx
+++ b/resources/js/components/compose/mention-picker.tsx
@@ -652,7 +652,7 @@ function MentionModeToggle({
 }: MentionModeToggleProps) {
     return (
         <div
-            role="radiogroup"
+            role="group"
             aria-label={ariaLabel}
             className="inline-flex items-center rounded-md bg-muted p-0.5"
         >
@@ -663,8 +663,7 @@ function MentionModeToggle({
                     <button
                         key={option.value}
                         type="button"
-                        role="radio"
-                        aria-checked={active}
+                        aria-pressed={active}
                         onClick={() => onChange(option.value)}
                         className={cn(
                             'rounded-[5px] px-2 py-1 text-[11px] leading-none font-medium transition-colors',

--- a/resources/js/components/compose/mention-picker.tsx
+++ b/resources/js/components/compose/mention-picker.tsx
@@ -194,11 +194,11 @@ export default function MentionPicker({
 
     if (mode === 'edit') {
         return (
-            <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-2.5">
                 <button
                     type="button"
                     onClick={() => setMode('search')}
-                    className="inline-flex items-center gap-1.5 self-start rounded-md px-1 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    className="-mb-0.5 inline-flex items-center gap-1.5 self-start rounded-md px-1 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                     <ArrowLeft className="size-3.5" aria-hidden />
                     Back to search
@@ -337,17 +337,20 @@ function MentionHandleEditor({
 
     return (
         <>
-            <div>
-                <div className="text-xs font-medium text-muted-foreground">
-                    Mention name
-                </div>
-                <InputGroup className="mt-1.5 h-9 rounded-lg border-border bg-background">
-                    <InputGroupAddon>@</InputGroupAddon>
+            <div className="flex items-center gap-2">
+                <span
+                    aria-hidden
+                    className="flex w-[15px] shrink-0 justify-center text-sm font-medium text-muted-foreground"
+                >
+                    @
+                </span>
+                <InputGroup className="h-8 min-w-0 flex-1 rounded-lg">
                     <InputGroupInput
                         ref={mentionNameInputRef}
                         value={mentionInputValue(activeMention.label)}
-                        placeholder="name"
+                        placeholder="Mention name"
                         aria-label="Mention name shown in the post"
+                        className="text-xs font-medium"
                         onChange={(event) =>
                             onUpdateMention(
                                 activeMention,
@@ -360,103 +363,28 @@ function MentionHandleEditor({
                     />
                 </InputGroup>
             </div>
-            <div className="text-xs font-medium text-muted-foreground">
-                Platform handles
-            </div>
-            <div className="flex flex-col gap-2">
-                {activePlatforms.map((platform) => {
-                    if (platform === 'linkedin') {
-                        // Keyed on the mention id so the local tag-mode/vanity
-                        // state resets when a different mention is edited.
-                        return (
-                            <LinkedInMentionField
-                                key={`linkedin-${activeMention.id}`}
-                                activeMention={activeMention}
-                                onUpdateMention={onUpdateMention}
-                            />
-                        );
-                    }
-
-                    const useMention = usesPlatformMention(
-                        activeMention,
-                        platform,
-                    );
-                    const handleValue =
-                        activeMention.handles[platform] ?? activeMention.label;
-
-                    return (
-                        <div
-                            key={platform}
-                            className="flex flex-col gap-1.5 text-xs"
-                        >
-                            <div className="flex items-center justify-between gap-2">
-                                <span className="inline-flex items-center gap-1.5 text-muted-foreground">
-                                    <PlatformGlyph
-                                        platform={platform}
-                                        size={14}
-                                        className="text-foreground"
-                                    />
-                                    <span className="capitalize">
-                                        {platform}
-                                    </span>
-                                </span>
-                                {platformSupportsMention(platform) && (
-                                    <MentionModeToggle
-                                        ariaLabel={`How to show ${activeMention.label} on ${platform}`}
-                                        value={useMention ? 'mention' : 'text'}
-                                        options={[
-                                            {
-                                                value: 'mention',
-                                                label: 'Mention',
-                                            },
-                                            {
-                                                value: 'text',
-                                                label: 'Plain text',
-                                            },
-                                        ]}
-                                        onChange={(next) =>
-                                            onUpdateMention(
-                                                activeMention,
-                                                setPlatformMentionMode(
-                                                    activeMention,
-                                                    platform,
-                                                    next === 'mention',
-                                                ),
-                                            )
-                                        }
-                                    />
-                                )}
-                            </div>
-                            <InputGroup className="min-h-9 w-full min-w-0 rounded-lg border-border bg-background">
-                                {useMention && (
-                                    <InputGroupAddon className="pr-0 text-foreground">
-                                        @
-                                    </InputGroupAddon>
-                                )}
-                                <InputGroupInput
-                                    value={mentionInputValue(handleValue)}
-                                    placeholder={
-                                        useMention ? 'handle' : 'display name'
-                                    }
-                                    aria-label={`${platform} ${
-                                        useMention ? 'handle' : 'display text'
-                                    } for ${activeMention.label}`}
-                                    onChange={(event) =>
-                                        onUpdateMention(
-                                            activeMention,
-                                            updateMentionHandle(
-                                                activeMention,
-                                                platform,
-                                                event.target.value,
-                                                useMention,
-                                            ),
-                                        )
-                                    }
-                                />
-                            </InputGroup>
-                        </div>
-                    );
-                })}
+            <div className="h-px bg-border" />
+            <div className="flex flex-col gap-1.5">
+                {/*
+                 * Keyed on the mention id so each field's local mode state resets
+                 * when a different mention is edited.
+                 */}
+                {activePlatforms.map((platform) =>
+                    platform === 'linkedin' ? (
+                        <LinkedInMentionField
+                            key={`linkedin-${activeMention.id}`}
+                            activeMention={activeMention}
+                            onUpdateMention={onUpdateMention}
+                        />
+                    ) : (
+                        <PlatformMentionField
+                            key={`${platform}-${activeMention.id}`}
+                            activeMention={activeMention}
+                            platform={platform}
+                            onUpdateMention={onUpdateMention}
+                        />
+                    ),
+                )}
             </div>
             {onSave && (
                 <div className="flex flex-col gap-1.5">
@@ -473,7 +401,7 @@ function MentionHandleEditor({
                         }
                         onClick={onSave}
                         className={cn(
-                            'rounded-lg bg-primary px-3 py-2 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90',
+                            'rounded-lg bg-primary py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90',
                             'disabled:cursor-not-allowed disabled:opacity-60',
                         )}
                     >
@@ -484,6 +412,95 @@ function MentionHandleEditor({
                 </div>
             )}
         </>
+    );
+}
+
+type PlatformMentionFieldProps = {
+    activeMention: MentionPlaceholder;
+    platform: PlatformName;
+    onUpdateMention: (
+        previous: MentionPlaceholder,
+        next: MentionPlaceholder,
+    ) => void;
+};
+
+/**
+ * One non-LinkedIn platform row. The mention/plain-text mode is held in local
+ * state rather than re-derived from whether the stored handle currently starts
+ * with '@'. That keeps the toggle, the '@' prefix, and the placeholder in
+ * agreement — and, crucially, clearing the field no longer silently flips the
+ * mode. Platforms that can't carry an `@` mention (only Facebook, today) show a
+ * static "Plain text" label instead of a toggle, so every row states its mode.
+ * The parent keys this on the mention id so the mode resets per mention.
+ */
+function PlatformMentionField({
+    activeMention,
+    platform,
+    onUpdateMention,
+}: PlatformMentionFieldProps) {
+    const supportsMention = platformSupportsMention(platform);
+    const [useMention, setUseMention] = useState(() =>
+        usesPlatformMention(activeMention, platform),
+    );
+    const handleValue = activeMention.handles[platform] ?? activeMention.label;
+
+    function setMode(next: boolean) {
+        setUseMention(next);
+        onUpdateMention(
+            activeMention,
+            setPlatformMentionMode(activeMention, platform, next),
+        );
+    }
+
+    return (
+        <div className="flex items-center gap-2">
+            <PlatformGlyph
+                platform={platform}
+                size={15}
+                className="shrink-0 text-muted-foreground"
+            />
+            <InputGroup className="h-8 min-w-0 flex-1 rounded-lg">
+                {supportsMention && useMention && (
+                    <InputGroupAddon className="pr-0 text-muted-foreground">
+                        @
+                    </InputGroupAddon>
+                )}
+                <InputGroupInput
+                    value={mentionInputValue(handleValue)}
+                    placeholder={useMention ? 'handle' : 'display name'}
+                    aria-label={`${platform} ${
+                        useMention ? 'handle' : 'display text'
+                    } for ${activeMention.label}`}
+                    className="text-xs"
+                    onChange={(event) =>
+                        onUpdateMention(
+                            activeMention,
+                            updateMentionHandle(
+                                activeMention,
+                                platform,
+                                event.target.value,
+                                supportsMention && useMention,
+                            ),
+                        )
+                    }
+                />
+            </InputGroup>
+            {supportsMention ? (
+                <MentionModeToggle
+                    ariaLabel={`How to show ${activeMention.label} on ${platform}`}
+                    value={useMention ? 'mention' : 'text'}
+                    options={[
+                        { value: 'mention', label: 'Mention' },
+                        { value: 'text', label: 'Plain text' },
+                    ]}
+                    onChange={(next) => setMode(next === 'mention')}
+                />
+            ) : (
+                <span className="shrink-0 px-1 text-[10px] font-medium text-muted-foreground/70">
+                    Plain text
+                </span>
+            )}
+        </div>
     );
 }
 
@@ -558,16 +575,26 @@ function LinkedInMentionField({
     }
 
     return (
-        <div className="flex flex-col gap-1.5 text-xs">
-            <div className="flex items-center justify-between gap-2">
-                <span className="inline-flex items-center gap-1.5 text-muted-foreground">
-                    <PlatformGlyph
-                        platform="linkedin"
-                        size={14}
-                        className="text-foreground"
+        <div className="flex flex-col gap-1 text-xs">
+            <div className="flex items-center gap-2">
+                <PlatformGlyph
+                    platform="linkedin"
+                    size={15}
+                    className="shrink-0 text-muted-foreground"
+                />
+                <InputGroup className="h-8 min-w-0 flex-1 rounded-lg">
+                    <InputGroupInput
+                        value={displayValue}
+                        placeholder={
+                            tagMode ? 'Company name' : 'Name shown on LinkedIn'
+                        }
+                        aria-label={`linkedin ${
+                            tagMode ? 'company name' : 'display text'
+                        } for ${activeMention.label}`}
+                        className="text-xs"
+                        onChange={(event) => handleChange(event.target.value)}
                     />
-                    <span className="capitalize">linkedin</span>
-                </span>
+                </InputGroup>
                 <MentionModeToggle
                     ariaLabel={`How to show ${activeMention.label} on LinkedIn`}
                     value={tagMode ? 'tag' : 'text'}
@@ -578,54 +605,48 @@ function LinkedInMentionField({
                     onChange={(next) => setTagMode(next === 'tag')}
                 />
             </div>
-            <InputGroup className="min-h-9 w-full min-w-0 rounded-lg border-border bg-background">
-                <InputGroupInput
-                    value={displayValue}
-                    placeholder={
-                        tagMode ? 'Company name' : 'Name shown on LinkedIn'
-                    }
-                    aria-label={`linkedin ${
-                        tagMode ? 'company name' : 'display text'
-                    } for ${activeMention.label}`}
-                    onChange={(event) => handleChange(event.target.value)}
-                />
-            </InputGroup>
-            {tagMode &&
-                (urn ? (
-                    <span className="flex items-center gap-1.5 rounded-lg bg-muted/60 px-2 py-1.5">
-                        <Building2 className="size-3.5 shrink-0 text-primary" />
-                        <span className="text-foreground">Company linked</span>
-                        <code className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground">
-                            {urn}
-                        </code>
-                        <button
-                            type="button"
-                            onClick={removeUrn}
-                            aria-label="Remove company tag"
-                            className="inline-flex size-4 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted-foreground/15 hover:text-foreground"
-                        >
-                            <X className="size-3" />
-                        </button>
-                    </span>
-                ) : vanityHint ? (
-                    <span className="flex items-start gap-1.5 text-muted-foreground">
-                        <Info className="mt-px size-3.5 shrink-0" />
-                        <span>
-                            That link doesn&rsquo;t include the company ID.
-                            Paste the URL with its number, or the
-                            company&rsquo;s URN.
+            {tagMode && (
+                <div className="flex flex-col gap-1 pl-6">
+                    {urn ? (
+                        <span className="flex items-center gap-1.5 rounded-md bg-muted/60 px-2 py-1">
+                            <Building2 className="size-3.5 shrink-0 text-primary" />
+                            <span className="text-foreground">
+                                Company linked
+                            </span>
+                            <code className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground">
+                                {urn}
+                            </code>
+                            <button
+                                type="button"
+                                onClick={removeUrn}
+                                aria-label="Remove company tag"
+                                className="inline-flex size-4 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted-foreground/15 hover:text-foreground"
+                            >
+                                <X className="size-3" />
+                            </button>
                         </span>
-                    </span>
-                ) : (
-                    <span className="text-muted-foreground">
-                        Paste the company&rsquo;s LinkedIn page URL to tag them.
-                    </span>
-                ))}
-            {tagMode && urn && (
-                <span className="text-[11px] text-muted-foreground/80">
-                    Match the company&rsquo;s exact name above, or LinkedIn
-                    won&rsquo;t link it.
-                </span>
+                    ) : vanityHint ? (
+                        <span className="flex items-start gap-1.5 text-[11px] text-muted-foreground">
+                            <Info className="mt-px size-3.5 shrink-0" />
+                            <span>
+                                That link doesn&rsquo;t include the company ID.
+                                Paste the URL with its number, or the
+                                company&rsquo;s URN.
+                            </span>
+                        </span>
+                    ) : (
+                        <span className="text-[11px] text-muted-foreground">
+                            Paste the company&rsquo;s LinkedIn page URL to tag
+                            them.
+                        </span>
+                    )}
+                    {urn && (
+                        <span className="text-[11px] text-muted-foreground/80">
+                            Match the company&rsquo;s exact name above, or
+                            LinkedIn won&rsquo;t link it.
+                        </span>
+                    )}
+                </div>
             )}
         </div>
     );
@@ -654,7 +675,7 @@ function MentionModeToggle({
         <div
             role="group"
             aria-label={ariaLabel}
-            className="inline-flex items-center rounded-md bg-muted p-0.5"
+            className="inline-flex shrink-0 items-center rounded-md bg-muted p-0.5"
         >
             {options.map((option) => {
                 const active = option.value === value;
@@ -666,7 +687,7 @@ function MentionModeToggle({
                         aria-pressed={active}
                         onClick={() => onChange(option.value)}
                         className={cn(
-                            'rounded-[5px] px-2 py-1 text-[11px] leading-none font-medium transition-colors',
+                            'rounded-[5px] px-1.5 py-1 text-[11px] leading-none font-medium whitespace-nowrap transition-colors',
                             active
                                 ? 'bg-background text-foreground shadow-sm'
                                 : 'text-muted-foreground hover:text-foreground',

--- a/resources/js/components/compose/mention-picker.tsx
+++ b/resources/js/components/compose/mention-picker.tsx
@@ -14,13 +14,14 @@ import {
 import {
     InputGroup,
     InputGroupAddon,
-    InputGroupButton,
     InputGroupInput,
 } from '@/components/ui/input-group';
 import {
     extractLinkedInOrgRef,
+    hasEmptyActiveHandle,
     mentionInputValue,
     normalizeMentionName,
+    platformSupportsMention,
     savedMentionToPlaceholder,
     setPlatformMentionMode,
     updateMentionHandle,
@@ -331,6 +332,9 @@ function MentionHandleEditor({
     onSave,
     saveMentionProcessing = false,
 }: MentionHandleEditorProps) {
+    const nameEmpty = mentionInputValue(activeMention.label).trim() === '';
+    const emptyHandle = hasEmptyActiveHandle(activeMention, activePlatforms);
+
     return (
         <>
             <div>
@@ -381,18 +385,48 @@ function MentionHandleEditor({
                         activeMention.handles[platform] ?? activeMention.label;
 
                     return (
-                        <label
+                        <div
                             key={platform}
                             className="flex flex-col gap-1.5 text-xs"
                         >
-                            <span className="inline-flex items-center gap-1.5 text-muted-foreground">
-                                <PlatformGlyph
-                                    platform={platform}
-                                    size={14}
-                                    className="text-foreground"
-                                />
-                                <span className="capitalize">{platform}</span>
-                            </span>
+                            <div className="flex items-center justify-between gap-2">
+                                <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                                    <PlatformGlyph
+                                        platform={platform}
+                                        size={14}
+                                        className="text-foreground"
+                                    />
+                                    <span className="capitalize">
+                                        {platform}
+                                    </span>
+                                </span>
+                                {platformSupportsMention(platform) && (
+                                    <MentionModeToggle
+                                        ariaLabel={`How to show ${activeMention.label} on ${platform}`}
+                                        value={useMention ? 'mention' : 'text'}
+                                        options={[
+                                            {
+                                                value: 'mention',
+                                                label: 'Mention',
+                                            },
+                                            {
+                                                value: 'text',
+                                                label: 'Plain text',
+                                            },
+                                        ]}
+                                        onChange={(next) =>
+                                            onUpdateMention(
+                                                activeMention,
+                                                setPlatformMentionMode(
+                                                    activeMention,
+                                                    platform,
+                                                    next === 'mention',
+                                                ),
+                                            )
+                                        }
+                                    />
+                                )}
+                            </div>
                             <InputGroup className="min-h-9 w-full min-w-0 rounded-lg border-border bg-background">
                                 {useMention && (
                                     <InputGroupAddon className="pr-0 text-foreground">
@@ -419,44 +453,35 @@ function MentionHandleEditor({
                                         )
                                     }
                                 />
-                                <InputGroupAddon align="inline-end">
-                                    <InputGroupButton
-                                        onClick={() =>
-                                            onUpdateMention(
-                                                activeMention,
-                                                setPlatformMentionMode(
-                                                    activeMention,
-                                                    platform,
-                                                    !useMention,
-                                                ),
-                                            )
-                                        }
-                                    >
-                                        {useMention
-                                            ? 'Plain text'
-                                            : '@ mention'}
-                                    </InputGroupButton>
-                                </InputGroupAddon>
                             </InputGroup>
-                        </label>
+                        </div>
                     );
                 })}
             </div>
             {onSave && (
-                <button
-                    type="button"
-                    disabled={
-                        saveMentionProcessing ||
-                        mentionInputValue(activeMention.label).trim() === ''
-                    }
-                    onClick={onSave}
-                    className={cn(
-                        'rounded-lg bg-primary px-3 py-2 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90',
-                        'disabled:cursor-not-allowed disabled:opacity-60',
+                <div className="flex flex-col gap-1.5">
+                    {emptyHandle && !nameEmpty && !saveMentionProcessing && (
+                        <p className="text-[11px] text-muted-foreground">
+                            Fill in every platform to save this mention — the
+                            empty one still works in this post.
+                        </p>
                     )}
-                >
-                    {saveMentionProcessing ? 'Saving…' : 'Save to workspace'}
-                </button>
+                    <button
+                        type="button"
+                        disabled={
+                            saveMentionProcessing || nameEmpty || emptyHandle
+                        }
+                        onClick={onSave}
+                        className={cn(
+                            'rounded-lg bg-primary px-3 py-2 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90',
+                            'disabled:cursor-not-allowed disabled:opacity-60',
+                        )}
+                    >
+                        {saveMentionProcessing
+                            ? 'Saving…'
+                            : 'Save to workspace'}
+                    </button>
+                </div>
             )}
         </>
     );
@@ -509,8 +534,8 @@ function LinkedInMentionField({
         onUpdateMention(activeMention, next);
     }
 
-    function toggleMode() {
-        if (tagMode) {
+    function setTagMode(next: boolean) {
+        if (!next) {
             setTagIntent(false);
             setVanityHint(null);
             onUpdateMention(
@@ -533,15 +558,26 @@ function LinkedInMentionField({
     }
 
     return (
-        <label className="flex flex-col gap-1.5 text-xs">
-            <span className="inline-flex items-center gap-1.5 text-muted-foreground">
-                <PlatformGlyph
-                    platform="linkedin"
-                    size={14}
-                    className="text-foreground"
+        <div className="flex flex-col gap-1.5 text-xs">
+            <div className="flex items-center justify-between gap-2">
+                <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                    <PlatformGlyph
+                        platform="linkedin"
+                        size={14}
+                        className="text-foreground"
+                    />
+                    <span className="capitalize">linkedin</span>
+                </span>
+                <MentionModeToggle
+                    ariaLabel={`How to show ${activeMention.label} on LinkedIn`}
+                    value={tagMode ? 'tag' : 'text'}
+                    options={[
+                        { value: 'text', label: 'Plain text' },
+                        { value: 'tag', label: 'Tag company' },
+                    ]}
+                    onChange={(next) => setTagMode(next === 'tag')}
                 />
-                <span className="capitalize">linkedin</span>
-            </span>
+            </div>
             <InputGroup className="min-h-9 w-full min-w-0 rounded-lg border-border bg-background">
                 <InputGroupInput
                     value={displayValue}
@@ -553,11 +589,6 @@ function LinkedInMentionField({
                     } for ${activeMention.label}`}
                     onChange={(event) => handleChange(event.target.value)}
                 />
-                <InputGroupAddon align="inline-end">
-                    <InputGroupButton onClick={toggleMode}>
-                        {tagMode ? 'Plain text' : 'Tag company'}
-                    </InputGroupButton>
-                </InputGroupAddon>
             </InputGroup>
             {tagMode &&
                 (urn ? (
@@ -596,6 +627,56 @@ function LinkedInMentionField({
                     won&rsquo;t link it.
                 </span>
             )}
-        </label>
+        </div>
+    );
+}
+
+type MentionModeToggleProps = {
+    /** The currently selected option value. */
+    value: string;
+    options: { value: string; label: string }[];
+    onChange: (value: string) => void;
+    ariaLabel: string;
+};
+
+/**
+ * Compact segmented control that shows both mode options side by side with the
+ * active one highlighted — so it is always clear which mode is on, unlike a
+ * single button whose label names the mode it would switch to.
+ */
+function MentionModeToggle({
+    value,
+    options,
+    onChange,
+    ariaLabel,
+}: MentionModeToggleProps) {
+    return (
+        <div
+            role="radiogroup"
+            aria-label={ariaLabel}
+            className="inline-flex items-center rounded-md bg-muted p-0.5"
+        >
+            {options.map((option) => {
+                const active = option.value === value;
+
+                return (
+                    <button
+                        key={option.value}
+                        type="button"
+                        role="radio"
+                        aria-checked={active}
+                        onClick={() => onChange(option.value)}
+                        className={cn(
+                            'rounded-[5px] px-2 py-1 text-[11px] leading-none font-medium transition-colors',
+                            active
+                                ? 'bg-background text-foreground shadow-sm'
+                                : 'text-muted-foreground hover:text-foreground',
+                        )}
+                    >
+                        {option.label}
+                    </button>
+                );
+            })}
+        </div>
     );
 }

--- a/resources/js/lib/compose/__tests__/mentions.test.ts
+++ b/resources/js/lib/compose/__tests__/mentions.test.ts
@@ -68,8 +68,8 @@ describe('mention helpers', () => {
             bluesky: '@Guest',
             linkedin: 'Guest',
             facebook: 'Guest',
-            instagram: 'Guest',
-            threads: 'Guest',
+            instagram: '@Guest',
+            threads: '@Guest',
         });
         expect(mentionToken(mention.id)).toBe(`{{mention:${mention.id}}}`);
     });
@@ -162,8 +162,12 @@ describe('mention helpers', () => {
     });
 
     it('knows which platforms support an @ mention', () => {
+        // Platforms that auto-link a bare @handle offer a mention toggle.
         expect(platformSupportsMention('x')).toBe(true);
         expect(platformSupportsMention('bluesky')).toBe(true);
+        expect(platformSupportsMention('instagram')).toBe(true);
+        expect(platformSupportsMention('threads')).toBe(true);
+        // LinkedIn has its own company-tag flow; Facebook's API won't auto-link.
         expect(platformSupportsMention('linkedin')).toBe(false);
         expect(platformSupportsMention('facebook')).toBe(false);
     });
@@ -297,8 +301,8 @@ describe('syncMentionsFromText', () => {
                     bluesky: '@guest',
                     linkedin: 'guest',
                     facebook: 'guest',
-                    instagram: 'guest',
-                    threads: 'guest',
+                    instagram: '@guest',
+                    threads: '@guest',
                 },
             },
         ]);
@@ -316,8 +320,8 @@ describe('syncMentionsFromText', () => {
                     bluesky: '@',
                     linkedin: '',
                     facebook: '',
-                    instagram: '',
-                    threads: '',
+                    instagram: '@',
+                    threads: '@',
                 },
             },
         ]);
@@ -336,8 +340,8 @@ describe('syncMentionsFromText', () => {
                     bluesky: '@guest',
                     linkedin: 'guest',
                     facebook: 'guest',
-                    instagram: 'guest',
-                    threads: 'guest',
+                    instagram: '@guest',
+                    threads: '@guest',
                 },
             },
         ]);

--- a/resources/js/lib/compose/__tests__/mentions.test.ts
+++ b/resources/js/lib/compose/__tests__/mentions.test.ts
@@ -120,6 +120,27 @@ describe('mention helpers', () => {
         expect(cleared.handles.linkedin ?? cleared.label).toBe('');
     });
 
+    it('preserves inter-word whitespace while a plain-text name is typed', () => {
+        const mention: MentionPlaceholder = {
+            id: 'acme',
+            label: '@acme',
+            handles: { linkedin: 'Acme' },
+        };
+
+        // Controlled input: trimming here would eat the trailing space between
+        // words and strand "Acme Corp" at "AcmeCorp".
+        const typed = updateMentionHandle(mention, 'linkedin', 'Acme ', false);
+        expect(typed.handles.linkedin).toBe('Acme ');
+
+        const finished = updateMentionHandle(
+            typed,
+            'linkedin',
+            'Acme Corp',
+            false,
+        );
+        expect(finished.handles.linkedin).toBe('Acme Corp');
+    });
+
     it('flags an empty active handle so saving can be blocked', () => {
         const filled: MentionPlaceholder = {
             id: 'guest',

--- a/resources/js/lib/compose/__tests__/mentions.test.ts
+++ b/resources/js/lib/compose/__tests__/mentions.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from 'vitest';
 import {
     createMention,
     extractLinkedInOrgRef,
+    hasEmptyActiveHandle,
     mentionInputValue,
     mentionToken,
     normalizeLinkedInUrn,
+    platformSupportsMention,
     replaceMentionLabel,
     replaceMentionTokens,
     savedMentionToPlaceholder,
@@ -101,6 +103,48 @@ describe('mention helpers', () => {
         expect(updateMentionHandle(mention, 'x', 'guest_x').handles.x).toBe(
             '@guest_x',
         );
+    });
+
+    it('keeps an emptied handle blank instead of snapping back to the label', () => {
+        const mention: MentionPlaceholder = {
+            id: 'guest',
+            label: '@guest',
+            handles: { x: '@guest', linkedin: 'Guest' },
+        };
+
+        // Clearing the field stores '' (not a delete), so the input stays blank
+        // rather than falling back to `handles[platform] ?? label`.
+        const cleared = updateMentionHandle(mention, 'linkedin', '', false);
+
+        expect(cleared.handles.linkedin).toBe('');
+        expect(cleared.handles.linkedin ?? cleared.label).toBe('');
+    });
+
+    it('flags an empty active handle so saving can be blocked', () => {
+        const filled: MentionPlaceholder = {
+            id: 'guest',
+            label: '@guest',
+            handles: { x: '@guest', linkedin: 'Guest' },
+        };
+        expect(hasEmptyActiveHandle(filled, ['x', 'linkedin'])).toBe(false);
+
+        const cleared = updateMentionHandle(filled, 'linkedin', '', false);
+        expect(hasEmptyActiveHandle(cleared, ['x', 'linkedin'])).toBe(true);
+
+        // An untouched platform falls back to the label, so it is not "empty".
+        const untouched: MentionPlaceholder = {
+            id: 'guest',
+            label: '@guest',
+            handles: {},
+        };
+        expect(hasEmptyActiveHandle(untouched, ['x'])).toBe(false);
+    });
+
+    it('knows which platforms support an @ mention', () => {
+        expect(platformSupportsMention('x')).toBe(true);
+        expect(platformSupportsMention('bluesky')).toBe(true);
+        expect(platformSupportsMention('linkedin')).toBe(false);
+        expect(platformSupportsMention('facebook')).toBe(false);
     });
 
     it('can store plain display text for a platform instead of an @ mention', () => {

--- a/resources/js/lib/compose/mentions.ts
+++ b/resources/js/lib/compose/mentions.ts
@@ -18,7 +18,15 @@ const PLATFORMS: PlatformName[] = [
     'instagram',
     'threads',
 ];
-const MENTION_PLATFORMS = new Set<PlatformName>(['x', 'bluesky']);
+// Platforms whose posts auto-link a bare `@handle`, so a real @mention is worth
+// offering alongside plain text. Facebook is intentionally excluded: its post
+// API does not auto-link `@text`, so a "mention" there would publish literally.
+const MENTION_PLATFORMS = new Set<PlatformName>([
+    'x',
+    'bluesky',
+    'instagram',
+    'threads',
+]);
 const HANDLE_PATTERN = /(^|\s)@([a-zA-Z0-9_.-]{0,50})(?=\s|$|[.,!?;:])/g;
 
 export function createMention(label: string): MentionPlaceholder {

--- a/resources/js/lib/compose/mentions.ts
+++ b/resources/js/lib/compose/mentions.ts
@@ -75,12 +75,18 @@ export function updateMentionHandle(
     useMention = true,
 ): MentionPlaceholder {
     const handles = { ...mention.handles };
-    const trimmed = handle.trim();
     // Keep an emptied field as '' rather than deleting the key, so the editor
     // input stays blank instead of snapping back to the mention-name fallback
     // (`handles[platform] ?? label`). Saving is gated separately.
+    //
+    // Pass the raw `handle` (not a trimmed copy) into `mentionTextInput`: this is
+    // a controlled input, so trimming on every keystroke would eat the trailing
+    // space between words, stranding a plain-text name like "Acme Corp" at
+    // "AcmeCorp". A whitespace-only value still counts as empty.
     handles[platform] =
-        trimmed === '' ? '' : mentionTextInput(platform, trimmed, useMention);
+        handle.trim() === ''
+            ? ''
+            : mentionTextInput(platform, handle, useMention);
 
     return { ...mention, handles };
 }

--- a/resources/js/lib/compose/mentions.ts
+++ b/resources/js/lib/compose/mentions.ts
@@ -76,13 +76,35 @@ export function updateMentionHandle(
 ): MentionPlaceholder {
     const handles = { ...mention.handles };
     const trimmed = handle.trim();
-    if (trimmed === '') {
-        delete handles[platform];
-    } else {
-        handles[platform] = mentionTextInput(platform, trimmed, useMention);
-    }
+    // Keep an emptied field as '' rather than deleting the key, so the editor
+    // input stays blank instead of snapping back to the mention-name fallback
+    // (`handles[platform] ?? label`). Saving is gated separately.
+    handles[platform] =
+        trimmed === '' ? '' : mentionTextInput(platform, trimmed, useMention);
 
     return { ...mention, handles };
+}
+
+/** Whether a platform supports a real `@` mention (vs. plain display text only). */
+export function platformSupportsMention(platform: PlatformName): boolean {
+    return MENTION_PLATFORMS.has(platform);
+}
+
+/**
+ * True when any active platform's display/handle field has been cleared. Used to
+ * block saving a half-filled mention to the workspace while still letting the
+ * empty field be used in the current post.
+ */
+export function hasEmptyActiveHandle(
+    mention: MentionPlaceholder,
+    platforms: PlatformName[],
+): boolean {
+    return platforms.some(
+        (platform) =>
+            mentionInputValue(
+                mention.handles[platform] ?? mention.label,
+            ).trim() === '',
+    );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace the single toggle button in the mention editor with a segmented control that shows both options (e.g. "Mention" / "Plain text", "Tag company" / "Plain text") side by side, so the active mode is always visible instead of only showing the action you'd switch to
- Clearing a platform's handle/display field now keeps it blank instead of snapping back to the mention name — the empty value still works in the current post
- Disable "Save to workspace" while any active platform's field is empty, with a hint explaining the field still works in this post even though it can't be saved yet
