### PR TITLE
feat(analytics): add summary stat tiles and redesign follower chart

### DIFF
--- a/app/Http/Controllers/AnalyticsController.php
+++ b/app/Http/Controllers/AnalyticsController.php
@@ -132,12 +132,18 @@ class AnalyticsController extends Controller
     }
 
     /**
-     * The headline numbers — total followers, engagement, and posts published —
-     * each with a change vs the previous equal-length window. Deltas are null
-     * when there's no honest baseline to compare against.
+     * The headline numbers — total followers, engagement, and posts published.
+     * The follower delta is growth across the selected window; the engagement
+     * and posts deltas compare against the previous equal-length window. Deltas
+     * are null when there's no honest baseline to compare against.
      *
      * @param  array<int, array<string, mixed>>  $accounts
-     * @return array<string, mixed>
+     * @return array{
+     *     account_count: int,
+     *     followers: array{value: int, delta: int|null},
+     *     engagement: array{value: int, delta: int|null},
+     *     posts: array{value: int, delta: int|null},
+     * }
      */
     private function buildSummary(array $accounts, int $totalEngagement, int $postsCount, CarbonInterface $previousFrom, CarbonInterface $from): array
     {
@@ -156,12 +162,18 @@ class AnalyticsController extends Controller
             ->where('published_at', '<', $from)
             ->get();
 
-        $hasBaseline = $previousPosts->isNotEmpty();
-        $previousEngagement = (int) $previousPosts
-            ->filter(fn (Post $post): bool => $post->targets->contains(
-                fn (PostTarget $t): bool => $t->metrics_status === MetricsStatus::Ok,
-            ))
-            ->sum(fn (Post $post): int => (int) $post->targets->sum(fn (PostTarget $t): int => $t->likes + $t->comments + $t->reposts));
+        // Engagement is only measurable on posts that captured Ok metrics, so the
+        // baseline for the engagement delta must also require such a post — a
+        // previous window of unmeasured posts is not a zero baseline.
+        $previousMeasuredPosts = $previousPosts->filter(fn (Post $post): bool => $post->targets->contains(
+            fn (PostTarget $t): bool => $t->metrics_status === MetricsStatus::Ok,
+        ));
+        $hasEngagementBaseline = $previousMeasuredPosts->isNotEmpty();
+        $previousEngagement = (int) $previousMeasuredPosts->sum(
+            fn (Post $post): int => (int) $post->targets->sum(fn (PostTarget $t): int => $t->likes + $t->comments + $t->reposts),
+        );
+
+        $hasPostBaseline = $previousPosts->isNotEmpty();
 
         return [
             'account_count' => $accountsCollection->count(),
@@ -171,11 +183,11 @@ class AnalyticsController extends Controller
             ],
             'engagement' => [
                 'value' => $totalEngagement,
-                'delta' => $hasBaseline ? $totalEngagement - $previousEngagement : null,
+                'delta' => $hasEngagementBaseline ? $totalEngagement - $previousEngagement : null,
             ],
             'posts' => [
                 'value' => $postsCount,
-                'delta' => $hasBaseline ? $postsCount - $previousPosts->count() : null,
+                'delta' => $hasPostBaseline ? $postsCount - $previousPosts->count() : null,
             ],
         ];
     }
@@ -186,7 +198,7 @@ class AnalyticsController extends Controller
      *
      * @param  Collection<int, AccountMetric>  $metrics
      */
-    private function followerDelta($metrics): ?int
+    private function followerDelta(Collection $metrics): ?int
     {
         if ($metrics->count() < 2) {
             return null;

--- a/app/Http/Controllers/AnalyticsController.php
+++ b/app/Http/Controllers/AnalyticsController.php
@@ -12,6 +12,7 @@ use App\Models\ConnectedAccount;
 use App\Models\Post;
 use App\Models\PostTarget;
 use App\Support\InstanceSettings;
+use Carbon\CarbonInterface;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
@@ -46,11 +47,12 @@ class AnalyticsController extends Controller
     }
 
     /**
-     * @return array{accounts: array<int, array<string, mixed>>, posts: array<int, array<string, mixed>>, comparison: array{top: array<int, array<string, mixed>>, bottom: array<int, array<string, mixed>>}}
+     * @return array{accounts: array<int, array<string, mixed>>, posts: array<int, array<string, mixed>>, summary: array<string, mixed>, comparison: array{top: array<int, array<string, mixed>>, bottom: array<int, array<string, mixed>>}}
      */
     private function buildPayload(int $days): array
     {
         $from = Date::now()->subDays($days);
+        $previousFrom = Date::now()->subDays($days * 2);
 
         // Discord webhooks have no follower/member metrics — omit them from the
         // follower growth chart and account cards entirely.
@@ -71,6 +73,7 @@ class AnalyticsController extends Controller
                 'avatar_url' => $account->avatar_url,
                 'status' => $account->metrics_status?->value,
                 'latest_followers' => $account->metrics->last()?->followers,
+                'followers_delta' => $this->followerDelta($account->metrics),
                 'series' => $this->downsampleDaily($account->metrics),
             ])->all();
 
@@ -114,11 +117,88 @@ class AnalyticsController extends Controller
         return [
             'accounts' => $accounts,
             'posts' => $markers,
+            'summary' => $this->buildSummary($accounts, $posts, $ranked, $previousFrom, $from),
             'comparison' => [
                 'top' => $comparisonTop,
                 'bottom' => $comparisonBottom,
             ],
         ];
+    }
+
+    /**
+     * The headline numbers — total followers, engagement, and posts published —
+     * each with a change vs the previous equal-length window. Deltas are null
+     * when there's no honest baseline to compare against.
+     *
+     * @param  array<int, array<string, mixed>>  $accounts
+     * @param  Collection<int, Post>  $posts
+     * @param  Collection<int, array<string, mixed>>  $ranked
+     * @return array<string, mixed>
+     */
+    private function buildSummary(array $accounts, Collection $posts, Collection $ranked, CarbonInterface $previousFrom, CarbonInterface $from): array
+    {
+        $accountsCollection = collect($accounts);
+
+        $totalFollowers = (int) $accountsCollection->sum(fn (array $a): int => (int) ($a['latest_followers'] ?? 0));
+        $trackedDeltas = $accountsCollection->pluck('followers_delta')->filter(fn ($d): bool => $d !== null);
+        $followersDelta = $trackedDeltas->isEmpty() ? null : (int) $trackedDeltas->sum();
+
+        $totalEngagement = (int) $ranked->sum('engagement');
+        $postsCount = $posts->count();
+
+        // Previous window — only used as a baseline for the delta chips.
+        $previousPosts = Post::query()
+            ->with('targets:id,post_id,platform,likes,comments,reposts,metrics_status')
+            ->whereIn('status', [PostStatus::Published->value, PostStatus::Partial->value])
+            ->whereNotNull('published_at')
+            ->where('published_at', '>=', $previousFrom)
+            ->where('published_at', '<', $from)
+            ->get();
+
+        $hasBaseline = $previousPosts->isNotEmpty();
+        $previousEngagement = (int) $previousPosts
+            ->filter(fn (Post $post): bool => $post->targets->contains(
+                fn (PostTarget $t): bool => $t->metrics_status === MetricsStatus::Ok,
+            ))
+            ->sum(fn (Post $post): int => (int) $post->targets->sum(fn (PostTarget $t): int => $t->likes + $t->comments + $t->reposts));
+
+        return [
+            'account_count' => $accountsCollection->count(),
+            'followers' => [
+                'value' => $totalFollowers,
+                'delta' => $followersDelta,
+            ],
+            'engagement' => [
+                'value' => $totalEngagement,
+                'delta' => $hasBaseline ? $totalEngagement - $previousEngagement : null,
+            ],
+            'posts' => [
+                'value' => $postsCount,
+                'delta' => $hasBaseline ? $postsCount - $previousPosts->count() : null,
+            ],
+        ];
+    }
+
+    /**
+     * Change in followers across the window: latest reading minus the earliest.
+     * Null unless there are at least two comparable readings.
+     *
+     * @param  Collection<int, AccountMetric>  $metrics
+     */
+    private function followerDelta($metrics): ?int
+    {
+        if ($metrics->count() < 2) {
+            return null;
+        }
+
+        $first = $metrics->first()?->followers;
+        $last = $metrics->last()?->followers;
+
+        if ($first === null || $last === null) {
+            return null;
+        }
+
+        return $last - $first;
     }
 
     /**

--- a/app/Http/Controllers/AnalyticsController.php
+++ b/app/Http/Controllers/AnalyticsController.php
@@ -117,7 +117,13 @@ class AnalyticsController extends Controller
         return [
             'accounts' => $accounts,
             'posts' => $markers,
-            'summary' => $this->buildSummary($accounts, $posts, $ranked, $previousFrom, $from),
+            'summary' => $this->buildSummary(
+                $accounts,
+                (int) $ranked->sum('engagement'),
+                $posts->count(),
+                $previousFrom,
+                $from,
+            ),
             'comparison' => [
                 'top' => $comparisonTop,
                 'bottom' => $comparisonBottom,
@@ -131,20 +137,15 @@ class AnalyticsController extends Controller
      * when there's no honest baseline to compare against.
      *
      * @param  array<int, array<string, mixed>>  $accounts
-     * @param  Collection<int, Post>  $posts
-     * @param  Collection<int, array<string, mixed>>  $ranked
      * @return array<string, mixed>
      */
