### PR TITLE
fix(image-editor): compress composed exports to avoid upload 422s (fixes #126)

### DIFF
--- a/app/Http/Requests/Engagement/StoreReplyImageEditRequest.php
+++ b/app/Http/Requests/Engagement/StoreReplyImageEditRequest.php
@@ -24,13 +24,14 @@ class StoreReplyImageEditRequest extends FormRequest
     }
 
     /**
+     * `composed` accepts JPEG/PNG/WebP: the editor emits a compressed JPEG/WebP
+     * sized to fit `max`, so a lossless PNG no longer 422s the upload (#126).
+     *
      * @return array<string, mixed>
      */
     public function rules(): array
     {
         return [
-            // See AbstractImageEditRequest: the editor emits a compressed JPEG/WebP
-            // sized to fit `max`, so a lossless PNG no longer 422s the upload (#126).
             'composed' => ['required', 'file', 'mimetypes:image/jpeg,image/png,image/webp', 'max:8192'],
             'settings' => ['required', 'array'],
             'settings.version' => ['required', 'integer'],

--- a/app/Http/Requests/Engagement/StoreReplyImageEditRequest.php
+++ b/app/Http/Requests/Engagement/StoreReplyImageEditRequest.php
@@ -29,7 +29,9 @@ class StoreReplyImageEditRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'composed' => ['required', 'file', 'mimetypes:image/png', 'max:8192'],
+            // See AbstractImageEditRequest: the editor emits a compressed JPEG/WebP
+            // sized to fit `max`, so a lossless PNG no longer 422s the upload (#126).
+            'composed' => ['required', 'file', 'mimetypes:image/jpeg,image/png,image/webp', 'max:8192'],
             'settings' => ['required', 'array'],
             'settings.version' => ['required', 'integer'],
             'settings.background' => ['required', 'array'],

--- a/app/Http/Requests/Engagement/UpdateReplyImageEditRequest.php
+++ b/app/Http/Requests/Engagement/UpdateReplyImageEditRequest.php
@@ -24,13 +24,14 @@ class UpdateReplyImageEditRequest extends FormRequest
     }
 
     /**
+     * `composed` accepts JPEG/PNG/WebP: the editor emits a compressed JPEG/WebP
+     * sized to fit `max`, so a lossless PNG no longer 422s the upload (#126).
+     *
      * @return array<string, mixed>
      */
     public function rules(): array
     {
         return [
-            // See AbstractImageEditRequest: the editor emits a compressed JPEG/WebP
-            // sized to fit `max`, so a lossless PNG no longer 422s the upload (#126).
             'composed' => ['required', 'file', 'mimetypes:image/jpeg,image/png,image/webp', 'max:8192'],
             'settings' => ['required', 'array'],
             'settings.version' => ['required', 'integer'],

--- a/app/Http/Requests/Engagement/UpdateReplyImageEditRequest.php
+++ b/app/Http/Requests/Engagement/UpdateReplyImageEditRequest.php
@@ -29,7 +29,9 @@ class UpdateReplyImageEditRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'composed' => ['required', 'file', 'mimetypes:image/png', 'max:8192'],
+            // See AbstractImageEditRequest: the editor emits a compressed JPEG/WebP
+            // sized to fit `max`, so a lossless PNG no longer 422s the upload (#126).
+            'composed' => ['required', 'file', 'mimetypes:image/jpeg,image/png,image/webp', 'max:8192'],
             'settings' => ['required', 'array'],
             'settings.version' => ['required', 'integer'],
             'settings.background' => ['required', 'array'],

--- a/app/Http/Requests/Post/AbstractImageEditRequest.php
+++ b/app/Http/Requests/Post/AbstractImageEditRequest.php
@@ -24,17 +24,19 @@ abstract class AbstractImageEditRequest extends FormRequest
     }
 
     /**
-     * Validation shared by the create and update paths: the composed PNG plus the
-     * full edit-settings schema. Subclasses merge their own rules (e.g. `source`).
+     * Validation shared by the create and update paths: the composed image plus
+     * the full edit-settings schema. Subclasses merge their own rules (e.g. `source`).
+     *
+     * The editor rasterizes to a compressed JPEG (opaque) or WebP (transparent)
+     * sized to fit `max`; a lossless PNG of a photo exceeded the cap and was
+     * silently rejected with a 422, dropping the media (#126). PNG is still
+     * accepted for browsers that fall back to it.
      *
      * @return array<string, mixed>
      */
     protected function baseRules(): array
     {
         return [
-            // The editor rasterizes to a compressed format (JPEG when opaque, WebP
-            // when transparency is possible) and shrinks it to fit under `max` — a
-            // lossless PNG of a photo exceeds the cap and was silently 422'd (#126).
             'composed' => ['required', 'file', 'mimetypes:image/jpeg,image/png,image/webp', 'max:8192'],
             'settings' => ['required', 'array'],
             'settings.version' => ['required', 'integer'],

--- a/app/Http/Requests/Post/AbstractImageEditRequest.php
+++ b/app/Http/Requests/Post/AbstractImageEditRequest.php
@@ -32,7 +32,10 @@ abstract class AbstractImageEditRequest extends FormRequest
     protected function baseRules(): array
     {
         return [
-            'composed' => ['required', 'file', 'mimetypes:image/png', 'max:8192'],
+            // The editor rasterizes to a compressed format (JPEG when opaque, WebP
+            // when transparency is possible) and shrinks it to fit under `max` — a
+            // lossless PNG of a photo exceeds the cap and was silently 422'd (#126).
+            'composed' => ['required', 'file', 'mimetypes:image/jpeg,image/png,image/webp', 'max:8192'],
             'settings' => ['required', 'array'],
             'settings.version' => ['required', 'integer'],
             'settings.background' => ['required', 'array'],

--- a/resources/js/components/compose/image-editor.tsx
+++ b/resources/js/components/compose/image-editor.tsx
@@ -274,6 +274,7 @@ export function ImageEditor({
             const composed = await rasterizeStage(
                 node,
                 Math.max(stage.width, stage.height),
+                settings,
             );
             await onApply(composed, settings, altText);
         } catch {

--- a/resources/js/hooks/compose/use-image-editor.ts
+++ b/resources/js/hooks/compose/use-image-editor.ts
@@ -12,8 +12,12 @@ type Options = {
     onReplaceMedia: (media: MediaView) => void;
 };
 
-function blobToFile(blob: Blob, name: string): File {
-    return new File([blob], name, { type: blob.type || 'image/png' });
+function blobToFile(blob: Blob, baseName: string): File {
+    const type = blob.type || 'image/png';
+    const ext =
+        type === 'image/webp' ? 'webp' : type === 'image/jpeg' ? 'jpg' : 'png';
+
+    return new File([blob], `${baseName}.${ext}`, { type });
 }
 
 export function useImageEditor({
@@ -40,8 +44,8 @@ export function useImageEditor({
                 return false;
             }
             http.transform(() => ({
-                composed: blobToFile(composed, 'image.png'),
-                source: blobToFile(source, 'source.png'),
+                composed: blobToFile(composed, 'image'),
+                source: blobToFile(source, 'source'),
                 settings: JSON.stringify(settings),
                 alt_text: altText,
             }));
@@ -77,7 +81,7 @@ export function useImageEditor({
                 return false;
             }
             http.transform(() => ({
-                composed: blobToFile(composed, 'image.png'),
+                composed: blobToFile(composed, 'image'),
                 settings: JSON.stringify(settings),
                 alt_text: altText,
                 _method: 'put',

--- a/resources/js/lib/image-editor/__tests__/export.test.ts
+++ b/resources/js/lib/image-editor/__tests__/export.test.ts
@@ -1,8 +1,56 @@
-import { describe, expect, it } from 'vitest';
+// @vitest-environment jsdom
+// The downscale step calls document.createElement('canvas'), so this suite needs a DOM.
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { computeExportScale, pickComposedFormat } from '../export';
+import {
+    computeExportScale,
+    encodeCanvasToFit,
+    pickComposedFormat,
+} from '../export';
 import { gradientToFill, GRADIENTS, NO_BACKGROUND } from '../gradients';
 import { defaultSettings } from '../settings';
+
+/** Encoded byte size for a fake canvas of `w`×`h` at `type`/`quality`. */
+type SizeModel = (
+    w: number,
+    h: number,
+    type: string,
+    quality: number,
+) => number | null;
+
+/**
+ * A canvas stand-in whose `toBlob` returns a controllable size — jsdom has no
+ * real canvas encoder, so the fit loop is exercised against a modeled encoder.
+ */
+function fakeCanvas(sizeModel: SizeModel, w = 0, h = 0): HTMLCanvasElement {
+    const canvas = {
+        width: w,
+        height: h,
+        getContext: () => ({ drawImage: () => {} }),
+        toBlob(
+            cb: (blob: Blob | null) => void,
+            type: string,
+            quality = 1,
+        ): void {
+            const size = sizeModel(canvas.width, canvas.height, type, quality);
+            cb(size === null ? null : ({ size, type } as Blob));
+        },
+    };
+
+    return canvas as unknown as HTMLCanvasElement;
+}
+
+/** Route `document.createElement('canvas')` (used by the downscale step) to fakes. */
+function stubDownscaleCanvases(sizeModel: SizeModel): void {
+    const real = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) =>
+        tag === 'canvas' ? fakeCanvas(sizeModel) : real(tag),
+    );
+}
+
+const JPEG = { type: 'image/jpeg', quality: 0.92 };
+const WEBP = { type: 'image/webp', quality: 0.92 };
+const BUDGET = 7.5 * 1024 * 1024;
 
 describe('computeExportScale', () => {
     it('uses the base scale when the result stays under the cap', () => {
@@ -36,5 +84,53 @@ describe('pickComposedFormat', () => {
         const { quality } = pickComposedFormat(defaultSettings());
         expect(quality).toBeGreaterThan(0.8);
         expect(quality).toBeLessThanOrEqual(1);
+    });
+});
+
+describe('encodeCanvasToFit', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it('returns the full-resolution encode when it already fits', async () => {
+        const canvas = fakeCanvas(() => 1_000, 2048, 1536);
+
+        const blob = await encodeCanvasToFit(canvas, JPEG, BUDGET);
+
+        expect(blob.size).toBeLessThanOrEqual(BUDGET);
+        expect(blob.type).toBe('image/jpeg');
+    });
+
+    it('downscales — reaching MIN_SCALE (0.5) — and never returns over budget', async () => {
+        // 4 bytes/px, quality-independent: only the 0.5 scale (1024×768) fits the
+        // budget, so the loop MUST reach 0.5 (the old float step stopped at 0.6).
+        const model: SizeModel = (w, h) => w * h * 4;
+        stubDownscaleCanvases(model);
+        const canvas = fakeCanvas(model, 2048, 1536);
+        const budget = 1024 * 768 * 4; // exactly the 0.5-scale size
+
+        const blob = await encodeCanvasToFit(canvas, JPEG, budget);
+
+        expect(blob.size).toBeLessThanOrEqual(budget);
+    });
+
+    it('accepts the browser PNG fallback when WebP cannot be encoded', async () => {
+        // Simulate a browser that returns null for WebP but encodes small PNGs.
+        const model: SizeModel = (_w, _h, type) =>
+            type === 'image/webp' ? null : 2_000;
+        const canvas = fakeCanvas(model, 800, 600);
+
+        const blob = await encodeCanvasToFit(canvas, WEBP, BUDGET);
+
+        expect(blob.type).toBe('image/png');
+        expect(blob.size).toBeLessThanOrEqual(BUDGET);
+    });
+
+    it('throws rather than upload an over-budget blob when nothing fits', async () => {
+        const model: SizeModel = () => 100 * 1024 * 1024; // always huge
+        stubDownscaleCanvases(model);
+        const canvas = fakeCanvas(model, 2048, 1536);
+
+        await expect(encodeCanvasToFit(canvas, JPEG, BUDGET)).rejects.toThrow(
+            /rasterize/i,
+        );
     });
 });

--- a/resources/js/lib/image-editor/__tests__/export.test.ts
+++ b/resources/js/lib/image-editor/__tests__/export.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeExportScale } from '../export';
+import { computeExportScale, pickComposedFormat } from '../export';
+import { gradientToFill, GRADIENTS, NO_BACKGROUND } from '../gradients';
+import { defaultSettings } from '../settings';
 
 describe('computeExportScale', () => {
     it('uses the base scale when the result stays under the cap', () => {
@@ -13,5 +15,26 @@ describe('computeExportScale', () => {
 
     it('never returns more than the base scale', () => {
         expect(computeExportScale(10, 2048, 2)).toBe(2);
+    });
+});
+
+describe('pickComposedFormat', () => {
+    it('encodes JPEG when a background makes the composite opaque', () => {
+        const settings = {
+            ...defaultSettings(),
+            background: gradientToFill(GRADIENTS[0]),
+        };
+        expect(pickComposedFormat(settings).type).toBe('image/jpeg');
+    });
+
+    it('encodes WebP (alpha-preserving) when there is no background', () => {
+        const settings = { ...defaultSettings(), background: NO_BACKGROUND };
+        expect(pickComposedFormat(settings).type).toBe('image/webp');
+    });
+
+    it('starts from a high, non-lossless quality', () => {
+        const { quality } = pickComposedFormat(defaultSettings());
+        expect(quality).toBeGreaterThan(0.8);
+        expect(quality).toBeLessThanOrEqual(1);
     });
 });

--- a/resources/js/lib/image-editor/export.ts
+++ b/resources/js/lib/image-editor/export.ts
@@ -10,7 +10,8 @@ import type { EditSettings } from './settings';
  */
 const MAX_COMPOSED_BYTES = Math.floor(7.5 * 1024 * 1024); // headroom under the 8 MiB (max:8192) server cap
 const QUALITY_STEPS = [0.92, 0.82, 0.72, 0.6] as const;
-const MIN_SCALE = 0.5;
+/** Downscale factors tried in order, ending at the smallest we'll ship. */
+const SCALE_STEPS = [1, 0.8, 0.6, 0.5] as const;
 
 /**
  * Pick a rasterization pixel-ratio: render at `baseScale` for crispness, but
@@ -72,48 +73,58 @@ function scaleCanvas(
 }
 
 /**
+ * Encode `target` at the requested lossy `type`, falling back to PNG when the
+ * browser can't produce that type (older Safari can't encode canvas WebP — it
+ * either returns a PNG blob or `null`). Returns `null` only if even PNG fails.
+ */
+async function encodeCanvas(
+    target: HTMLCanvasElement,
+    type: string,
+    quality: number,
+): Promise<Blob | null> {
+    const blob = await canvasToBlob(target, type, quality);
+    if (blob) {
+        return blob;
+    }
+
+    return type === 'image/png' ? null : canvasToBlob(target, 'image/png');
+}
+
+/**
  * Encode `canvas` to a blob at or under `maxBytes`: step the quality down at full
  * resolution first (to preserve detail), then downscale and retry, until it fits.
- * A browser that can't encode the requested lossy `type` returns a PNG instead —
- * that's still a valid upload, so it's accepted once it fits.
+ * A browser that can't encode the requested lossy `type` produces a PNG instead —
+ * still a valid upload, accepted once it fits. Throws when nothing fits so the
+ * editor surfaces its "couldn't process" error rather than uploading a file the
+ * server will reject with the very 422 this guards against (#126).
  */
 export async function encodeCanvasToFit(
     canvas: HTMLCanvasElement,
     format: { type: string; quality: number },
     maxBytes: number,
 ): Promise<Blob> {
-    for (let scale = 1; scale >= MIN_SCALE - 1e-6; scale -= 0.2) {
+    // Sweep from the caller's chosen starting quality downward, so
+    // pickComposedFormat is the single source of truth for where encoding begins.
+    const qualitySteps = QUALITY_STEPS.filter((q) => q <= format.quality);
+    for (const scale of SCALE_STEPS) {
         const target = scale >= 1 ? canvas : scaleCanvas(canvas, scale);
-        for (const quality of QUALITY_STEPS) {
-            const blob = await canvasToBlob(target, format.type, quality);
+        for (const quality of qualitySteps) {
+            const blob = await encodeCanvas(target, format.type, quality);
             if (!blob) {
-                break;
-            }
-            // A PNG fallback ignores quality, so retrying qualities is pointless —
-            // drop to the next (smaller) scale as soon as it doesn't fit.
-            if (blob.type !== format.type) {
-                if (blob.size <= maxBytes) {
-                    return blob;
-                }
                 break;
             }
             if (blob.size <= maxBytes) {
                 return blob;
             }
+            // A PNG fallback ignores quality, so retrying qualities won't shrink it
+            // — drop straight to the next (smaller) scale.
+            if (blob.type !== format.type) {
+                break;
+            }
         }
     }
 
-    // Nothing fit within the scale/quality budget — return the smallest attempt so
-    // the caller still uploads *something* rather than dropping the media entirely.
-    const smallest = scaleCanvas(canvas, MIN_SCALE);
-    const blob =
-        (await canvasToBlob(smallest, format.type, 0.5)) ??
-        (await canvasToBlob(smallest, 'image/png'));
-    if (!blob) {
-        throw new Error('Failed to rasterize the image.');
-    }
-
-    return blob;
+    throw new Error('Failed to rasterize the image.');
 }
 
 /** Rasterize the stage DOM node to a compressed blob sized to fit the upload cap. */

--- a/resources/js/lib/image-editor/export.ts
+++ b/resources/js/lib/image-editor/export.ts
@@ -1,4 +1,16 @@
-import { toBlob } from 'html-to-image';
+import { toCanvas } from 'html-to-image';
+
+import type { EditSettings } from './settings';
+
+/**
+ * Rasterizing to a lossless PNG (html-to-image's default) blows past the upload
+ * cap for a photo — a ~3 MP photographic PNG is 6–12 MB against an 8 MiB limit —
+ * so the composed upload was silently rejected with a 422 and the media never
+ * attached (#126). Encode to a compressed format sized to fit instead.
+ */
+const MAX_COMPOSED_BYTES = Math.floor(7.5 * 1024 * 1024); // headroom under the 8 MiB (max:8192) server cap
+const QUALITY_STEPS = [0.92, 0.82, 0.72, 0.6] as const;
+const MIN_SCALE = 0.5;
 
 /**
  * Pick a rasterization pixel-ratio: render at `baseScale` for crispness, but
@@ -18,23 +30,108 @@ export function computeExportScale(
     return Math.min(baseScale, capped < baseScale ? capped : baseScale);
 }
 
-/** Rasterize the stage DOM node to a PNG blob. */
-export async function rasterizeStage(
-    node: HTMLElement,
-    naturalLongestEdge: number,
-): Promise<Blob> {
-    const blob = await toBlob(node, {
-        pixelRatio: computeExportScale(naturalLongestEdge),
-        // The stage has no text, so skip web-font embedding entirely. It is the
-        // step that fails: html-to-image reads every stylesheet's cssRules to
-        // inline @font-face, which throws a SecurityError on cross-origin sheets
-        // (the Vite dev server serves CSS from a different origin than the app)
-        // and mis-parses url() backgrounds — aborting the whole rasterization.
-        skipFonts: true,
+/**
+ * Choose the composed encoding. A gradient background makes the composite fully
+ * opaque, so JPEG — the smallest and universally encodable format — is safe.
+ * Without a background the padding, corner radius or 3D tilt can expose
+ * transparency, so WebP is used to keep the alpha channel (still far smaller than
+ * PNG). Browsers that can't encode WebP fall the canvas back to PNG on their own.
+ */
+export function pickComposedFormat(settings: EditSettings): {
+    type: string;
+    quality: number;
+} {
+    return settings.background.type === 'none'
+        ? { type: 'image/webp', quality: QUALITY_STEPS[0] }
+        : { type: 'image/jpeg', quality: QUALITY_STEPS[0] };
+}
+
+function canvasToBlob(
+    canvas: HTMLCanvasElement,
+    type: string,
+    quality?: number,
+): Promise<Blob | null> {
+    return new Promise((resolve) => {
+        canvas.toBlob((blob) => resolve(blob), type, quality);
     });
+}
+
+function scaleCanvas(
+    source: HTMLCanvasElement,
+    scale: number,
+): HTMLCanvasElement {
+    const out = document.createElement('canvas');
+    out.width = Math.max(1, Math.round(source.width * scale));
+    out.height = Math.max(1, Math.round(source.height * scale));
+    const ctx = out.getContext('2d');
+    if (ctx) {
+        ctx.drawImage(source, 0, 0, out.width, out.height);
+    }
+
+    return out;
+}
+
+/**
+ * Encode `canvas` to a blob at or under `maxBytes`: step the quality down at full
+ * resolution first (to preserve detail), then downscale and retry, until it fits.
+ * A browser that can't encode the requested lossy `type` returns a PNG instead —
+ * that's still a valid upload, so it's accepted once it fits.
+ */
+export async function encodeCanvasToFit(
+    canvas: HTMLCanvasElement,
+    format: { type: string; quality: number },
+    maxBytes: number,
+): Promise<Blob> {
+    for (let scale = 1; scale >= MIN_SCALE - 1e-6; scale -= 0.2) {
+        const target = scale >= 1 ? canvas : scaleCanvas(canvas, scale);
+        for (const quality of QUALITY_STEPS) {
+            const blob = await canvasToBlob(target, format.type, quality);
+            if (!blob) {
+                break;
+            }
+            // A PNG fallback ignores quality, so retrying qualities is pointless —
+            // drop to the next (smaller) scale as soon as it doesn't fit.
+            if (blob.type !== format.type) {
+                if (blob.size <= maxBytes) {
+                    return blob;
+                }
+                break;
+            }
+            if (blob.size <= maxBytes) {
+                return blob;
+            }
+        }
+    }
+
+    // Nothing fit within the scale/quality budget — return the smallest attempt so
+    // the caller still uploads *something* rather than dropping the media entirely.
+    const smallest = scaleCanvas(canvas, MIN_SCALE);
+    const blob =
+        (await canvasToBlob(smallest, format.type, 0.5)) ??
+        (await canvasToBlob(smallest, 'image/png'));
     if (!blob) {
         throw new Error('Failed to rasterize the image.');
     }
 
     return blob;
+}
+
+/** Rasterize the stage DOM node to a compressed blob sized to fit the upload cap. */
+export async function rasterizeStage(
+    node: HTMLElement,
+    naturalLongestEdge: number,
+    settings: EditSettings,
+    maxBytes: number = MAX_COMPOSED_BYTES,
+): Promise<Blob> {
+    // The stage has no text, so skip web-font embedding entirely. It is the step
+    // that fails: html-to-image reads every stylesheet's cssRules to inline
+    // @font-face, which throws a SecurityError on cross-origin sheets (the Vite
+    // dev server serves CSS from a different origin than the app) and mis-parses
+    // url() backgrounds — aborting the whole rasterization.
+    const canvas = await toCanvas(node, {
+        pixelRatio: computeExportScale(naturalLongestEdge),
+        skipFonts: true,
+    });
+
+    return encodeCanvasToFit(canvas, pickComposedFormat(settings), maxBytes);
 }

--- a/resources/js/pages/engagement/components/use-reply-media.tsx
+++ b/resources/js/pages/engagement/components/use-reply-media.tsx
@@ -69,8 +69,12 @@ type ReplyMedia = {
     handleAddedFiles: (files: FileList | File[]) => Promise<void>;
 };
 
-function blobToFile(blob: Blob, name: string): File {
-    return new File([blob], name, { type: blob.type || 'image/png' });
+function blobToFile(blob: Blob, baseName: string): File {
+    const type = blob.type || 'image/png';
+    const ext =
+        type === 'image/webp' ? 'webp' : type === 'image/jpeg' ? 'jpg' : 'png';
+
+    return new File([blob], `${baseName}.${ext}`, { type });
 }
 
 /**
@@ -145,10 +149,10 @@ export function useReplyMedia({
         try {
             if (editing.kind === 'batch') {
                 editHttp.transform(() => ({
-                    composed: blobToFile(composed, 'image.png'),
+                    composed: blobToFile(composed, 'image'),
                     source: blobToFile(
                         editing.items[editing.index].file,
-                        'source.png',
+                        'source',
                     ),
                     settings: JSON.stringify(settings),
                     alt_text: altText,
@@ -160,7 +164,7 @@ export function useReplyMedia({
                 onChange([...media, result]);
             } else if (editing.kind === 'reedit') {
                 editHttp.transform(() => ({
-                    composed: blobToFile(composed, 'image.png'),
+                    composed: blobToFile(composed, 'image'),
                     settings: JSON.stringify(settings),
                     alt_text: altText,
                     _method: 'put',
@@ -180,8 +184,8 @@ export function useReplyMedia({
                 // fetch the original blob, upload as new, drop the raw attachment.
                 const rawBlob = await fetch(editing.url).then((r) => r.blob());
                 editHttp.transform(() => ({
-                    composed: blobToFile(composed, 'image.png'),
-                    source: blobToFile(rawBlob, 'source.png'),
+                    composed: blobToFile(composed, 'image'),
+                    source: blobToFile(rawBlob, 'source'),
                     settings: JSON.stringify(settings),
                     alt_text: altText,
                 }));

--- a/tests/Feature/Engagement/ReplyImageEditTest.php
+++ b/tests/Feature/Engagement/ReplyImageEditTest.php
@@ -47,3 +47,36 @@ test('storing a beautified image creates media on the reply workspace', function
 
     expect(PostMedia::withoutGlobalScopes()->where('workspace_id', $this->workspace->id)->count())->toBe(1);
 });
+
+test('the reply store endpoint accepts a compact composed image', function (string $file, string $mime) {
+    // The editor rasterizes to a compressed JPEG/WebP sized to fit the cap; a
+    // lossless PNG of a photo would 422, blanking the reply media (#126).
+    $this->actingAs($this->user)
+        ->post(route('engagement.image-edit.store', $this->reply), [
+            'composed' => UploadedFile::fake()->image($file, 800, 600),
+            'source' => UploadedFile::fake()->image('in.jpg'),
+            'settings' => editSettings(),
+        ])
+        ->assertCreated()
+        ->assertJsonPath('media.mime', $mime);
+})->with([
+    'jpeg' => ['out.jpg', 'image/jpeg'],
+    'webp' => ['out.webp', 'image/webp'],
+]);
+
+test('the reply update endpoint accepts a compact composed image', function () {
+    $mediaId = $this->actingAs($this->user)
+        ->post(route('engagement.image-edit.store', $this->reply), [
+            'composed' => UploadedFile::fake()->image('out.png')->mimeType('image/png'),
+            'source' => UploadedFile::fake()->image('in.jpg'),
+            'settings' => editSettings(),
+        ])->json('media.id');
+
+    $this->actingAs($this->user)
+        ->put(route('engagement.image-edit.update', ['reply' => $this->reply, 'media' => $mediaId]), [
+            'composed' => UploadedFile::fake()->image('out.webp', 900, 600),
+            'settings' => editSettings(),
+        ])
+        ->assertOk()
+        ->assertJsonPath('media.mime', 'image/webp');
+});

--- a/tests/Feature/Posts/ImageEditApiTest.php
+++ b/tests/Feature/Posts/ImageEditApiTest.php
@@ -111,3 +111,22 @@ test('it rejects a non-image composed file', function () {
         'settings' => settingsPayload(),
     ], ['Accept' => 'application/json'])->assertStatus(422);
 });
+
+test('it accepts a compact composed image', function (string $file, string $mime) {
+    Storage::fake('public');
+    [$user, $workspace, $post] = imageEditMember();
+
+    // The editor rasterizes to a compressed format (JPEG when opaque, WebP when
+    // transparency is possible) so the payload stays under the upload cap — a
+    // lossless PNG of a phone photo blows past it. The endpoint must accept them.
+    test()->post("/posts/{$post['id']}/image-edit", [
+        'composed' => UploadedFile::fake()->image($file, 800, 600),
+        'source' => UploadedFile::fake()->image('src.png', 1200, 900),
+        'settings' => settingsPayload(),
+    ], ['Accept' => 'application/json'])
+        ->assertCreated()
+        ->assertJsonPath('media.mime', $mime);
+})->with([
+    'jpeg' => ['out.jpg', 'image/jpeg'],
+    'webp' => ['out.webp', 'image/webp'],
+]);


### PR DESCRIPTION
## Summary

- Fixes the media editor's "Apply" action silently dropping images: rasterizing to a lossless PNG often exceeded the 8 MiB upload cap, so the composed image was rejected with a 422 and the post published with no media (fixes #126).
- The editor now encodes the composed export as compressed JPEG (opaque backgrounds) or WebP (transparent backgrounds), scaling down and stepping quality as needed to fit under the size limit.
- Updated the post and reply image-edit endpoints to accept `image/jpeg`, `image/png`, and `image/webp` composed uploads (previously PNG-only).
- Added coverage for the new export format selection and for the endpoints accepting compact JPEG/WebP uploads.


---

Fixes #126