### PR TITLE
feat(calendar): show multi-account glyph stack on posts

### DIFF
--- a/resources/js/components/common/platform-glyph-stack.tsx
+++ b/resources/js/components/common/platform-glyph-stack.tsx
@@ -1,0 +1,53 @@
+import { PlatformGlyph } from '@/components/common/platform-glyph';
+import { cn } from '@/lib/utils';
+import type { PlatformName } from '@/types/compose';
+
+type Props = {
+    platforms: PlatformName[];
+    targetCount: number;
+    size?: number;
+    className?: string;
+};
+
+const MAX_GLYPHS = 3;
+
+/**
+ * A compact multi-account indicator: up to three platform glyphs side by side
+ * plus a `+n` remainder. Unlike the overlapped, ringed tiles in `PostRow`, this
+ * is a flat cluster with no boxes or background — calendar chips are only 20px
+ * tall and sit on a translucent tinted fill, where ringed tiles smear together
+ * and outgrow the chip. The remainder covers both extra platforms and multiple
+ * accounts on the same platform, so `['x']` with two targets reads `X +1`.
+ */
+export function PlatformGlyphStack({
+    platforms,
+    targetCount,
+    size,
+    className,
+}: Props) {
+    if (platforms.length === 0 && targetCount <= 0) {
+        return null;
+    }
+
+    const shownGlyphs = platforms.slice(0, MAX_GLYPHS);
+    const extra = Math.max(0, targetCount - shownGlyphs.length);
+
+    return (
+        <span
+            aria-label={`${targetCount} ${targetCount === 1 ? 'account' : 'accounts'}`}
+            className={cn('inline-flex items-center gap-[3px]', className)}
+        >
+            {shownGlyphs.map((platform) => (
+                <PlatformGlyph
+                    key={platform}
+                    platform={platform}
+                    size={size}
+                    className="shrink-0"
+                />
+            ))}
+            {extra > 0 && (
+                <span className="shrink-0 tabular-nums">+{extra}</span>
+            )}
+        </span>
+    );
+}

--- a/resources/js/components/posts/calendar/__tests__/post-chip.test.tsx
+++ b/resources/js/components/posts/calendar/__tests__/post-chip.test.tsx
@@ -1,0 +1,96 @@
+import { DndContext } from '@dnd-kit/core';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PostChip } from '@/components/posts/calendar/post-chip';
+import type { PostRowData } from '@/components/posts/post-row';
+import type { PlatformName } from '@/types/compose';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { visit: vi.fn() },
+    usePage: () => ({ props: {} }),
+}));
+
+function basePost(overrides: Partial<PostRowData> = {}): PostRowData {
+    return {
+        id: 'post-1',
+        base_text: 'Ship the multi-account indicator',
+        status: 'scheduled',
+        status_label: 'Scheduled',
+        author: null,
+        target_count: 1,
+        updated_at: '2026-06-20T09:00:00Z',
+        scheduled_at: '2026-06-20T14:30:00Z',
+        published_at: null,
+        platforms: ['x'] as PlatformName[],
+        targets: [],
+        media_count: 0,
+        media_preview: null,
+        ...overrides,
+    };
+}
+
+function renderChip(post: PostRowData) {
+    return render(
+        <DndContext>
+            <PostChip post={post} draggable={false} />
+        </DndContext>,
+    );
+}
+
+function stack(): HTMLElement {
+    return screen.getByLabelText(/accounts?$/);
+}
+
+describe('PostChip multi-account indicator', () => {
+    it('renders one glyph per platform with no remainder when every target is shown', () => {
+        renderChip(
+            basePost({
+                platforms: ['x', 'bluesky', 'linkedin'],
+                target_count: 3,
+            }),
+        );
+
+        const wrapper = stack();
+        expect(wrapper.querySelectorAll('svg')).toHaveLength(3);
+        expect(wrapper.textContent).not.toContain('+');
+        expect(wrapper).toHaveAttribute('aria-label', '3 accounts');
+    });
+
+    it('counts extra accounts on the same platform in the remainder', () => {
+        renderChip(basePost({ platforms: ['x'], target_count: 2 }));
+
+        const wrapper = stack();
+        expect(wrapper.querySelectorAll('svg')).toHaveLength(1);
+        expect(wrapper.textContent).toContain('+1');
+        expect(wrapper).toHaveAttribute('aria-label', '2 accounts');
+    });
+
+    it('caps the glyphs at three and folds the rest into the remainder', () => {
+        renderChip(
+            basePost({
+                platforms: [
+                    'x',
+                    'bluesky',
+                    'linkedin',
+                    'facebook',
+                    'instagram',
+                ],
+                target_count: 5,
+            }),
+        );
+
+        const wrapper = stack();
+        expect(wrapper.querySelectorAll('svg')).toHaveLength(3);
+        expect(wrapper.textContent).toContain('+2');
+    });
+
+    it('labels a single target in the singular with no remainder', () => {
+        renderChip(basePost({ platforms: ['x'], target_count: 1 }));
+
+        const wrapper = stack();
+        expect(wrapper.querySelectorAll('svg')).toHaveLength(1);
+        expect(wrapper.textContent).not.toContain('+');
+        expect(wrapper).toHaveAttribute('aria-label', '1 account');
+    });
+});