-    private function buildSummary(array $accounts, Collection $posts, Collection $ranked, CarbonInterface $previousFrom, CarbonInterface $from): array
+    private function buildSummary(array $accounts, int $totalEngagement, int $postsCount, CarbonInterface $previousFrom, CarbonInterface $from): array
     {
         $accountsCollection = collect($accounts);
 
         $totalFollowers = (int) $accountsCollection->sum(fn (array $a): int => (int) ($a['latest_followers'] ?? 0));
         $trackedDeltas = $accountsCollection->pluck('followers_delta')->filter(fn ($d): bool => $d !== null);
         $followersDelta = $trackedDeltas->isEmpty() ? null : (int) $trackedDeltas->sum();
-
-        $totalEngagement = (int) $ranked->sum('engagement');
-        $postsCount = $posts->count();
 
         // Previous window — only used as a baseline for the delta chips.
         $previousPosts = Post::query()

--- a/app/Http/Controllers/ConnectedAccounts/MetaConnectionController.php
+++ b/app/Http/Controllers/ConnectedAccounts/MetaConnectionController.php
@@ -319,6 +319,12 @@ class MetaConnectionController extends Controller
         return redirect()->route('accounts.index')->with('error', $message);
     }
 
+    /**
+     * Reads live session state that a concurrent OAuth callback may stash while
+     * we hold the lock, so its result changes between calls within one request.
+     *
+     * @phpstan-impure
+     */
     private function hasStashedAssets(Request $request): bool
     {
         $stash = $request->session()->get(self::SESSION_KEY);

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -100,6 +100,16 @@
     --chart-3: oklch(0.646 0.222 41.116);
     --chart-4: oklch(0.553 0.195 38.402);
     --chart-5: oklch(0.47 0.157 37.304);
+    /* Categorical account-line palette — distinct hues assigned in fixed order,
+       validated colorblind-safe for the light card surface (dataviz method). */
+    --account-1: #2a78d6;
+    --account-2: #eb6834;
+    --account-3: #1baf7a;
+    --account-4: #eda100;
+    --account-5: #e87ba4;
+    --account-6: #008300;
+    --account-7: #4a3aa7;
+    --account-8: #e34948;
     --radius: 0.625rem;
     --sidebar: oklch(0.985 0 0);
     --sidebar-foreground: oklch(0.145 0 0);
@@ -136,6 +146,15 @@
     --chart-3: oklch(0.646 0.222 41.116);
     --chart-4: oklch(0.553 0.195 38.402);
     --chart-5: oklch(0.47 0.157 37.304);
+    /* Same eight hues, re-stepped for the dark card surface. */
+    --account-1: #3987e5;
+    --account-2: #d95926;
+    --account-3: #199e70;
+    --account-4: #c98500;
+    --account-5: #d55181;
+    --account-6: #008300;
+    --account-7: #9085e9;
+    --account-8: #e66767;
     --sidebar: oklch(0.205 0 0);
     --sidebar-foreground: oklch(0.985 0 0);
     --sidebar-primary: oklch(0.768 0.233 130.85);

--- a/resources/js/components/analytics/__tests__/follower-chart.test.ts
+++ b/resources/js/components/analytics/__tests__/follower-chart.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-    buildFollowerChartData,
+    followerYDomain,
     formatFollowerTooltipDate,
-    nextHiddenAccountIds,
 } from '../follower-chart-utils';
 
 describe('follower chart tooltip', () => {
@@ -18,74 +17,35 @@ describe('follower chart tooltip', () => {
     });
 });
 
