### PR TITLE
fix(posts): proxy media through same-origin endpoint for editors

### DIFF
--- a/app/Http/Controllers/Posts/PostMediaContentController.php
+++ b/app/Http/Controllers/Posts/PostMediaContentController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Posts;
+
+use App\Http\Controllers\Controller;
+use App\Models\PostMedia;
+use App\Support\FileStorage;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class PostMediaContentController extends Controller
+{
+    /**
+     * Stream a stored media file back through the app on its own origin.
+     *
+     * In production the bytes live on an S3-compatible bucket that serves them
+     * via presigned URLs with no CORS headers. That is fine for plain <img>/<video>
+     * display, but the client-side image/video editors must `fetch()` the source
+     * into a canvas — a cross-origin request the bucket rejects. Proxying the read
+     * here gives the editor a same-origin URL, sidestepping bucket CORS entirely.
+     *
+     * `variant=source` serves the retained pre-edit original (present only on
+     * beautified media); the default serves the composed/main file.
+     */
+    public function show(Request $request, PostMedia $media): StreamedResponse
+    {
+        if ($request->query('variant') === 'source') {
+            abort_if($media->source_path === null, 404);
+            $disk = $media->source_disk ?? $media->disk;
+            $path = $media->source_path;
+        } else {
+            $disk = $media->disk;
+            $path = $media->path;
+        }
+
+        $storage = FileStorage::disk($disk);
+        abort_unless($storage->exists($path), 404);
+
+        return $storage->response($path, null, [
+            // Authenticated per-user response — never store in a shared cache.
+            'Cache-Control' => 'private, max-age=300',
+        ]);
+    }
+}

--- a/app/Models/PostMedia.php
+++ b/app/Models/PostMedia.php
@@ -134,7 +134,7 @@ class PostMedia extends Model
     }
 
     /**
-     * @return array{id: string, url: string, mime: string, kind: string, duration_seconds: int|null, alt_text: string|null, position: int, edit_settings: array<string, mixed>|null, source_url: string|null}
+     * @return array{id: string, url: string, mime: string, kind: string, duration_seconds: int|null, alt_text: string|null, position: int, edit_settings: array<string, mixed>|null, source_url: string|null, edit_url: string, source_edit_url: string|null}
      */
     public function toView(): array
     {
@@ -148,6 +148,12 @@ class PostMedia extends Model
             'position' => $this->position,
             'edit_settings' => $this->edit_settings,
             'source_url' => $this->source_url(),
+            // Same-origin proxy URLs the canvas editors fetch instead of the
+            // display URLs, whose storage origin omits CORS headers.
+            'edit_url' => route('media.raw', $this),
+            'source_edit_url' => $this->source_path === null
+                ? null
+                : route('media.raw', ['media' => $this, 'variant' => 'source']),
         ];
     }
 

--- a/app/Models/PostMedia.php
+++ b/app/Models/PostMedia.php
@@ -134,6 +134,10 @@ class PostMedia extends Model
     }
 
     /**
+     * `edit_url` / `source_edit_url` are same-origin proxy URLs the canvas
+     * editors fetch instead of the display URLs, whose storage origin may omit
+     * CORS headers. `source_edit_url` is null when no pre-edit source is kept.
+     *
      * @return array{id: string, url: string, mime: string, kind: string, duration_seconds: int|null, alt_text: string|null, position: int, edit_settings: array<string, mixed>|null, source_url: string|null, edit_url: string, source_edit_url: string|null}
      */
     public function toView(): array
@@ -148,8 +152,6 @@ class PostMedia extends Model
             'position' => $this->position,
             'edit_settings' => $this->edit_settings,
             'source_url' => $this->source_url(),
