### PR TITLE
ci: speed up test workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,10 +35,21 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Install Dependencies
-        run: |
-          composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
-          bun install
+      - name: Install Composer Dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+        with:
+          composer-options: "--no-scripts"
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install Node Dependencies
+        run: bun install
 
       - name: Run Pint
         run: composer lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Generate Application Key
         run: php artisan key:generate
 
+      - name: Generate Passport Keys
+        run: php artisan passport:keys --no-interaction
+
       - name: Build Assets
         run: bun run build
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 jobs:
-  ci:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,18 +35,28 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
-          coverage: xdebug
+          coverage: none
+
+      - name: Install Dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+        with:
+          composer-options: "--optimize-autoloader"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
+      - name: Cache Bun dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install Node Dependencies
         run: bun install
-
-      - name: Install Dependencies
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Copy Environment File
         run: cp .env.example .env
@@ -57,8 +67,38 @@ jobs:
       - name: Build Assets
         run: bun run build
 
+      - name: Tests
+        run: php artisan test --parallel
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ['8.5']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Install Dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+        with:
+          composer-options: "--optimize-autoloader"
+
+      - name: Copy Environment File
+        run: cp .env.example .env
+
+      - name: Generate Application Key
+        run: php artisan key:generate
+
       - name: Run Type Analysis
         run: composer types:check