-describe('buildFollowerChartData', () => {
-    it('merges same-day readings from every account onto one row', () => {
-        const rows = buildFollowerChartData([
-            {
-                id: 'x',
-                platform: 'x',
-                handle: '@acme',
-                display_name: 'Acme X',
-                avatar_url: null,
-                status: 'ok',
-                latest_followers: 120,
-                series: [
-                    {
-                        at: '2026-05-14T09:15:00.000Z',
-                        followers: 100,
-                        following: 10,
-                    },
-                    {
-                        at: '2026-05-15T09:15:00.000Z',
-                        followers: 120,
-                        following: 10,
-                    },
-                ],
-            },
-            {
-                id: 'li',
-                platform: 'linkedin',
-                handle: 'acme-inc',
-                display_name: 'Acme Inc',
-                avatar_url: null,
-                status: 'ok',
-                latest_followers: 9800,
-                series: [
-                    {
-                        at: '2026-05-14T11:15:00.000Z',
-                        followers: 9700,
-                        following: 20,
-                    },
-                    {
-                        at: '2026-05-15T11:15:00.000Z',
-                        followers: 9800,
-                        following: 20,
-                    },
-                ],
-            },
-        ]);
-
-        expect(rows).toHaveLength(2);
-        expect(rows[0]).toMatchObject({
-            x: 100,
-            li: 9700,
-        });
-        expect(rows[1]).toMatchObject({
-            x: 120,
-            li: 9800,
-        });
-        expect(Object.keys(rows[0]).filter((k) => k !== 'date')).toEqual(
-            expect.arrayContaining(['x', 'li']),
-        );
+describe('followerYDomain', () => {
+    it('pads a growing series so small changes fill the panel', () => {
+        // 1600 → 1700 must not collapse to a flat line against a 0 baseline.
+        const [min, max] = followerYDomain([1600, 1650, 1700]);
+        expect(min).toBeGreaterThan(1500);
+        expect(min).toBeLessThan(1600);
+        expect(max).toBeGreaterThan(1700);
+        // The visible band is a small window around the data, not [0, 1700].
+        expect(max - min).toBeLessThan(200);
     });
-});
 
-describe('nextHiddenAccountIds', () => {
-    it('hides a visible account and shows a hidden one', () => {
-        const hidden = nextHiddenAccountIds(new Set(), 'x');
-        expect([...hidden]).toEqual(['x']);
+    it('never anchors the window at zero for a high-count account', () => {
+        const [min] = followerYDomain([1600, 1700]);
+        expect(min).toBeGreaterThan(0);
+    });
 
-        const shown = nextHiddenAccountIds(hidden, 'x');
-        expect([...shown]).toEqual([]);
+    it('gives a flat series a small symmetric band', () => {
+        const [min, max] = followerYDomain([50, 50, 50]);
+        expect(min).toBeLessThan(50);
+        expect(max).toBeGreaterThan(50);
+    });
+
+    it('handles a series that starts at zero', () => {
+        const [min, max] = followerYDomain([0, 10, 25]);
+        expect(min).toBeLessThanOrEqual(0);
+        expect(max).toBeGreaterThan(25);
+    });
+
+    it('falls back to a unit window when there are no values', () => {
+        expect(followerYDomain([])).toEqual([0, 1]);
     });
 });

--- a/resources/js/components/analytics/__tests__/metric-delta.test.ts
+++ b/resources/js/components/analytics/__tests__/metric-delta.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatDelta } from '../metric-delta';
+
+describe('formatDelta', () => {
+    it('prefixes gains with + and groups thousands', () => {
+        expect(formatDelta(1204)).toBe('+1,204');
+    });
+
+    it('prefixes losses with a minus sign', () => {
+        expect(formatDelta(-342)).toBe('−342');
+    });
+
+    it('renders a flat period without a sign', () => {
+        expect(formatDelta(0)).toBe('0');
+    });
+});

--- a/resources/js/components/analytics/follower-chart-utils.ts
+++ b/resources/js/components/analytics/follower-chart-utils.ts
@@ -1,17 +1,17 @@
 import { dayjs } from '@/lib/datetime/dayjs';
-import type { AnalyticsPageProps } from '@/types/metrics';
 
+// Distinct categorical hues (not a warm monochrome ramp) so each account line
+// stays tellable-apart. Assigned in fixed order and validated colorblind-safe.
 const ACCOUNT_COLORS = [
-    'var(--chart-1)',
-    'var(--chart-2)',
-    'var(--chart-3)',
-    'var(--chart-4)',
-    'var(--chart-5)',
+    'var(--account-1)',
+    'var(--account-2)',
+    'var(--account-3)',
+    'var(--account-4)',
+    'var(--account-5)',
+    'var(--account-6)',
+    'var(--account-7)',
+    'var(--account-8)',
 ];
-
-export type FollowerChartRow = Record<string, number | undefined> & {
-    date: number;
-};
 
 type TooltipPayloadWithDate = readonly {
     payload?: {
@@ -23,20 +23,29 @@ export function accountChartColor(index: number): string {
     return ACCOUNT_COLORS[index % ACCOUNT_COLORS.length];
 }
 
-/** Toggle membership of `accountId` in a hidden-id set. */
-export function nextHiddenAccountIds(
-    hidden: ReadonlySet<string>,
-    accountId: string,
-): Set<string> {
-    const next = new Set(hidden);
-
-    if (next.has(accountId)) {
-        next.delete(accountId);
-    } else {
-        next.add(accountId);
+/**
+ * A padded [min, max] window around a follower series so the trend fills the
+ * panel rather than being crushed against a zero baseline. Each account is
+ * plotted on its own axis (one chart per account), so a +100 change on 1,600
+ * and a +25 change from 0 both read as real movement instead of a flat line.
+ */
+export function followerYDomain(values: number[]): [number, number] {
+    if (values.length === 0) {
+        return [0, 1];
     }
 
-    return next;
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+
+    if (min === max) {
+        // Flat series — sit the line mid-panel with a small symmetric band.
+        const pad = Math.max(Math.abs(min) * 0.05, 1);
+        return [min - pad, max + pad];
+    }
+
+    // Headroom above and below so peaks and troughs don't touch the edges.
+    const pad = (max - min) * 0.15;
+    return [min - pad, max + pad];
 }
 
 export function formatFollowerTooltipDate(
@@ -52,43 +61,4 @@ export function formatFollowerTooltipDate(
     const formattedDate = dayjs(date);
 
     return formattedDate.isValid() ? formattedDate.format('MMM D, YYYY') : '';
-}
-
-/**
- * Merge account series onto one row per calendar day so the tooltip can show
- * every account at the hovered time (capture timestamps rarely align exactly).
- */
-export function buildFollowerChartData(
-    accounts: AnalyticsPageProps['accounts'],
-): FollowerChartRow[] {
-    const dayKeys = [
-        ...new Set(
-            accounts.flatMap((account) =>
-                account.series.map((point) =>
-                    dayjs(point.at).format('YYYY-MM-DD'),
-                ),
-            ),
-        ),
-    ].sort();
-
-    return dayKeys.map((day) => {
-        const row: FollowerChartRow = {
-            date: dayjs(day).startOf('day').valueOf(),
-        };
-
-        for (const account of accounts) {
-            // Server already downsamples to one reading per day; take the last
-            // of that day if multiple slipped through.
-            const dayPoints = account.series.filter(
-                (point) => dayjs(point.at).format('YYYY-MM-DD') === day,
-            );
-            const point = dayPoints.at(-1);
-
-            if (point?.followers != null) {
-                row[account.id] = point.followers;
-            }
-        }
-
-        return row;
-    });
 }

--- a/resources/js/components/analytics/follower-chart.tsx
+++ b/resources/js/components/analytics/follower-chart.tsx
@@ -1,7 +1,8 @@
+import { router } from '@inertiajs/react';
 import {
+    Area,
+    AreaChart,
     CartesianGrid,
-    Line,
-    LineChart,
     ReferenceLine,
     XAxis,
     YAxis,
@@ -9,9 +10,10 @@ import {
 
 import {
     accountChartColor,
-    buildFollowerChartData,
+    followerYDomain,
     formatFollowerTooltipDate,
 } from '@/components/analytics/follower-chart-utils';
+import { DeltaChip } from '@/components/analytics/metric-delta';
 import { PlatformGlyph } from '@/components/common/platform-glyph';
 import {
     ChartContainer,
@@ -20,194 +22,292 @@ import {
     type ChartConfig,
 } from '@/components/ui/chart';
 import { dayjs } from '@/lib/datetime/dayjs';
-import { cn } from '@/lib/utils';
-import type { AnalyticsPageProps } from '@/types/metrics';
+import { show as postRoute } from '@/routes/posts';
+import type {
+    AnalyticsAccount,
+    AnalyticsPageProps,
+    AnalyticsPostMarker,
+} from '@/types/metrics';
 
 export {
     accountChartColor,
-    buildFollowerChartData,
+    followerYDomain,
     formatFollowerTooltipDate,
-    nextHiddenAccountIds,
-    type FollowerChartRow,
 } from '@/components/analytics/follower-chart-utils';
 
 type FollowerChartProps = {
     accounts: AnalyticsPageProps['accounts'];
     posts: AnalyticsPageProps['posts'];
-    /** Account ids currently hidden from the graph. */
-    hiddenAccountIds: ReadonlySet<string>;
-    onToggleAccount: (accountId: string) => void;
+    /** Per-platform account-metric polling switches. */
+    accountMetricsEnabled: Record<string, boolean>;
 };
 
+type TrendPoint = { date: number; value: number };
+
+function seriesPoints(account: AnalyticsAccount): TrendPoint[] {
+    return account.series
+        .filter((point) => point.followers != null)
+        .map((point) => ({
+            date: dayjs(point.at).valueOf(),
+            value: point.followers,
+        }));
+}
+
 /**
- * The follower-growth line chart. Lives in its own module so recharts (a heavy
- * dependency) is code-split into a lazily-loaded chunk and only fetched when
- * there is series data to plot.
+ * Follower growth as one auto-scaled area chart per account. Each account gets
+ * its own y-axis so a +100 change on a 1,600-follower account and a +25 change
+ * from zero both read as real movement, instead of being flattened onto one
+ * shared axis. Lives in its own module so recharts is code-split into a lazily
+ * loaded chunk.
  */
 export default function FollowerChart({
     accounts,
     posts,
-    hiddenAccountIds,
-    onToggleAccount,
+    accountMetricsEnabled,
 }: FollowerChartProps) {
-    const chartData = buildFollowerChartData(accounts);
-    const visibleAccounts = accounts.filter(
-        (account) => !hiddenAccountIds.has(account.id),
+    // A shared time window across every panel keeps them comparable left-to-right.
+    const allDates = accounts.flatMap((account) =>
+        seriesPoints(account).map((point) => point.date),
     );
-
-    const chartConfig: ChartConfig = Object.fromEntries(
-        accounts.map((a, i) => [
-            a.id,
-            {
-                label: a.display_name ?? a.handle,
-                color: accountChartColor(i),
-            },
-        ]),
-    );
+    const xDomain: [number, number] | undefined =
+        allDates.length > 0
+            ? [Math.min(...allDates), Math.max(...allDates)]
+            : undefined;
 
     return (
-        <div className="p-5">
-            <ChartContainer
-                config={chartConfig}
-                className="h-[260px] w-full"
-                initialDimension={{ width: 800, height: 260 }}
-            >
-                <LineChart
-                    data={chartData}
-                    margin={{ top: 4, right: 8, bottom: 0, left: 0 }}
-                >
-                    <CartesianGrid
-                        strokeDasharray="3 3"
-                        className="stroke-border/50"
-                        vertical={false}
-                    />
-                    <XAxis
-                        dataKey="date"
-                        type="number"
-                        scale="time"
-                        domain={['dataMin', 'dataMax']}
-                        tickLine={false}
-                        axisLine={false}
-                        tickMargin={8}
-                        tick={{ fontSize: 11 }}
-                        tickFormatter={(v: number) => dayjs(v).format('MMM D')}
-                        interval="preserveStartEnd"
-                    />
-                    <YAxis
-                        tickLine={false}
-                        axisLine={false}
-                        tickMargin={8}
-                        tick={{ fontSize: 11 }}
-                        tickFormatter={(v: number) =>
-                            v >= 1000 ? `${(v / 1000).toFixed(1)}k` : String(v)
-                        }
-                        width={40}
-                    />
-                    <ChartTooltip
-                        shared
-                        content={
-                            <ChartTooltipContent
-                                labelFormatter={formatFollowerTooltipDate}
-                                indicator="dot"
-                            />
-                        }
-                    />
+        <div
+            className={
+                accounts.length > 1
+                    ? 'grid grid-cols-1 gap-4 lg:grid-cols-2'
+                    : 'grid grid-cols-1 gap-4'
+            }
+        >
+            {accounts.map((account, index) => (
+                <AccountTrendCard
+                    key={account.id}
+                    account={account}
+                    color={accountChartColor(index)}
+                    metricsEnabled={
+                        accountMetricsEnabled[account.platform] ?? true
+                    }
+                    posts={posts.filter((post) =>
+                        post.platforms.includes(account.platform),
+                    )}
+                    xDomain={xDomain}
+                />
+            ))}
+        </div>
+    );
+}
 
-                    {/* Post publish markers */}
-                    {posts.map((post) => (
-                        <ReferenceLine
-                            key={post.id}
-                            x={new Date(post.published_at).getTime()}
-                            stroke="var(--primary)"
-                            strokeDasharray="3 3"
-                            strokeWidth={1.5}
-                            opacity={0.6}
-                            label={(props: {
-                                viewBox?: { x?: number; y?: number };
-                            }) => {
-                                const x = (props.viewBox?.x ?? 0) + 3;
-                                const y = (props.viewBox?.y ?? 0) + 12;
-                                return (
-                                    <text
-                                        x={x}
-                                        y={y}
-                                        fontSize={10}
-                                        fill="var(--primary)"
-                                    >
-                                        <title>
-                                            {post.title || 'Untitled post'}
-                                        </title>
-                                        ↑
-                                    </text>
-                                );
-                            }}
+type AccountTrendCardProps = {
+    account: AnalyticsAccount;
+    color: string;
+    metricsEnabled: boolean;
+    posts: AnalyticsPostMarker[];
+    xDomain: [number, number] | undefined;
+};
+
+function AccountTrendCard({
+    account,
+    color,
+    metricsEnabled,
+    posts,
+    xDomain,
+}: AccountTrendCardProps) {
+    const label = account.display_name ?? account.handle;
+    const points = seriesPoints(account);
+    const values = points.map((point) => point.value);
+    const [yMin, yMax] = followerYDomain(values);
+    const fillId = `follower-fill-${account.id}`;
+
+    // Only mark posts that fall inside this panel's visible time window.
+    const markers = posts.filter((post) => {
+        if (!xDomain) {
+            return false;
+        }
+        const at = new Date(post.published_at).getTime();
+        return at >= xDomain[0] && at <= xDomain[1];
+    });
+
+    const chartConfig: ChartConfig = {
+        value: { label, color },
+    };
+
+    return (
+        <div className="flex flex-col gap-3 rounded-[min(var(--radius-4xl),24px)] bg-card p-4 shadow-sm ring-1 ring-foreground/5 dark:ring-foreground/10">
+            <div className="flex items-start justify-between gap-2">
+                <div className="flex min-w-0 items-center gap-2">
+                    <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-foreground">
+                        <PlatformGlyph platform={account.platform} size={13} />
+                    </span>
+                    <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">{label}</p>
+                        <p className="text-xs text-muted-foreground">
+                            followers
+                        </p>
+                    </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                    <span className="font-heading text-xl leading-none font-semibold tracking-tight tabular-nums">
+                        {account.latest_followers !== null
+                            ? account.latest_followers.toLocaleString()
+                            : '—'}
+                    </span>
+                    {metricsEnabled && (
+                        <DeltaChip
+                            delta={account.followers_delta}
+                            label="followers this period"
                         />
-                    ))}
+                    )}
+                </div>
+            </div>
 
-                    {visibleAccounts.map((account) => {
-                        const colorIndex = accounts.findIndex(
-                            (a) => a.id === account.id,
-                        );
+            {!metricsEnabled ? (
+                <p className="flex h-[120px] items-center justify-center rounded-lg bg-muted/30 text-center text-xs text-muted-foreground">
+                    Account metrics are paused for this platform.
+                </p>
+            ) : points.length < 2 ? (
+                <p className="flex h-[120px] items-center justify-center rounded-lg bg-muted/30 text-center text-xs text-muted-foreground">
+                    Not enough history yet — check back after the next sync.
+                </p>
+            ) : (
+                <>
+                    <ChartContainer
+                        config={chartConfig}
+                        className="h-[120px] w-full"
+                        initialDimension={{ width: 400, height: 120 }}
+                    >
+                        <AreaChart
+                            data={points}
+                            margin={{ top: 4, right: 4, bottom: 0, left: 4 }}
+                        >
+                            <defs>
+                                <linearGradient
+                                    id={fillId}
+                                    x1="0"
+                                    y1="0"
+                                    x2="0"
+                                    y2="1"
+                                >
+                                    <stop
+                                        offset="5%"
+                                        stopColor={color}
+                                        stopOpacity={0.25}
+                                    />
+                                    <stop
+                                        offset="95%"
+                                        stopColor={color}
+                                        stopOpacity={0}
+                                    />
+                                </linearGradient>
+                            </defs>
+                            <CartesianGrid
+                                vertical={false}
+                                className="stroke-border/50"
+                            />
+                            <XAxis
+                                dataKey="date"
+                                type="number"
+                                scale="time"
+                                domain={xDomain ?? ['dataMin', 'dataMax']}
+                                hide
+                            />
+                            <YAxis domain={[yMin, yMax]} hide />
+                            <ChartTooltip
+                                content={
+                                    <ChartTooltipContent
+                                        labelFormatter={
+                                            formatFollowerTooltipDate
+                                        }
+                                        indicator="dot"
+                                    />
+                                }
+                            />
 
-                        return (
-                            <Line
-                                key={account.id}
-                                dataKey={account.id}
+                            {/* Post publish markers — when this account posted. */}
+                            {markers.map((post) => (
+                                <ReferenceLine
+                                    key={post.id}
+                                    x={new Date(post.published_at).getTime()}
+                                    stroke="var(--muted-foreground)"
+                                    strokeDasharray="3 3"
+                                    strokeOpacity={0.4}
+                                    label={(props: {
+                                        viewBox?: { x?: number; y?: number };
+                                    }) => (
+                                        <PostMarker
+                                            x={props.viewBox?.x ?? 0}
+                                            y={props.viewBox?.y ?? 0}
+                                            post={post}
+                                        />
+                                    )}
+                                />
+                            ))}
+
+                            <Area
+                                dataKey="value"
                                 type="monotone"
-                                stroke={accountChartColor(colorIndex)}
+                                stroke={color}
                                 strokeWidth={2}
+                                fill={`url(#${fillId})`}
+                                fillOpacity={1}
+                                baseValue={yMin}
                                 dot={false}
-                                activeDot={{ r: 4, strokeWidth: 0 }}
+                                activeDot={{
+                                    r: 4,
+                                    strokeWidth: 2,
+                                    className: 'stroke-background',
+                                }}
                                 connectNulls
                             />
-                        );
-                    })}
-                </LineChart>
-            </ChartContainer>
-
-            {/* Legend — click to show/hide series */}
-            {accounts.length > 1 && (
-                <div className="mt-3 flex flex-wrap items-center gap-2">
-                    {accounts.map((account, i) => {
-                        const hidden = hiddenAccountIds.has(account.id);
-                        const label = account.display_name ?? account.handle;
-
-                        return (
-                            <button
-                                key={account.id}
-                                type="button"
-                                onClick={() => onToggleAccount(account.id)}
-                                aria-pressed={!hidden}
-                                aria-label={
-                                    hidden
-                                        ? `Show ${label} on graph`
-                                        : `Hide ${label} from graph`
-                                }
-                                className={cn(
-                                    'inline-flex items-center gap-1.5 rounded-full border px-2 py-1 transition-opacity',
-                                    hidden
-                                        ? 'border-transparent opacity-40 hover:opacity-70'
-                                        : 'border-border/60 bg-muted/40 opacity-100 hover:bg-muted/70',
-                                )}
-                            >
+                        </AreaChart>
+                    </ChartContainer>
+                    <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+                        <span className="tabular-nums">
+                            {dayjs(points[0].date).format('MMM D')}
+                        </span>
+                        {markers.length > 0 && (
+                            <span className="flex items-center gap-1.5">
                                 <span
-                                    className="block h-2 w-4 rounded-full"
-                                    style={{
-                                        backgroundColor: accountChartColor(i),
-                                    }}
+                                    aria-hidden="true"
+                                    className="inline-block h-0 w-4 border-t border-dashed border-muted-foreground/60"
                                 />
-                                <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
-                                    <PlatformGlyph
-                                        platform={account.platform}
-                                        size={10}
-                                    />
-                                    {label}
-                                </span>
-                            </button>
-                        );
-                    })}
-                </div>
+                                {markers.length}{' '}
+                                {markers.length === 1 ? 'post' : 'posts'}
+                            </span>
+                        )}
+                        <span className="tabular-nums">
+                            {dayjs(points[points.length - 1].date).format(
+                                'MMM D',
+                            )}
+                        </span>
+                    </div>
+                </>
             )}
         </div>
+    );
+}
+
+type PostMarkerProps = {
+    x: number;
+    y: number;
+    post: AnalyticsPostMarker;
+};
+
+function PostMarker({ x, y, post }: PostMarkerProps) {
+    return (
+        <g
+            transform={`translate(${x}, ${y})`}
+            className="cursor-pointer"
+            onClick={() => router.visit(postRoute(post.id).url)}
+        >
+            <title>
+                {`${post.title || 'Untitled post'} · ${dayjs(post.published_at).format('MMM D')}`}
+            </title>
+            {/* Larger transparent hit target for easy hover/click. */}
+            <circle r={7} fill="transparent" />
+            <circle r={2.5} className="fill-muted-foreground" />
+        </g>
     );
 }

--- a/resources/js/components/analytics/metric-delta.tsx
+++ b/resources/js/components/analytics/metric-delta.tsx
@@ -1,0 +1,49 @@
+import { ArrowDown, ArrowUp } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+/** Signed, thousands-grouped delta: `+342`, `−1,204`, `0`. */
+export function formatDelta(delta: number): string {
+    const sign = delta > 0 ? '+' : delta < 0 ? '−' : '';
+
+    return `${sign}${Math.abs(delta).toLocaleString()}`;
+}
+
+type DeltaChipProps = {
+    /** Change over the period. `null` renders nothing — there was no baseline. */
+    delta: number | null;
+    /** Screen-reader context, e.g. "followers vs previous period". */
+    label?: string;
+    className?: string;
+};
+
+/**
+ * A directional change indicator built on the shared Badge. Up reads as good
+ * (green), down as a decline (red), and a flat period is quietly neutral.
+ */
+export function DeltaChip({ delta, label, className }: DeltaChipProps) {
+    if (delta === null) {
+        return null;
+    }
+
+    const direction = delta > 0 ? 'up' : delta < 0 ? 'down' : 'flat';
+
+    return (
+        <Badge
+            variant={
+                direction === 'up'
+                    ? 'success'
+                    : direction === 'down'
+                      ? 'destructive'
+                      : 'secondary'
+            }
+            className={cn('gap-0.5 px-1.5 tabular-nums', className)}
+        >
+            {direction === 'up' && <ArrowUp aria-hidden="true" />}
+            {direction === 'down' && <ArrowDown aria-hidden="true" />}
+            {formatDelta(delta)}
+            {label && <span className="sr-only"> {label}</span>}
+        </Badge>
+    );
+}

--- a/resources/js/components/analytics/stat-tile.tsx
+++ b/resources/js/components/analytics/stat-tile.tsx
@@ -1,0 +1,40 @@
+import { DeltaChip } from '@/components/analytics/metric-delta';
+import { Card, CardContent } from '@/components/ui/card';
+import type { AnalyticsSummaryMetric } from '@/types/metrics';
+
+type StatTileProps = {
+    label: string;
+    metric: AnalyticsSummaryMetric;
+    /** Small context line under the number, e.g. "across 4 accounts". */
+    caption: string;
+    /** Screen-reader suffix for the delta, e.g. "vs previous period". */
+    deltaLabel: string;
+};
+
+/**
+ * A headline number with its change over the period — the at-a-glance answer to
+ * "how am I doing" that the page opens with.
+ */
+export function StatTile({
+    label,
+    metric,
+    caption,
+    deltaLabel,
+}: StatTileProps) {
+    return (
+        <Card size="sm" className="gap-0">
+            <CardContent className="flex flex-col gap-1.5">
+                <span className="text-sm font-medium text-muted-foreground">
+                    {label}
+                </span>
+                <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <span className="font-heading text-3xl leading-none font-semibold tracking-tight tabular-nums">
+                        {metric.value.toLocaleString()}
+                    </span>
+                    <DeltaChip delta={metric.delta} label={deltaLabel} />
+                </div>
+                <span className="text-xs text-muted-foreground">{caption}</span>
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/pages/analytics/index.test.ts
+++ b/resources/js/pages/analytics/index.test.ts
@@ -16,7 +16,6 @@ describe('analytics disabled metric notices', () => {
             'Some account metrics are temporarily disabled',
         );
         expect(source).toContain('Some post metrics are temporarily disabled');
-        expect(source).toContain('account metrics temporarily disabled');
     });
 
     it('derives disabled platform labels from the polling payload keys', () => {
@@ -61,12 +60,25 @@ describe('analytics post comparison links', () => {
     });
 });
 
-describe('analytics graph series toggles', () => {
-    it('wires shared hide/show state for the chart legend and account cards', () => {
-        expect(source).toContain('hiddenAccountIds');
-        expect(source).toContain('toggleAccountOnGraph');
-        expect(source).toContain('nextHiddenAccountIds');
-        expect(source).toContain('onToggleAccount={toggleAccountOnGraph}');
-        expect(source).toContain('hidden from graph');
+describe('analytics headline summary', () => {
+    it('renders stat tiles for followers, engagement, and posts', () => {
+        expect(source).toContain('StatTile');
+        expect(source).toContain('metric={summary.followers}');
+        expect(source).toContain('metric={summary.engagement}');
+        expect(source).toContain('metric={summary.posts}');
+    });
+
+    it('renders a per-account follower growth chart with post markers', () => {
+        expect(source).toContain('FollowerChart');
+        expect(source).toContain('accountMetricsEnabled={');
+        expect(source).toContain('posts={posts}');
+    });
+});
+
+describe('analytics range switching', () => {
+    it('reloads only the range-dependent props and preserves scroll/state', () => {
+        expect(source).toContain('preserveScroll');
+        expect(source).toContain('preserveState');
+        expect(source).toContain('only={RANGE_RELOAD_PROPS}');
     });
 });

--- a/resources/js/pages/analytics/index.tsx
+++ b/resources/js/pages/analytics/index.tsx
@@ -1,12 +1,10 @@
 import { Head, Link } from '@inertiajs/react';
 import { PauseCircle, TrendingUp } from 'lucide-react';
-import { lazy, Suspense, useState } from 'react';
+import { lazy, Suspense } from 'react';
 
-import {
-    accountChartColor,
-    nextHiddenAccountIds,
-} from '@/components/analytics/follower-chart-utils';
+import { StatTile } from '@/components/analytics/stat-tile';
 import { PlatformGlyph } from '@/components/common/platform-glyph';
+import { Card, CardDescription, CardTitle } from '@/components/ui/card';
 import {
     Empty,
     EmptyContent,
@@ -36,6 +34,15 @@ const RANGE_OPTIONS = [
     { days: 14, label: '14d' },
     { days: 30, label: '30d' },
     { days: 90, label: '90d' },
+];
+
+// Trimming the response to just the range-dependent props keeps switching snappy.
+const RANGE_RELOAD_PROPS = [
+    'accounts',
+    'posts',
+    'summary',
+    'comparison',
+    'rangeDays',
 ];
 
 function allDisabled(enabled: Record<string, boolean>) {
@@ -132,62 +139,70 @@ function ComparisonItem({ row, rank, isTop }: ComparisonItemProps) {
     return (
         <Link
             href={postRoute(row.id).url}
-            className="flex items-start gap-3 py-2.5 transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none"
+            className="flex items-center gap-3 px-5 py-3 transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none"
         >
             <span
                 className={cn(
-                    'mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold tabular-nums',
+                    'flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold tabular-nums',
                     isTop
-                        ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400'
+                        ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
                         : 'bg-muted text-muted-foreground',
                 )}
             >
                 {rank}
             </span>
             <div className="min-w-0 flex-1">
-                <p className="truncate text-[13px] leading-snug font-medium">
+                <p className="truncate text-sm leading-snug font-medium">
                     {row.title || 'Untitled post'}
                 </p>
-                <div className="mt-0.5 flex items-center gap-1.5">
+                <div className="mt-1 flex items-center gap-1.5">
                     {row.platforms.map((p) => (
                         <span key={p} className="text-muted-foreground">
-                            <PlatformGlyph platform={p} size={10} />
+                            <PlatformGlyph platform={p} size={11} />
                         </span>
                     ))}
-                    <span className="text-[11px] text-muted-foreground">
+                    <span className="text-xs text-muted-foreground">
                         {dayjs(row.published_at).format('MMM D')}
                     </span>
                 </div>
             </div>
-            <span
-                className={cn(
-                    'shrink-0 text-[12px] font-semibold tabular-nums',
-                    isTop
-                        ? 'text-emerald-600 dark:text-emerald-400'
-                        : 'text-muted-foreground',
-                )}
-            >
-                {row.engagement.toLocaleString()}
-            </span>
+            <div className="shrink-0 text-right">
+                <p className="text-sm font-semibold tabular-nums">
+                    {row.engagement.toLocaleString()}
+                </p>
+                <p className="text-xs text-muted-foreground">engagement</p>
+            </div>
         </Link>
+    );
+}
+
+function FollowerChartSkeleton({ count }: { count: number }) {
+    return (
+        <div
+            className={
+                count > 1
+                    ? 'grid grid-cols-1 gap-4 lg:grid-cols-2'
+                    : 'grid grid-cols-1 gap-4'
+            }
+        >
+            {Array.from({ length: Math.max(count, 1) }).map((_, i) => (
+                <div
+                    key={i}
+                    className="h-[196px] w-full animate-pulse rounded-[min(var(--radius-4xl),24px)] bg-muted/50"
+                />
+            ))}
+        </div>
     );
 }
 
 export default function AnalyticsIndex({
     accounts,
     posts,
+    summary,
     comparison,
     polling,
     rangeDays,
 }: AnalyticsPageProps) {
-    const [hiddenAccountIds, setHiddenAccountIds] = useState<Set<string>>(
-        () => new Set(),
-    );
-
-    function toggleAccountOnGraph(accountId: string) {
-        setHiddenAccountIds((prev) => nextHiddenAccountIds(prev, accountId));
-    }
-
     const hasSeries = accounts.some((a) => a.series.length > 0);
     const disabledAccountMetricPlatforms = disabledPlatformLabels(
         polling.account_metrics_enabled,
@@ -198,6 +213,9 @@ export default function AnalyticsIndex({
     const metricsDisabled =
         allDisabled(polling.account_metrics_enabled) &&
         allDisabled(polling.post_metrics_enabled);
+    const rangeLabel =
+        RANGE_OPTIONS.find((opt) => opt.days === rangeDays)?.label ??
+        `${rangeDays}d`;
 
     return (
         <>
@@ -207,17 +225,17 @@ export default function AnalyticsIndex({
                 {/* Page header */}
                 <div className="flex flex-wrap items-center justify-between gap-3">
                     <div>
-                        <h1 className="text-[22px] leading-tight font-semibold tracking-tight">
+                        <h1 className="font-heading text-2xl leading-tight font-semibold tracking-tight">
                             Analytics
                         </h1>
-                        <p className="mt-0.5 text-[13px] text-muted-foreground">
+                        <p className="mt-1 text-sm text-muted-foreground">
                             Follower growth and post engagement across your
                             accounts.
                         </p>
                     </div>
 
                     {/* Range selector */}
-                    <div className="flex items-center gap-1 rounded-lg border border-border bg-muted/50 p-0.5">
+                    <div className="flex items-center gap-0.5 rounded-lg border border-border bg-muted/40 p-1">
                         {RANGE_OPTIONS.map((opt) => (
                             <Link
                                 key={opt.days}
@@ -226,10 +244,13 @@ export default function AnalyticsIndex({
                                         query: { days: opt.days },
                                     }).url
                                 }
+                                preserveScroll
+                                preserveState
+                                only={RANGE_RELOAD_PROPS}
                                 className={cn(
-                                    'rounded-md px-3 py-1 text-[12px] font-medium transition-colors',
+                                    'rounded-md px-3 py-1 text-sm font-medium transition-all active:scale-[0.97]',
                                     rangeDays === opt.days
-                                        ? 'bg-background text-foreground shadow-sm ring-1 ring-border/50'
+                                        ? 'bg-background text-foreground shadow-sm ring-1 ring-border/60'
                                         : 'text-muted-foreground hover:text-foreground',
                                 )}
                             >
@@ -259,58 +280,53 @@ export default function AnalyticsIndex({
                 )}
 
                 {!metricsDisabled && (
-                    <AnalyticsPollingBanner
-                        disabledAccountMetricPlatforms={
-                            disabledAccountMetricPlatforms
-                        }
-                        disabledPostMetricPlatforms={
-                            disabledPostMetricPlatforms
-                        }
-                    />
-                )}
+                    <>
+                        {/* Headline numbers — the at-a-glance answer */}
+                        {accounts.length > 0 && (
+                            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                                <StatTile
+                                    label="Followers"
+                                    metric={summary.followers}
+                                    caption={`across ${summary.account_count} ${summary.account_count === 1 ? 'account' : 'accounts'}`}
+                                    deltaLabel={`followers over the last ${rangeLabel}`}
+                                />
+                                <StatTile
+                                    label="Engagement"
+                                    metric={summary.engagement}
+                                    caption="likes, comments & reposts this period"
+                                    deltaLabel="vs previous period"
+                                />
+                                <StatTile
+                                    label="Posts published"
+                                    metric={summary.posts}
+                                    caption="in the selected period"
+                                    deltaLabel="vs previous period"
+                                />
+                            </div>
+                        )}
 
-                {/* Follower timeline — the signature piece */}
-                <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm ring-1 ring-foreground/5 dark:ring-foreground/10">
-                    <div className="border-b border-border px-5 py-4">
-                        <h2 className="text-[13px] font-semibold tracking-tight">
-                            Follower growth
-                        </h2>
-                    </div>
+                        <AnalyticsPollingBanner
+                            disabledAccountMetricPlatforms={
+                                disabledAccountMetricPlatforms
+                            }
+                            disabledPostMetricPlatforms={
+                                disabledPostMetricPlatforms
+                            }
+                        />
 
-                    {allDisabled(polling.account_metrics_enabled) ? (
-                        <Empty className="m-4 rounded-xl border-dashed">
-                            <EmptyHeader>
-                                <EmptyMedia variant="icon">
-                                    <PauseCircle />
-                                </EmptyMedia>
-                                <EmptyTitle className="text-base">
-                                    Account metrics temporarily disabled
-                                </EmptyTitle>
-                                <EmptyDescription>
-                                    Follower growth snapshots are paused by your
-                                    instance admin.
-                                </EmptyDescription>
-                            </EmptyHeader>
-                        </Empty>
-                    ) : !hasSeries ? (
-                        <Empty className="m-4 rounded-xl border-dashed">
-                            <EmptyHeader>
-                                <EmptyMedia variant="icon">
-                                    <TrendingUp />
-                                </EmptyMedia>
-                                <EmptyTitle className="text-base">
-                                    Collecting your data
-                                </EmptyTitle>
-                                <EmptyDescription>
-                                    First numbers appear after the next sync —
-                                    usually within an hour of connecting your
-                                    accounts.
-                                </EmptyDescription>
-                            </EmptyHeader>
-                        </Empty>
-                    ) : (
-                        <>
-                            <div className="px-5 pt-4">
+                        {/* Follower growth — all accounts on one shared timeline */}
+                        {accounts.length > 0 && (
+                            <section className="space-y-3">
+                                <div>
+                                    <h2 className="font-heading text-base font-medium">
+                                        Follower growth
+                                    </h2>
+                                    <p className="text-sm text-muted-foreground">
+                                        Each account on its own scale over the
+                                        last {rangeLabel}
+                                    </p>
+                                </div>
+
                                 <DisabledMetricsNotice
                                     title="Some account metrics are temporarily disabled"
                                     disabledPlatforms={
@@ -319,198 +335,173 @@ export default function AnalyticsIndex({
                                 >
                                     Follower snapshots are paused for
                                 </DisabledMetricsNotice>
-                            </div>
-                            <Suspense
-                                fallback={
-                                    <div className="p-5">
-                                        <div className="h-[260px] w-full animate-pulse rounded-xl bg-muted/50" />
-                                    </div>
-                                }
-                            >
-                                <FollowerChart
-                                    accounts={accounts}
-                                    posts={posts}
-                                    hiddenAccountIds={hiddenAccountIds}
-                                    onToggleAccount={toggleAccountOnGraph}
-                                />
-                            </Suspense>
-                        </>
-                    )}
-                </div>
 
-                {/* Account follower counts — click to show/hide on the graph */}
-                {accounts.length > 0 && (
-                    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-                        {accounts.map((account, index) => {
-                            const hidden = hiddenAccountIds.has(account.id);
-                            const label =
-                                account.display_name ?? account.handle;
-                            const color = accountChartColor(index);
-
-                            return (
-                                <button
-                                    key={account.id}
-                                    type="button"
-                                    onClick={() =>
-                                        toggleAccountOnGraph(account.id)
-                                    }
-                                    aria-pressed={!hidden}
-                                    aria-label={
-                                        hidden
-                                            ? `Show ${label} on graph`
-                                            : `Hide ${label} from graph`
-                                    }
-                                    className={cn(
-                                        'overflow-hidden rounded-xl border bg-card px-4 py-3 text-left shadow-sm ring-1 ring-foreground/5 transition-all dark:ring-foreground/10',
-                                        hidden
-                                            ? 'border-border opacity-45 hover:opacity-75'
-                                            : 'border-border hover:border-border/80',
-                                    )}
-                                    style={
-                                        hidden
-                                            ? undefined
-                                            : {
-                                                  boxShadow: `inset 3px 0 0 0 ${color}`,
-                                              }
-                                    }
-                                >
-                                    <div className="flex items-center gap-2">
-                                        <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-foreground">
-                                            <PlatformGlyph
-                                                platform={account.platform}
-                                                size={11}
+                                {allDisabled(
+                                    polling.account_metrics_enabled,
+                                ) ? (
+                                    <Empty className="rounded-2xl border border-dashed py-10">
+                                        <EmptyHeader>
+                                            <EmptyMedia variant="icon">
+                                                <PauseCircle />
+                                            </EmptyMedia>
+                                            <EmptyTitle className="text-base">
+                                                Account metrics temporarily
+                                                disabled
+                                            </EmptyTitle>
+                                            <EmptyDescription>
+                                                Follower growth snapshots are
+                                                paused by your instance admin.
+                                            </EmptyDescription>
+                                        </EmptyHeader>
+                                    </Empty>
+                                ) : !hasSeries ? (
+                                    <Empty className="rounded-2xl border border-dashed py-10">
+                                        <EmptyHeader>
+                                            <EmptyMedia variant="icon">
+                                                <TrendingUp />
+                                            </EmptyMedia>
+                                            <EmptyTitle className="text-base">
+                                                Collecting your data
+                                            </EmptyTitle>
+                                            <EmptyDescription>
+                                                First numbers appear after the
+                                                next sync — follower snapshots
+                                                refresh a few times a day.
+                                            </EmptyDescription>
+                                        </EmptyHeader>
+                                    </Empty>
+                                ) : (
+                                    <Suspense
+                                        fallback={
+                                            <FollowerChartSkeleton
+                                                count={accounts.length}
                                             />
-                                        </span>
-                                        <p className="truncate text-[11px] text-muted-foreground">
-                                            {label}
-                                        </p>
-                                    </div>
-                                    <p className="mt-2 text-[22px] leading-tight font-semibold tracking-tight tabular-nums">
-                                        {account.latest_followers !== null
-                                            ? account.latest_followers.toLocaleString()
-                                            : '—'}
-                                    </p>
-                                    <p className="text-[11px] text-muted-foreground">
-                                        {polling.account_metrics_enabled[
-                                            account.platform
-                                        ]
-                                            ? hidden
-                                                ? 'hidden from graph'
-                                                : 'followers'
-                                            : 'account metrics temporarily disabled'}
-                                    </p>
-                                </button>
-                            );
-                        })}
-                    </div>
+                                        }
+                                    >
+                                        <FollowerChart
+                                            accounts={accounts}
+                                            posts={posts}
+                                            accountMetricsEnabled={
+                                                polling.account_metrics_enabled
+                                            }
+                                        />
+                                    </Suspense>
+                                )}
+                            </section>
+                        )}
+                    </>
                 )}
 
                 {/* Post comparison */}
-                {allDisabled(polling.post_metrics_enabled) ? (
-                    <Empty className="rounded-2xl border border-dashed">
-                        <EmptyHeader>
-                            <EmptyMedia variant="icon">
-                                <PauseCircle />
-                            </EmptyMedia>
-                            <EmptyTitle>
-                                Post metrics temporarily disabled
-                            </EmptyTitle>
-                            <EmptyDescription>
-                                Post engagement polling is paused by your
-                                instance admin.
-                            </EmptyDescription>
-                        </EmptyHeader>
-                    </Empty>
-                ) : (
-                    (comparison.top.length > 0 ||
-                        comparison.bottom.length > 0) && (
-                        <>
-                            <DisabledMetricsNotice
-                                title="Some post metrics are temporarily disabled"
-                                disabledPlatforms={disabledPostMetricPlatforms}
-                            >
-                                Post engagement polling is paused for
-                            </DisabledMetricsNotice>
+                {!metricsDisabled &&
+                    (allDisabled(polling.post_metrics_enabled) ? (
+                        <Empty className="rounded-2xl border border-dashed">
+                            <EmptyHeader>
+                                <EmptyMedia variant="icon">
+                                    <PauseCircle />
+                                </EmptyMedia>
+                                <EmptyTitle>
+                                    Post metrics temporarily disabled
+                                </EmptyTitle>
+                                <EmptyDescription>
+                                    Post engagement polling is paused by your
+                                    instance admin.
+                                </EmptyDescription>
+                            </EmptyHeader>
+                        </Empty>
+                    ) : (
+                        (comparison.top.length > 0 ||
+                            comparison.bottom.length > 0) && (
+                            <div className="space-y-4">
+                                <DisabledMetricsNotice
+                                    title="Some post metrics are temporarily disabled"
+                                    disabledPlatforms={
+                                        disabledPostMetricPlatforms
+                                    }
+                                >
+                                    Post engagement polling is paused for
+                                </DisabledMetricsNotice>
 
-                            {comparison.bottom.length === 0 ? (
-                                /* Fewer than 10 eligible posts — single ranked list */
-                                <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm ring-1 ring-foreground/5 dark:ring-foreground/10">
-                                    <div className="border-b border-border px-5 py-3.5">
-                                        <h2 className="text-[13px] font-semibold tracking-tight">
-                                            Posts by engagement
-                                        </h2>
-                                        <p className="text-[11px] text-muted-foreground">
-                                            All posts ranked by engagement this
-                                            period
-                                        </p>
-                                    </div>
-                                    <div className="divide-y divide-border px-5">
-                                        {comparison.top.map((row, i) => (
-                                            <ComparisonItem
-                                                key={row.id}
-                                                row={row}
-                                                rank={i + 1}
-                                                isTop={true}
-                                            />
-                                        ))}
-                                    </div>
-                                </div>
-                            ) : (
-                                /* 10+ eligible posts — best vs needs-attention two-column layout */
-                                <div className="grid gap-3 sm:grid-cols-2">
-                                    {/* Top posts */}
-                                    {comparison.top.length > 0 && (
-                                        <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm ring-1 ring-foreground/5 dark:ring-foreground/10">
-                                            <div className="border-b border-border px-5 py-3.5">
-                                                <h2 className="text-[13px] font-semibold tracking-tight">
-                                                    Best performing
-                                                </h2>
-                                                <p className="text-[11px] text-muted-foreground">
-                                                    Highest engagement this
+                                {comparison.bottom.length === 0 ? (
+                                    /* Fewer than 10 eligible posts — single ranked list */
+                                    <Card className="gap-0 py-0">
+                                        <div className="px-5 py-4">
+                                            <CardTitle>
+                                                Posts by engagement
+                                            </CardTitle>
+                                            <CardDescription className="mt-1">
+                                                All posts ranked by engagement
+                                                this period
+                                            </CardDescription>
+                                        </div>
+                                        <div className="divide-y divide-border border-t border-border">
+                                            {comparison.top.map((row, i) => (
+                                                <ComparisonItem
+                                                    key={row.id}
+                                                    row={row}
+                                                    rank={i + 1}
+                                                    isTop={true}
+                                                />
+                                            ))}
+                                        </div>
+                                    </Card>
+                                ) : (
+                                    /* 10+ eligible posts — best vs needs-attention two-column layout */
+                                    <div className="grid gap-4 sm:grid-cols-2">
+                                        {comparison.top.length > 0 && (
+                                            <Card className="gap-0 py-0">
+                                                <div className="px-5 py-4">
+                                                    <CardTitle>
+                                                        Best performing
+                                                    </CardTitle>
+                                                    <CardDescription className="mt-1">
+                                                        Highest engagement this
+                                                        period
+                                                    </CardDescription>
+                                                </div>
+                                                <div className="divide-y divide-border border-t border-border">
+                                                    {comparison.top.map(
+                                                        (row, i) => (
+                                                            <ComparisonItem
+                                                                key={row.id}
+                                                                row={row}
+                                                                rank={i + 1}
+                                                                isTop={true}
+                                                            />
+                                                        ),
+                                                    )}
+                                                </div>
+                                            </Card>
+                                        )}
+
+                                        <Card className="gap-0 py-0">
+                                            <div className="px-5 py-4">
+                                                <CardTitle>
+                                                    Needs attention
+                                                </CardTitle>
+                                                <CardDescription className="mt-1">
+                                                    Lowest engagement this
                                                     period
-                                                </p>
+                                                </CardDescription>
                                             </div>
-                                            <div className="divide-y divide-border px-5">
-                                                {comparison.top.map(
+                                            <div className="divide-y divide-border border-t border-border">
+                                                {comparison.bottom.map(
                                                     (row, i) => (
                                                         <ComparisonItem
                                                             key={row.id}
                                                             row={row}
                                                             rank={i + 1}
-                                                            isTop={true}
+                                                            isTop={false}
                                                         />
                                                     ),
                                                 )}
                                             </div>
-                                        </div>
-                                    )}
-
-                                    {/* Bottom posts */}
-                                    <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm ring-1 ring-foreground/5 dark:ring-foreground/10">
-                                        <div className="border-b border-border px-5 py-3.5">
-                                            <h2 className="text-[13px] font-semibold tracking-tight">
-                                                Needs attention
-                                            </h2>
-                                            <p className="text-[11px] text-muted-foreground">
-                                                Lowest engagement this period
-                                            </p>
-                                        </div>
-                                        <div className="divide-y divide-border px-5">
-                                            {comparison.bottom.map((row, i) => (
-                                                <ComparisonItem
-                                                    key={row.id}
-                                                    row={row}
-                                                    rank={i + 1}
-                                                    isTop={false}
-                                                />
-                                            ))}
-                                        </div>
+                                        </Card>
                                     </div>
-                                </div>
-                            )}
-                        </>
-                    )
-                )}
+                                )}
+                            </div>
+                        )
+                    ))}
 
                 {/* No accounts at all */}
                 {accounts.length === 0 && (
@@ -528,7 +519,7 @@ export default function AnalyticsIndex({
                         <EmptyContent>
                             <Link
                                 href={dashboard().url}
-                                className="inline-flex h-9 items-center justify-center rounded-md border border-border bg-background px-4 text-sm font-medium transition-colors hover:bg-muted"
+                                className="inline-flex h-9 items-center justify-center rounded-md border border-border bg-background px-4 text-sm font-medium transition-all hover:bg-muted active:scale-[0.98]"
                             >
                                 Go to Dashboard
                             </Link>

--- a/resources/js/types/metrics.ts
+++ b/resources/js/types/metrics.ts
@@ -38,6 +38,8 @@ export type AnalyticsAccount = {
     avatar_url: string | null;
     status: MetricsStatus | null;
     latest_followers: number | null;
+    /** Change in followers across the selected window (null until 2+ readings). */
+    followers_delta: number | null;
     series: { at: string; followers: number; following: number | null }[];
 };
 
@@ -52,9 +54,25 @@ export type AnalyticsComparisonRow = AnalyticsPostMarker & {
     engagement: number;
 };
 
+/** A single number with an optional change-over-the-period delta. */
+export type AnalyticsSummaryMetric = {
+    value: number;
+    /** Change vs the previous equal-length window; null when there's no baseline. */
+    delta: number | null;
+};
+
+export type AnalyticsSummary = {
+    followers: AnalyticsSummaryMetric;
+    engagement: AnalyticsSummaryMetric;
+    posts: AnalyticsSummaryMetric;
+    /** How many accounts contribute to the follower total. */
+    account_count: number;
+};
+
 export type AnalyticsPageProps = {
     accounts: AnalyticsAccount[];
     posts: AnalyticsPostMarker[];
+    summary: AnalyticsSummary;
     comparison: {
         top: AnalyticsComparisonRow[];
         bottom: AnalyticsComparisonRow[];

--- a/tests/Feature/Metrics/AnalyticsPageTest.php
+++ b/tests/Feature/Metrics/AnalyticsPageTest.php
@@ -127,6 +127,44 @@ test('deltas are null when the previous window has no baseline posts', function 
             ->where('summary.posts.delta', null));
 });
 
+test('engagement delta is null when the previous window has posts but no captured metrics', function (): void {
+    // Previous window has a post, but its target never captured Ok metrics — so
+    // there is no engagement baseline even though a post exists.
+    $previous = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'author_id' => $this->user->id,
+        'status' => PostStatus::Published->value,
+        'published_at' => Date::now()->subDays(15),
+    ]);
+    PostTarget::factory()->create([
+        'post_id' => $previous->id,
+        'metrics_status' => MetricsStatus::Failed->value,
+        'likes' => 0, 'comments' => 0, 'reposts' => 0,
+    ]);
+
+    $current = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'author_id' => $this->user->id,
+        'status' => PostStatus::Published->value,
+        'published_at' => Date::now()->subDay(),
+    ]);
+    PostTarget::factory()->create([
+        'post_id' => $current->id,
+        'metrics_status' => MetricsStatus::Ok->value,
+        'likes' => 50, 'comments' => 0, 'reposts' => 0,
+    ]);
+
+    $this->actingAs($this->user)
+        ->get(route('analytics.index', ['days' => 10]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('summary.engagement.value', 50)
+            // No measured post last window → no fake "+50" spike.
+            ->where('summary.engagement.delta', null)
+            // The post count baseline still exists (one post each window).
+            ->where('summary.posts.delta', 0));
+});
+
 test('analytics polling settings are keyed by platform enum values', function (): void {
     app(InstanceSettings::class)->update([
         'post_metrics_polling_enabled' => [

--- a/tests/Feature/Metrics/AnalyticsPageTest.php
+++ b/tests/Feature/Metrics/AnalyticsPageTest.php
@@ -38,6 +38,95 @@ test('analytics page renders with accounts and range', function (): void {
             ->where('rangeDays', 90));
 });
 
+test('the summary reports total followers with a window delta', function (): void {
+    $account = ConnectedAccount::factory()->for($this->workspace)->create();
+
+    // Two readings inside the default 90-day window: 100 → 130 = +30.
+    AccountMetric::factory()->create(['connected_account_id' => $account->id, 'captured_at' => Date::now()->subDays(10), 'followers' => 100]);
+    AccountMetric::factory()->create(['connected_account_id' => $account->id, 'captured_at' => Date::now(), 'followers' => 130]);
+
+    $this->actingAs($this->user)
+        ->get(route('analytics.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('summary.account_count', 1)
+            ->where('summary.followers.value', 130)
+            ->where('summary.followers.delta', 30)
+            ->where('accounts.0.followers_delta', 30));
+});
+
+test('the follower delta is null without two comparable readings', function (): void {
+    $account = ConnectedAccount::factory()->for($this->workspace)->create();
+    AccountMetric::factory()->create(['connected_account_id' => $account->id, 'captured_at' => Date::now(), 'followers' => 100]);
+
+    $this->actingAs($this->user)
+        ->get(route('analytics.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('summary.followers.value', 100)
+            ->where('summary.followers.delta', null)
+            ->where('accounts.0.followers_delta', null));
+});
+
+test('the engagement summary compares against the previous window', function (): void {
+    // Previous window (10–20 days ago): one post with 40 engagement.
+    $previous = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'author_id' => $this->user->id,
+        'status' => PostStatus::Published->value,
+        'published_at' => Date::now()->subDays(15),
+    ]);
+    PostTarget::factory()->create([
+        'post_id' => $previous->id,
+        'metrics_status' => MetricsStatus::Ok->value,
+        'likes' => 40, 'comments' => 0, 'reposts' => 0,
+    ]);
+
+    // Current window (last 10 days): one post with 100 engagement.
+    $current = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'author_id' => $this->user->id,
+        'status' => PostStatus::Published->value,
+        'published_at' => Date::now()->subDay(),
+    ]);
+    PostTarget::factory()->create([
+        'post_id' => $current->id,
+        'metrics_status' => MetricsStatus::Ok->value,
+        'likes' => 70, 'comments' => 20, 'reposts' => 10,
+    ]);
+
+    $this->actingAs($this->user)
+        ->get(route('analytics.index', ['days' => 10]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('summary.engagement.value', 100)
+            ->where('summary.engagement.delta', 60)
+            ->where('summary.posts.value', 1)
+            ->where('summary.posts.delta', 0));
+});
+
+test('deltas are null when the previous window has no baseline posts', function (): void {
+    $post = Post::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'author_id' => $this->user->id,
+        'status' => PostStatus::Published->value,
+        'published_at' => Date::now()->subDay(),
+    ]);
+    PostTarget::factory()->create([
+        'post_id' => $post->id,
+        'metrics_status' => MetricsStatus::Ok->value,
+        'likes' => 50, 'comments' => 0, 'reposts' => 0,
+    ]);
+
+    $this->actingAs($this->user)
+        ->get(route('analytics.index', ['days' => 7]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('summary.engagement.value', 50)
+            ->where('summary.engagement.delta', null)
+            ->where('summary.posts.delta', null));
+});
+
 test('analytics polling settings are keyed by platform enum values', function (): void {
     app(InstanceSettings::class)->update([
         'post_metrics_polling_enabled' => [


### PR DESCRIPTION
## Summary
- Add headline stat tiles for followers, engagement, and posts published, each showing a delta vs. the previous equal-length period
- Redesign the follower growth chart from a single shared-axis line chart into one auto-scaled area chart per account, so small changes on high-follower accounts are no longer flattened against a zero baseline
- Add a colorblind-safe 8-color categorical palette (`--account-1` … `--account-8`) for account lines, replacing the reused 5-color chart palette
- Make post-publish markers on the chart clickable, linking to the post detail page
- Switch the date-range selector to a partial Inertia reload (only range-dependent props) with `preserveScroll`/`preserveState` for snappier switching
- Remove the graph legend show/hide toggle in favor of always-visible per-account trend cards with follower deltas
- Backend: compute `followers_delta` per account and a `summary` payload (followers/engagement/posts totals with previous-period deltas) in `AnalyticsController`