-            // Same-origin proxy URLs the canvas editors fetch instead of the
-            // display URLs, whose storage origin omits CORS headers.
             'edit_url' => route('media.raw', $this),
             'source_edit_url' => $this->source_path === null
                 ? null

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -413,7 +413,7 @@ export default function Composer({
         }
         setEditing({
             kind: 'video',
-            url: m.url,
+            url: m.edit_url,
             durationSeconds: m.duration_seconds ?? 0,
             mediaId: m.id,
             altText: m.alt_text,
@@ -431,13 +431,13 @@ export default function Composer({
         if (m.edit_settings && m.source_url) {
             setEditing({
                 kind: 'reedit',
-                url: m.source_url,
+                url: m.source_edit_url ?? m.edit_url,
                 settings: normalizeSettings(m.edit_settings),
                 mediaId: m.id,
                 altText: m.alt_text,
             });
         } else {
-            setEditing({ kind: 'raw', url: m.url, mediaId: m.id });
+            setEditing({ kind: 'raw', url: m.edit_url, mediaId: m.id });
         }
     }
 

--- a/resources/js/components/compose/preview/__tests__/fixtures.ts
+++ b/resources/js/components/compose/preview/__tests__/fixtures.ts
@@ -12,6 +12,8 @@ export function imageMedia(id: string): MediaView {
         position: 0,
         edit_settings: null,
         source_url: null,
+        edit_url: `https://app.example.test/media/${id}/raw`,
+        source_edit_url: null,
     };
 }
 
@@ -26,6 +28,8 @@ export function videoMedia(id: string): MediaView {
         position: 0,
         edit_settings: null,
         source_url: null,
+        edit_url: `https://app.example.test/media/${id}/raw`,
+        source_edit_url: null,
     };
 }
 

--- a/resources/js/lib/compose/__tests__/composer-state.test.ts
+++ b/resources/js/lib/compose/__tests__/composer-state.test.ts
@@ -270,6 +270,8 @@ describe('composerReducer', () => {
                 position: 0,
                 edit_settings: null,
                 source_url: null,
+                edit_url: 'http://x/raw',
+                source_edit_url: null,
             },
         });
         expect(state.media.map((m) => m.id)).toEqual(['m1']);
@@ -287,6 +289,8 @@ describe('composerReducer', () => {
                 position: 1,
                 edit_settings: null,
                 source_url: null,
+                edit_url: 'http://x/raw',
+                source_edit_url: null,
             },
         });
         expect(state.media.map((m) => m.id)).toEqual(['m1', 'm2']);