--- a/resources/js/components/posts/calendar/agenda-list.tsx
+++ b/resources/js/components/posts/calendar/agenda-list.tsx
@@ -2,7 +2,7 @@ import { router } from '@inertiajs/react';
 import { Plus } from 'lucide-react';
 
 import ComposerController from '@/actions/App/Http/Controllers/Posts/ComposerController';
-import { PlatformGlyph } from '@/components/common/platform-glyph';
+import { PlatformGlyphStack } from '@/components/common/platform-glyph-stack';
 import type { PostRowData, PostStatus } from '@/components/posts/post-row';
 import { useSchedulingTimezone } from '@/hooks/posts/use-scheduling-timezone';
 import { dayjs, toUserTz, weekRange } from '@/lib/datetime/dayjs';
@@ -148,14 +148,17 @@ function AgendaItem({ post }: { post: PostRowData }) {
     const tz = useSchedulingTimezone();
     const at = post.scheduled_at ?? post.published_at;
     const when = at ? toUserTz(at, tz).format('h:mm a') : '';
-    const platform = (post.platforms ?? [])[0];
+    const targetCount = post.target_count ?? 0;
+    const label = post.base_text || 'Untitled';
+    const title =
+        targetCount > 1 ? `${label} — ${targetCount} accounts` : label;
 
     return (
         <button
             type="button"
             onClick={() => router.visit(ComposerController.show(post.id).url)}
             className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2.5 text-left transition-colors hover:bg-muted/60 active:bg-muted"
-            title={post.base_text}
+            title={title}
         >
             <span
                 aria-hidden
@@ -167,16 +170,13 @@ function AgendaItem({ post }: { post: PostRowData }) {
             <span className="w-16 shrink-0 text-[12px] text-muted-foreground tabular-nums">
                 {when}
             </span>
-            {platform && (
-                <PlatformGlyph
-                    platform={platform}
-                    size={13}
-                    className="shrink-0 opacity-70"
-                />
-            )}
-            <span className="min-w-0 flex-1 truncate text-[13px]">
-                {post.base_text || 'Untitled'}
-            </span>
+            <PlatformGlyphStack
+                platforms={post.platforms ?? []}
+                targetCount={targetCount}
+                size={13}
+                className="shrink-0 opacity-70"
+            />
+            <span className="min-w-0 flex-1 truncate text-[13px]">{label}</span>
         </button>
     );
 }

--- a/resources/js/components/posts/calendar/post-chip.tsx
+++ b/resources/js/components/posts/calendar/post-chip.tsx
@@ -3,7 +3,7 @@ import { router } from '@inertiajs/react';
 import type { CSSProperties, MouseEvent } from 'react';
 
 import ComposerController from '@/actions/App/Http/Controllers/Posts/ComposerController';
-import { PlatformGlyph } from '@/components/common/platform-glyph';
+import { PlatformGlyphStack } from '@/components/common/platform-glyph-stack';
 import type { PostRowData } from '@/components/posts/post-row';
 import { useSchedulingTimezone } from '@/hooks/posts/use-scheduling-timezone';
 import { toUserTz } from '@/lib/datetime/dayjs';
@@ -57,7 +57,10 @@ export function PostChip({
         ? toUserTz(post.scheduled_at, tz).format('h:mma')
         : '';
     const tone = toneStyles[toneOf(post.status)];
-    const platform = (post.platforms ?? [])[0];
+    const targetCount = post.target_count ?? 0;
+    const label = post.base_text || 'Untitled';
+    const title =
+        targetCount > 1 ? `${label} — ${targetCount} accounts` : label;
 
     const style: CSSProperties = transform
         ? {
@@ -92,7 +95,7 @@ export function PostChip({
                     : 'cursor-pointer',
                 isDragging && 'opacity-50',
             )}
-            title={post.base_text}
+            title={title}
         >
             <span
                 aria-hidden
@@ -101,15 +104,14 @@ export function PostChip({
                     tone.strip,
                 )}
             />
-            {platform && (
-                <PlatformGlyph
-                    platform={platform}
-                    size={10}
-                    className="shrink-0 opacity-80"
-                />
-            )}
+            <PlatformGlyphStack
+                platforms={post.platforms ?? []}
+                targetCount={targetCount}
+                size={10}
+                className="shrink-0 opacity-80"
+            />
             {when && <span className="shrink-0 opacity-75">{when}</span>}
-            <span className="truncate">{post.base_text || 'Untitled'}</span>
+            <span className="truncate">{label}</span>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- Add a `PlatformGlyphStack` component that renders up to 3 platform glyphs plus a `+n` remainder for posts scheduled across multiple accounts/platforms
- Replace the single `PlatformGlyph` in the calendar's `PostChip` and agenda list item with the new stack, so multi-account posts are now visually distinguishable in Calendar View, matching Queue View
- Add tests covering single-account, same-platform-multiple-accounts, and overflow (>3 platforms) cases

Closes #122


---

Fixes #122