-
-      - name: Tests
-        run: php artisan test

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "sentry/sentry-laravel": "^4.26"
     },
     "require-dev": {
+        "brianium/paratest": "^7.20",
         "driftingly/rector-laravel": "^2.5",
         "fakerphp/faker": "^1.24",
         "larastan/larastan": "^3.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd42a209d8c3a74c4b4eb6048aa0fae6",
+    "content-hash": "05a4fcd6d4b31bdc15d866966431c85b",
     "packages": [
         {
             "name": "aws/aws-crt-php",

--- a/tests/Feature/Api/ApiAuthTest.php
+++ b/tests/Feature/Api/ApiAuthTest.php
@@ -1,34 +1,7 @@
 <?php
 
 use App\Models\ApiKey;
-use App\Models\User;
-use App\Models\Workspace;
 use App\Services\Api\ApiKeyManager;
-use Illuminate\Support\Facades\Artisan;
-use Laravel\Passport\Client;
-
-/**
- * Issue a real key and return [User, Workspace, plaintextToken]. The user is a
- * member of the workspace.
- *
- * @return array{0: User, 1: Workspace, 2: string}
- */
-function issuedKey(string $scope = 'write'): array
-{
-    if (! file_exists(storage_path('oauth-private.key'))) {
-        Artisan::call('passport:keys', ['--no-interaction' => true]);
-    }
-
-    Client::factory()->asPersonalAccessTokenClient()->create(['provider' => 'users']);
-
-    $user = User::factory()->create();
-    $workspace = Workspace::factory()->create();
-    $workspace->members()->create(['user_id' => $user->id, 'role' => 'admin']);
-
-    [, $plain] = app(ApiKeyManager::class)->issue($workspace, $user, 'test', $scope, null);
-
-    return [$user, $workspace, $plain];
-}
 
 test('a request without a token is 401', function () {
     $this->getJson('/api/v1/connected-accounts')->assertUnauthorized();

--- a/tests/Feature/Publishing/PublishPostTargetTest.php
+++ b/tests/Feature/Publishing/PublishPostTargetTest.php
@@ -4,67 +4,16 @@ use App\Dto\Publishing\PublishContext;
 use App\Dto\Publishing\PublishResult;
 use App\Enums\ConnectedAccountStatus;
 use App\Enums\ErrorKind;
-use App\Enums\Platform;
 use App\Enums\PostStatus;
 use App\Enums\PostTargetStatus;
 use App\Jobs\PublishPostTarget;
-use App\Models\ConnectedAccount;
-use App\Models\ConnectedAccountSecret;
-use App\Models\Post;
-use App\Models\PostTarget;
 use App\Models\PostTargetAttempt;
 use App\Services\Publishing\BackoffSchedule;
-use App\Services\Publishing\Contracts\PublishConnector;
 use App\Services\Publishing\PostStatusRollup;
 use App\Services\Publishing\PublishConnectorRegistry;
 use App\Services\Publishing\TokenManager;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Date;
-
-function publishTarget(array $segments = ['hello'], string $status = 'pending'): PostTarget
-{
-    $post = Post::factory()->create(['status' => PostStatus::Publishing]);
-    $account = ConnectedAccount::factory()->create([
-        'platform' => Platform::X->value,
-        'token_expires_at' => now()->addHour(),
-    ]);
-    ConnectedAccountSecret::factory()->create([
-        'connected_account_id' => $account->id,
-        'access_token' => 'tok',
-    ]);
-
-    return PostTarget::factory()->for($post)->create([
-        'connected_account_id' => $account->id,
-        'platform' => Platform::X->value,
-        'sections' => $segments,
-        'status' => $status,
-    ]);
-}
-
-function bindConnector(PublishResult|callable $result): void
-{
-    $connector = new class($result) implements PublishConnector
-    {
-        public function __construct(private $result) {}
-
-        public function publish(PublishContext $context): PublishResult
-        {
-            return is_callable($this->result) ? ($this->result)($context) : $this->result;
-        }
-
-        public function delete(PostTarget $target, array $credentials): void {}
-    };
-
-    app()->instance(PublishConnectorRegistry::class, new class($connector) extends PublishConnectorRegistry
-    {
-        public function __construct(private PublishConnector $connector) {}
-
-        public function for(Platform $platform): PublishConnector
-        {
-            return $this->connector;
-        }
-    });
-}
 
 test('successful publish marks the target published with remote ids', function () {
     $target = publishTarget(['one', 'two']);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,11 +1,23 @@
 <?php
 
+use App\Dto\Publishing\PublishContext;
+use App\Dto\Publishing\PublishResult;
+use App\Enums\Platform;
+use App\Enums\PostStatus;
 use App\Enums\WorkspaceRole;
+use App\Models\ConnectedAccount;
+use App\Models\ConnectedAccountSecret;
 use App\Models\McpGrantWorkspace;
+use App\Models\Post;
+use App\Models\PostTarget;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Models\WorkspaceMembership;
+use App\Services\Api\ApiKeyManager;
+use App\Services\Publishing\Contracts\PublishConnector;
+use App\Services\Publishing\PublishConnectorRegistry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Str;
 use Laravel\Passport\AccessToken;
 use Laravel\Passport\Client;
@@ -56,6 +68,97 @@ expect()->extend('toBeOne', fn () => $this->toBe(1));
 function something()
 {
     // ..
+}
+
+/**
+ * Issue a real key and return [User, Workspace, plaintextToken]. The user is a
+ * member of the workspace.
+ *
+ * @return array{0: User, 1: Workspace, 2: string}
+ */
+function issuedKey(string $scope = 'write'): array
+{
+    if (! file_exists(storage_path('oauth-private.key'))) {
+        Artisan::call('passport:keys', ['--no-interaction' => true]);
+    }
+
+    Client::factory()->asPersonalAccessTokenClient()->create(['provider' => 'users']);
+
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create();
+    $workspace->members()->create(['user_id' => $user->id, 'role' => 'admin']);
+
+    [, $plain] = app(ApiKeyManager::class)->issue($workspace, $user, 'test', $scope, null);
+
+    return [$user, $workspace, $plain];
+}
+
+/**
+ * Build a 4x4 transparent PNG as raw bytes for media-conversion tests.
+ */
+function transparentPng(int $width = 4, int $height = 4): string
+{
+    $image = imagecreatetruecolor($width, $height);
+    imagesavealpha($image, true);
+    imagefill($image, 0, 0, imagecolorallocatealpha($image, 0, 0, 0, 127));
+    ob_start();
+    imagepng($image);
+
+    return (string) ob_get_clean();
+}
+
+/**
+ * Create a pending X PostTarget (with account + secret) ready to publish.
+ *
+ * @param  array<int, string>  $segments
+ */
+function publishTarget(array $segments = ['hello'], string $status = 'pending'): PostTarget
+{
+    $post = Post::factory()->create(['status' => PostStatus::Publishing]);
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::X->value,
+        'token_expires_at' => now()->addHour(),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'access_token' => 'tok',
+    ]);
+
+    return PostTarget::factory()->for($post)->create([
+        'connected_account_id' => $account->id,
+        'platform' => Platform::X->value,
+        'sections' => $segments,
+        'status' => $status,
+    ]);
+}
+
+/**
+ * Swap the publish connector registry for a stub returning the given result
+ * (or invoking the given callable with the PublishContext).
+ */
+function bindConnector(PublishResult|callable $result): void
+{
+    $connector = new class($result) implements PublishConnector
+    {
+        public function __construct(private $result) {}
+
+        public function publish(PublishContext $context): PublishResult
+        {
+            return is_callable($this->result) ? ($this->result)($context) : $this->result;
+        }
+
+        public function delete(PostTarget $target, array $credentials): void {}
+    };
+
+    app()->instance(PublishConnectorRegistry::class, new class($connector) extends PublishConnectorRegistry
+    {
+        public function __construct(private PublishConnector $connector) {}
+
+        public function for(Platform $platform): PublishConnector
+        {
+            return $this->connector;
+        }
+    });
 }
 
 /**

--- a/tests/Unit/Media/ImageToJpegConverterTest.php
+++ b/tests/Unit/Media/ImageToJpegConverterTest.php
@@ -5,17 +5,6 @@ use App\Services\Media\ImageConversionFailed;
 use App\Services\Media\ImageToJpegConverter;
 use Illuminate\Support\Facades\Storage;
 
-function transparentPng(int $width = 4, int $height = 4): string
-{
-    $image = imagecreatetruecolor($width, $height);
-    imagesavealpha($image, true);
-    imagefill($image, 0, 0, imagecolorallocatealpha($image, 0, 0, 0, 127));
-    ob_start();
-    imagepng($image);
-
-    return (string) ob_get_clean();
-}
-
 function mimeOf(string $bytes): string
 {
     return (new finfo(FILEINFO_MIME_TYPE))->buffer($bytes);


### PR DESCRIPTION
- Drop Xdebug from the tests job (coverage: none) — it was enabled but no coverage was collected, taxing every test 2-5x.
- Run the Pest suite with --parallel (adds brianium/paratest to require-dev, already present transitively via Pest).
- Split Larastan (types:check) into its own job so it runs alongside tests instead of blocking them.
- Cache composer (ramsey/composer-install) and bun (~/.bun/install/cache) deps in both tests and lint workflows.
- Make three test helpers parallel-safe by moving them into tests/Pest.php (loaded by every paratest worker): issuedKey, transparentPng, publishTarget, bindConnector. Previously defined in one test file and used across others, which only works under serial execution.