@@ -312,6 +316,8 @@ describe('composerReducer', () => {
                 position: 0,
                 edit_settings: null,
                 source_url: null,
+                edit_url: 'http://x/raw',
+                source_edit_url: null,
             },
         });
         state = composerReducer(state, {
@@ -326,6 +332,8 @@ describe('composerReducer', () => {
                 position: 1,
                 edit_settings: null,
                 source_url: null,
+                edit_url: 'http://x/raw',
+                source_edit_url: null,
             },
         });
         state = composerReducer(state, {
@@ -349,6 +357,8 @@ describe('composerReducer', () => {
                 position: 0,
                 edit_settings: null,
                 source_url: null,
+                edit_url: 'http://x/raw',
+                source_edit_url: null,
             },
         });
         state = composerReducer(state, {
@@ -363,6 +373,8 @@ describe('composerReducer', () => {
                 position: 1,
                 edit_settings: null,
                 source_url: null,
+                edit_url: 'http://x/raw',
+                source_edit_url: null,
             },
         });
         // unknown id ignored; m1 missing from the sequence is appended
@@ -584,6 +596,8 @@ describe('composerReducer', () => {
                 position: 0,
                 edit_settings: null,
                 source_url: null,
+                edit_url: 'http://x/raw',
+                source_edit_url: null,
             },
         });
         const existing = base.media[0];
@@ -701,6 +715,8 @@ describe('buildPutBody', () => {
                 position: 0,
                 edit_settings: null,
                 source_url: null,
+                edit_url: 'http://x/raw',
+                source_edit_url: null,
             },
         });
         state = composerReducer(state, {
@@ -715,6 +731,8 @@ describe('buildPutBody', () => {
                 position: 1,
                 edit_settings: null,
                 source_url: null,
+                edit_url: 'http://x/raw',
+                source_edit_url: null,
             },
         });
         const body = buildPutBody(state, ['a1', 'a2']);
@@ -760,6 +778,8 @@ describe('composerHasContent', () => {
                 position: 0,
                 edit_settings: null,
                 source_url: null,
+                edit_url: 'http://x/raw',
+                source_edit_url: null,
             },
         });
         expect(composerHasContent(state)).toBe(true);

--- a/resources/js/lib/compose/__tests__/platform-preview.test.ts
+++ b/resources/js/lib/compose/__tests__/platform-preview.test.ts
@@ -36,6 +36,8 @@ const image: MediaView = {
     position: 0,
     edit_settings: null,
     source_url: null,
+    edit_url: 'https://app.example.test/media/media-1/raw',
+    source_edit_url: null,
 };
 
 const mentions: MentionPlaceholder[] = [

--- a/resources/js/lib/compose/__tests__/precheck.test.ts
+++ b/resources/js/lib/compose/__tests__/precheck.test.ts
@@ -132,6 +132,8 @@ function mediaItem(over: Partial<MediaView> & { id: string }): MediaView {
         position: 0,
         edit_settings: null,
         source_url: null,
+        edit_url: 'https://app.example.test/media/raw',
+        source_edit_url: null,
         ...over,
     };
 }

--- a/resources/js/lib/compose/__tests__/x-preview.test.ts
+++ b/resources/js/lib/compose/__tests__/x-preview.test.ts
@@ -24,6 +24,8 @@ const image: MediaView = {
     position: 0,
     edit_settings: null,
     source_url: null,
+    edit_url: 'https://app.example.test/media/raw',
+    source_edit_url: null,
 };
 
 const mentions: MentionPlaceholder[] = [

--- a/resources/js/pages/engagement/components/use-reply-media.tsx
+++ b/resources/js/pages/engagement/components/use-reply-media.tsx
@@ -285,13 +285,13 @@ export function useReplyMedia({
         if (m.edit_settings && m.source_url) {
             setEditing({
                 kind: 'reedit',
-                url: m.source_url,
+                url: m.source_edit_url ?? m.edit_url,
                 settings: normalizeSettings(m.edit_settings),
                 mediaId: m.id,
                 altText: m.alt_text,
             });
         } else {
-            setEditing({ kind: 'raw', url: m.url, mediaId: m.id });
+            setEditing({ kind: 'raw', url: m.edit_url, mediaId: m.id });
         }
     }
 

--- a/resources/js/types/compose.ts
+++ b/resources/js/types/compose.ts
@@ -86,6 +86,10 @@ export type MediaView = {
     position: number;
     edit_settings: EditSettings | null;
     source_url: string | null;
+    /** Same-origin proxy URL the canvas editor fetches (display URLs omit CORS headers). */
+    edit_url: string;
+    /** Same-origin proxy URL for the retained pre-edit source; null when none. */
+    source_edit_url: string | null;
 };
 
 /** An upload still in flight (or just failed) — rendered as a ghost chip. */

--- a/routes/posts.php
+++ b/routes/posts.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Posts\NextSlotController;
 use App\Http\Controllers\Posts\PostController;
 use App\Http\Controllers\Posts\PostImageEditController;
 use App\Http\Controllers\Posts\PostingScheduleController;
+use App\Http\Controllers\Posts\PostMediaContentController;
 use App\Http\Controllers\Posts\PostMediaController;
 use App\Http\Controllers\Posts\PostMetricsRefreshController;
 use App\Http\Controllers\Posts\PostQueueController;
@@ -89,6 +90,10 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
         Route::put('posts/{post}/image-edit/{media}', [PostImageEditController::class, 'update'])->name('posts.image-edit.update');
     });
     Route::delete('posts/{post}/media/{media}', [PostMediaController::class, 'destroy'])->name('posts.media.destroy');
+
+    // Same-origin proxy for editor fetches — the storage bucket serves display
+    // URLs without CORS headers, which blocks the canvas-based image/video editors.
+    Route::get('media/{media}/raw', [PostMediaContentController::class, 'show'])->name('media.raw');
 
     Route::get('posts/{post}/shares', [PostShareController::class, 'index'])->name('posts.shares.index');
     Route::post('posts/{post}/shares', [PostShareController::class, 'store'])->name('posts.shares.store');

--- a/tests/Feature/Posts/PostMediaContentTest.php
+++ b/tests/Feature/Posts/PostMediaContentTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Enums\WorkspaceRole;
+use App\Models\PostMedia;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
+use Illuminate\Support\Facades\Storage;
+
+function mediaContentMember(): array
+{
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'role' => WorkspaceRole::Member,
+    ]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    test()->actingAs($user);
+
+    return [$user, $workspace];
+}
+
+test('GET media/{media}/raw streams the composed file same-origin for the workspace member', function () {
+    Storage::fake('public');
+    [, $workspace] = mediaContentMember();
+    Storage::disk('public')->put('media/ws/pic.png', 'COMPOSED-BYTES');
+
+    $media = PostMedia::factory()->create([
+        'workspace_id' => $workspace->id,
+        'disk' => 'public',
+        'path' => 'media/ws/pic.png',
+        'mime' => 'image/png',
+    ]);
+
+    $response = test()->get(route('media.raw', $media));
+
+    $response->assertOk();
+    expect($response->streamedContent())->toBe('COMPOSED-BYTES');
+});
+
+test('GET media/{media}/raw?variant=source streams the retained source file', function () {
+    Storage::fake('public');
+    [, $workspace] = mediaContentMember();
+    Storage::disk('public')->put('media/ws/composed.png', 'COMPOSED');
+    Storage::disk('public')->put('media/ws/source.png', 'SOURCE-BYTES');
+
+    $media = PostMedia::factory()->create([
+        'workspace_id' => $workspace->id,
+        'disk' => 'public',
+        'path' => 'media/ws/composed.png',
+        'source_disk' => 'public',
+        'source_path' => 'media/ws/source.png',
+    ]);
+
+    $response = test()->get(route('media.raw', ['media' => $media, 'variant' => 'source']));
+
+    $response->assertOk();
+    expect($response->streamedContent())->toBe('SOURCE-BYTES');
+});
+
+test('GET media/{media}/raw?variant=source 404s when no source is retained', function () {
+    Storage::fake('public');
+    [, $workspace] = mediaContentMember();
+    Storage::disk('public')->put('media/ws/pic.png', 'COMPOSED');
+
+    $media = PostMedia::factory()->create([
+        'workspace_id' => $workspace->id,
+        'disk' => 'public',
+        'path' => 'media/ws/pic.png',
+    ]);
+
+    test()->get(route('media.raw', ['media' => $media, 'variant' => 'source']))->assertNotFound();
+});
+
+test('GET media/{media}/raw 404s for media in another workspace (no IDOR)', function () {
+    Storage::fake('public');
+    mediaContentMember();
+    Storage::disk('public')->put('media/other/pic.png', 'SECRET');
+
+    $otherWorkspace = Workspace::factory()->create();
+    $media = PostMedia::factory()->create([
+        'workspace_id' => $otherWorkspace->id,
+        'disk' => 'public',
+        'path' => 'media/other/pic.png',
+    ]);
+
+    test()->get(route('media.raw', $media))->assertNotFound();
+});
+
+test('GET media/{media}/raw redirects a guest to login', function () {
+    Storage::fake('public');
+    $workspace = Workspace::factory()->create();
+    Storage::disk('public')->put('media/ws/pic.png', 'BYTES');
+    $media = PostMedia::factory()->create([
+        'workspace_id' => $workspace->id,
+        'disk' => 'public',
+        'path' => 'media/ws/pic.png',
+    ]);
+
+    test()->get(route('media.raw', $media))->assertRedirect(route('login'));
+});

--- a/tests/Feature/Posts/PostMediaContentTest.php
+++ b/tests/Feature/Posts/PostMediaContentTest.php
@@ -40,6 +40,27 @@ test('GET media/{media}/raw streams the composed file same-origin for the worksp
     expect($response->streamedContent())->toBe('COMPOSED-BYTES');
 });
 
+test('GET media/{media}/raw streams from the local disk for self-hosters without S3', function () {
+    // A self-hosted install with no object storage keeps media on the private
+    // `local` disk (storage/app/private). The proxy must stream those bytes just
+    // the same — this is the default self-host configuration.
+    Storage::fake('local');
+    [, $workspace] = mediaContentMember();
+    Storage::disk('local')->put('media/ws/local.png', 'LOCAL-DISK-BYTES');
+
+    $media = PostMedia::factory()->create([
+        'workspace_id' => $workspace->id,
+        'disk' => 'local',
+        'path' => 'media/ws/local.png',
+        'mime' => 'image/png',
+    ]);
+
+    $response = test()->get(route('media.raw', $media));
+
+    $response->assertOk();
+    expect($response->streamedContent())->toBe('LOCAL-DISK-BYTES');
+});
+
 test('GET media/{media}/raw?variant=source streams the retained source file', function () {
     Storage::fake('public');
     [, $workspace] = mediaContentMember();

--- a/tests/Unit/PostMediaTest.php
+++ b/tests/Unit/PostMediaTest.php
@@ -30,6 +30,8 @@ test('toView exposes edit settings and source url for a beautified image', funct
     expect($view['edit_settings'])->toBe(['version' => 1, 'padding' => 64])
         ->and($view['source_url'])->toContain('media/ws/source.png')
         ->and($view['id'])->toBe($media->id)
+        ->and($view['edit_url'])->toContain("media/{$media->id}/raw")
+        ->and($view['source_edit_url'])->toContain('variant=source')
         ->and($view)->toHaveKeys(['url', 'mime', 'kind', 'duration_seconds', 'alt_text', 'position']);
 });
 
@@ -37,7 +39,9 @@ test('toView returns null edit settings and source url for a plain image', funct
     $media = PostMedia::factory()->create();
 
     expect($media->toView()['edit_settings'])->toBeNull()
-        ->and($media->toView()['source_url'])->toBeNull();
+        ->and($media->toView()['source_url'])->toBeNull()
+        ->and($media->toView()['source_edit_url'])->toBeNull()
+        ->and($media->toView()['edit_url'])->toContain("media/{$media->id}/raw");
 });
 
 test('a new media instance defaults to the image kind in memory', function () {


### PR DESCRIPTION
## Summary
- Fixes broken image/video editing on draft posts caused by the canvas-based editors failing to `fetch()` media served from the storage bucket, which returns presigned URLs with no CORS headers
- Adds a same-origin `media/{media}/raw` route and `PostMediaContentController` that streams the composed (or, via `?variant=source`, the retained pre-edit source) file back through the app
- `PostMedia::toView()` now exposes `edit_url` and `source_edit_url` alongside the existing display `url`/`source_url`, and the composer and reply-media editors fetch through these new URLs instead of the direct storage URLs
- Adds feature tests covering streaming, source variant, 404 on missing source, workspace isolation (no IDOR), and guest redirect, plus updated unit/component tests for the new `MediaView` fields
