### PR TITLE
fix(mentions): persist Meta handle edits on saved mentions

### DIFF
--- a/app/Http/Controllers/WorkspaceMentionController.php
+++ b/app/Http/Controllers/WorkspaceMentionController.php
@@ -14,19 +14,25 @@ class WorkspaceMentionController extends Controller
 {
     public function store(Request $request): JsonResponse
     {
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:80', 'regex:/^@[A-Za-z0-9_.-]+$/'],
-            'handles' => ['required', 'array'],
-            'handles.x' => ['nullable', 'string', 'max:255'],
-            'handles.bluesky' => ['nullable', 'string', 'max:255'],
-            'handles.linkedin' => ['nullable', 'string', 'max:255'],
-            'handles.linkedin_urn' => ['nullable', 'string', 'max:255'],
-        ]);
-
         $allowedPlatforms = array_map(
             static fn (Platform $platform): string => $platform->value,
             Platform::cases(),
         );
+
+        // Nested rules must cover every platform key: `validated()` strips any
+        // `handles.*` key without an explicit rule (excludeUnvalidatedArrayKeys),
+        // which silently dropped Meta handles before these rules were derived
+        // from the enum (issue #123).
+        $handleRules = [];
+        foreach ([...$allowedPlatforms, 'linkedin_urn'] as $handleKey) {
+            $handleRules['handles.'.$handleKey] = ['nullable', 'string', 'max:255'];
+        }
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:80', 'regex:/^@[A-Za-z0-9_.-]+$/'],
+            'handles' => ['required', 'array'],
+            ...$handleRules,
+        ]);
         $handles = [];
         foreach ($allowedPlatforms as $platform) {
             $handle = trim((string) ($validated['handles'][$platform] ?? ''));

--- a/app/Http/Controllers/WorkspaceMentionController.php
+++ b/app/Http/Controllers/WorkspaceMentionController.php
@@ -57,6 +57,16 @@ class WorkspaceMentionController extends Controller
         return response()->json(['mention' => self::view($mention)]);
     }
 
+    public function destroy(Request $request, string $workspaceMention): JsonResponse
+    {
+        WorkspaceMention::withoutGlobalScopes()
+            ->where('workspace_id', $request->user()->current_workspace_id)
+            ->findOrFail($workspaceMention)
+            ->delete();
+
+        return response()->json(['deleted' => true]);
+    }
+
     /**
      * @return array{id: string, name: string, handles: array<string, string>}
      */

--- a/resources/js/components/compose/__tests__/mention-picker.test.ts
+++ b/resources/js/components/compose/__tests__/mention-picker.test.ts
@@ -86,6 +86,23 @@ describe('saved mention editing', () => {
         expect(source).toContain('absolute right-2');
         expect(source).toContain('editSaved(saved)');
     });
+
+    it('renders a delete action alongside edit when deletion is enabled', () => {
+        const source = readFileSync(
+            resolve(
+                process.cwd(),
+                'resources/js/components/compose/mention-picker.tsx',
+            ),
+            'utf8',
+        );
+
+        expect(source).toContain('aria-label={`Delete ${saved.name}`}');
+        expect(source).toContain('onDeleteMention(saved)');
+        // Both actions coexist: the row widens and the edit icon shifts left
+        // to make room for the trash icon.
+        expect(source).toContain('pr-16');
+        expect(source).toContain('right-9');
+    });
 });
 
 describe('linkedin mention field', () => {

--- a/resources/js/components/compose/__tests__/mention-picker.test.tsx
+++ b/resources/js/components/compose/__tests__/mention-picker.test.tsx
@@ -10,10 +10,7 @@ import MentionPicker, {
     savedMentionSearchKeywords,
     shouldFocusMentionPickerSearch,
 } from '@/components/compose/mention-picker';
-import type {
-    MentionPlaceholder,
-    WorkspaceMention,
-} from '@/types/compose';
+import type { MentionPlaceholder, WorkspaceMention } from '@/types/compose';
 
 beforeAll(() => {
     globalThis.ResizeObserver = class {

--- a/resources/js/components/compose/__tests__/mention-picker.test.tsx
+++ b/resources/js/components/compose/__tests__/mention-picker.test.tsx
@@ -1,14 +1,28 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
-import {
+import MentionPicker, {
     editSavedMention,
     mentionFilter,
     savedMentionSearchKeywords,
     shouldFocusMentionPickerSearch,
 } from '@/components/compose/mention-picker';
+import type {
+    MentionPlaceholder,
+    WorkspaceMention,
+} from '@/types/compose';
+
+beforeAll(() => {
+    globalThis.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    };
+    Element.prototype.scrollIntoView = function scrollIntoView() {};
+});
 
 describe('savedMentionSearchKeywords', () => {
     it('includes platform handles without @ prefix', () => {
@@ -88,20 +102,92 @@ describe('saved mention editing', () => {
     });
 
     it('renders a delete action alongside edit when deletion is enabled', () => {
-        const source = readFileSync(
-            resolve(
-                process.cwd(),
-                'resources/js/components/compose/mention-picker.tsx',
-            ),
-            'utf8',
+        const savedMention: WorkspaceMention = {
+            id: 'workspace-mention',
+            name: '@saved',
+            handles: { x: '@saved_x' },
+        };
+        const activeMention: MentionPlaceholder = {
+            id: 'draft',
+            label: '',
+            handles: {},
+        };
+
+        const onApplySavedMention = vi.fn();
+        const onUpdateMention = vi.fn();
+        const onDeleteMention = vi.fn();
+
+        // Render with delete enabled
+        const { rerender, container } = render(
+            <MentionPicker
+                activeMention={activeMention}
+                savedMentions={[savedMention]}
+                activePlatforms={['x']}
+                onApplySavedMention={onApplySavedMention}
+                onUpdateMention={onUpdateMention}
+                onDeleteMention={onDeleteMention}
+            />,
         );
 
-        expect(source).toContain('aria-label={`Delete ${saved.name}`}');
-        expect(source).toContain('onDeleteMention(saved)');
-        // Both actions coexist: the row widens and the edit icon shifts left
-        // to make room for the trash icon.
-        expect(source).toContain('pr-16');
-        expect(source).toContain('right-9');
+        // Delete button should be present
+        const deleteButton = screen.getByRole('button', {
+            name: `Delete ${savedMention.name}`,
+        });
+        expect(deleteButton).toBeInTheDocument();
+
+        // Edit button should also be present
+        const editButton = screen.getByRole('button', {
+            name: `Edit ${savedMention.name}`,
+        });
+        expect(editButton).toBeInTheDocument();
+
+        // Layout: verify the row has wider padding for both buttons
+        const row = container.querySelector('.pr-16');
+        expect(row).toBeInTheDocument();
+
+        // Layout: verify edit button shifted left
+        expect(editButton.className).toContain('right-9');
+
+        // Click delete button
+        deleteButton.click();
+
+        // Should call onDeleteMention with the saved mention
+        expect(onDeleteMention).toHaveBeenCalledTimes(1);
+        expect(onDeleteMention).toHaveBeenCalledWith(savedMention);
+
+        // Should NOT call onApplySavedMention (event isolation)
+        expect(onApplySavedMention).not.toHaveBeenCalled();
+
+        // Click edit button
+        editButton.click();
+
+        // Should call onUpdateMention (edit still works alongside delete)
+        expect(onUpdateMention).toHaveBeenCalledTimes(1);
+        expect(onUpdateMention).toHaveBeenCalledWith(activeMention, {
+            id: 'saved',
+            label: '@saved',
+            handles: { x: '@saved_x' },
+        });
+
+        // Should still NOT call onApplySavedMention (edit event isolation)
+        expect(onApplySavedMention).not.toHaveBeenCalled();
+
+        // Render without delete
+        rerender(
+            <MentionPicker
+                activeMention={activeMention}
+                savedMentions={[savedMention]}
+                activePlatforms={['x']}
+                onApplySavedMention={onApplySavedMention}
+                onUpdateMention={onUpdateMention}
+            />,
+        );
+
+        // Delete button should be absent
+        const noDeleteButton = screen.queryByRole('button', {
+            name: `Delete ${savedMention.name}`,
+        });
+        expect(noDeleteButton).not.toBeInTheDocument();
     });
 });
 

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useReducer, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import WorkspaceMentionController from '@/actions/App/Http/Controllers/WorkspaceMentionController';
+import { useConfirm } from '@/components/common/confirm-dialog';
 import { useAutosave } from '@/hooks/compose/use-autosave';
 import { useEmojiPreferences } from '@/hooks/compose/use-emoji-preferences';
 import { useImageEditor } from '@/hooks/compose/use-image-editor';
@@ -176,10 +177,12 @@ export default function Composer({
     onSaved,
 }: ComposerProps) {
     const schedulingTz = useSchedulingTimezone();
+    const confirm = useConfirm();
     const saveMentionHttp = useHttp<
         Record<string, never>,
         { mention: WorkspaceMention }
     >({});
+    const deleteMentionHttp = useHttp<Record<string, never>, unknown>({});
     const [savedMentions, setSavedMentions] = useState(initialSavedMentions);
     useEffect(() => {
         setSavedMentions(initialSavedMentions);
@@ -710,6 +713,28 @@ export default function Composer({
         });
     }
 
+    async function deleteMention(saved: WorkspaceMention): Promise<void> {
+        const confirmed = await confirm({
+            title: `Delete ${saved.name}?`,
+            description:
+                'This removes the saved mention from your workspace library. Mentions already added to posts are unaffected.',
+            actionLabel: 'Delete mention',
+            destructive: true,
+        });
+
+        if (!confirmed) {
+            return;
+        }
+
+        await deleteMentionHttp.delete(
+            WorkspaceMentionController.destroy(saved.id).url,
+        );
+
+        setSavedMentions((current) =>
+            current.filter((item) => item.id !== saved.id),
+        );
+    }
+
     function handleSegments(segments: string[]) {
         const manualSplit = segments.length > 1;
         if (
@@ -920,6 +945,7 @@ export default function Composer({
                     onApplySavedMention={applySavedMention}
                     onSaveMention={saveMention}
                     saveMentionProcessing={saveMentionHttp.processing}
+                    onDeleteMention={deleteMention}
                     onMentionsChange={(mentions) =>
                         dispatch({ type: 'setMentions', mentions })
                     }

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -80,6 +80,7 @@ type EditorBodyProps = {
     ) => void;
     onSaveMention?: (mention: MentionPlaceholder) => Promise<void>;
     saveMentionProcessing?: boolean;
+    onDeleteMention?: (saved: WorkspaceMention) => void | Promise<void>;
     markerState?: {
         platform: PlatformName;
         autoSplit: boolean;
@@ -152,6 +153,7 @@ function EditorBodyInner(
         onApplySavedMention,
         onSaveMention,
         saveMentionProcessing = false,
+        onDeleteMention,
         editable = true,
         emojiSkinTone = 'none',
         onEmojiInsert,
@@ -534,6 +536,7 @@ function EditorBodyInner(
                             onUpdateMention={updateMention}
                             onSaveMention={onSaveMention}
                             saveMentionProcessing={saveMentionProcessing}
+                            onDeleteMention={onDeleteMention}
                             onMentionComplete={completeMention}
                             onRemoveMention={removeActiveMention}
                         />

--- a/resources/js/components/compose/mention-picker.tsx
+++ b/resources/js/components/compose/mention-picker.tsx
@@ -1,4 +1,12 @@
-import { ArrowLeft, Building2, Info, Pencil, Plus, X } from 'lucide-react';
+import {
+    ArrowLeft,
+    Building2,
+    Info,
+    Pencil,
+    Plus,
+    Trash2,
+    X,
+} from 'lucide-react';
 import { useEffect, useMemo, useRef, useState, type RefObject } from 'react';
 
 import { PlatformGlyph } from '@/components/common/platform-glyph';
@@ -49,6 +57,8 @@ type MentionPickerProps = {
     ) => void;
     onSaveMention?: (mention: MentionPlaceholder) => Promise<void>;
     saveMentionProcessing?: boolean;
+    /** Delete a saved mention from the workspace library. Hidden when omitted. */
+    onDeleteMention?: (saved: WorkspaceMention) => void | Promise<void>;
     onMentionComplete?: (mention: MentionPlaceholder) => void;
     /** Discard the in-progress mention (Backspace on an empty search field). */
     onRemoveMention?: () => void;
@@ -113,6 +123,7 @@ export default function MentionPicker({
     onUpdateMention,
     onSaveMention,
     saveMentionProcessing = false,
+    onDeleteMention,
     onMentionComplete,
     onRemoveMention,
 }: MentionPickerProps) {
@@ -254,7 +265,10 @@ export default function MentionPicker({
                                 value={saved.name}
                                 keywords={savedMentionKeywords.get(saved.id)}
                                 onSelect={() => selectSaved(saved)}
-                                className="relative flex items-center gap-3 pr-9"
+                                className={cn(
+                                    'relative flex items-center gap-3',
+                                    onDeleteMention ? 'pr-16' : 'pr-9',
+                                )}
                             >
                                 <span className="font-medium">
                                     {saved.name}
@@ -283,10 +297,32 @@ export default function MentionPicker({
                                         event.stopPropagation();
                                         editSaved(saved);
                                     }}
-                                    className="absolute right-2 inline-flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                                    className={cn(
+                                        'absolute inline-flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground',
+                                        onDeleteMention ? 'right-9' : 'right-2',
+                                    )}
                                 >
                                     <Pencil className="size-3.5" aria-hidden />
                                 </button>
+                                {onDeleteMention && (
+                                    <button
+                                        type="button"
+                                        aria-label={`Delete ${saved.name}`}
+                                        onPointerDown={(event) =>
+                                            event.stopPropagation()
+                                        }
+                                        onClick={(event) => {
+                                            event.stopPropagation();
+                                            void onDeleteMention(saved);
+                                        }}
+                                        className="absolute right-2 inline-flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                                    >
+                                        <Trash2
+                                            className="size-3.5"
+                                            aria-hidden
+                                        />
+                                    </button>
+                                )}
                             </CommandItem>
                         ))}
                     </CommandGroup>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ Route::get('/share/{token}', [PublicShareController::class, 'show'])
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard');
     Route::post('workspace-mentions', [WorkspaceMentionController::class, 'store'])->name('workspace-mentions.store');
+    Route::delete('workspace-mentions/{workspaceMention}', [WorkspaceMentionController::class, 'destroy'])->name('workspace-mentions.destroy');
 });
 
 Route::middleware('auth')->group(function () {

--- a/tests/Feature/WorkspaceMentionTest.php
+++ b/tests/Feature/WorkspaceMentionTest.php
@@ -127,6 +127,45 @@ it('persists an edited Meta plain-text value on update', function () {
         ->toBe(['facebook' => 'Company X Inc.']);
 });
 
+it('deletes a saved mention for the current workspace', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    Context::add('workspace_id', $workspace->id);
+    $mention = WorkspaceMention::factory()->create([
+        'workspace_id' => $workspace->id,
+        'name' => '@company-x',
+        'handles' => ['x' => '@companyx'],
+    ]);
+
+    $this->actingAs($user)
+        ->deleteJson(route('workspace-mentions.destroy', $mention))
+        ->assertSuccessful();
+
+    expect(WorkspaceMention::query()->withoutGlobalScopes()->find($mention->id))
+        ->toBeNull();
+});
+
+it('cannot delete a mention belonging to another workspace', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    Context::add('workspace_id', $workspace->id);
+
+    $otherWorkspace = Workspace::factory()->create();
+    $foreignMention = WorkspaceMention::factory()->create([
+        'workspace_id' => $otherWorkspace->id,
+        'name' => '@foreign',
+    ]);
+
+    $this->actingAs($user)
+        ->deleteJson(route('workspace-mentions.destroy', $foreignMention))
+        ->assertNotFound();
+
+    expect(WorkspaceMention::query()->withoutGlobalScopes()->find($foreignMention->id))
+        ->not->toBeNull();
+});
+
 it('normalizes a saved LinkedIn org reference into a canonical URN', function () {
     $user = User::factory()->create();
     $workspace = Workspace::factory()->create(['owner_id' => $user->id]);

--- a/tests/Feature/WorkspaceMentionTest.php
+++ b/tests/Feature/WorkspaceMentionTest.php
@@ -80,6 +80,53 @@ it('preserves saved display text for people without a platform mention', functio
         ->assertJsonPath('mention.handles.linkedin', 'Taylor Otwell');
 });
 
+it('round-trips Meta platform handles on create', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    Context::add('workspace_id', $workspace->id);
+
+    $this->actingAs($user)
+        ->postJson(route('workspace-mentions.store'), [
+            'name' => '@company-x',
+            'handles' => [
+                'facebook' => 'Company X',
+                'instagram' => 'companyx',
+                'threads' => 'companyx',
+            ],
+        ])
+        ->assertSuccessful()
+        ->assertJsonPath('mention.handles.facebook', 'Company X')
+        ->assertJsonPath('mention.handles.instagram', 'companyx')
+        ->assertJsonPath('mention.handles.threads', 'companyx');
+
+    expect(WorkspaceMention::query()->first()->handles)
+        ->toBe(['facebook' => 'Company X', 'instagram' => 'companyx', 'threads' => 'companyx']);
+});
+
+it('persists an edited Meta plain-text value on update', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    Context::add('workspace_id', $workspace->id);
+    WorkspaceMention::factory()->create([
+        'workspace_id' => $workspace->id,
+        'name' => '@company-x',
+        'handles' => ['facebook' => 'Company X'],
+    ]);
+
+    $this->actingAs($user)
+        ->postJson(route('workspace-mentions.store'), [
+            'name' => '@company-x',
+            'handles' => ['facebook' => 'Company X Inc.'],
+        ])
+        ->assertSuccessful()
+        ->assertJsonPath('mention.handles.facebook', 'Company X Inc.');
+
+    expect(WorkspaceMention::query()->where('name', '@company-x')->first()->handles)
+        ->toBe(['facebook' => 'Company X Inc.']);
+});
+
 it('normalizes a saved LinkedIn org reference into a canonical URN', function () {
     $user = User::factory()->create();
     $workspace = Workspace::factory()->create(['owner_id' => $user->id]);


### PR DESCRIPTION
## Summary
- Fixes saved mention validation so `handles.*` rules cover every platform (including Meta: Facebook, Instagram, Threads); previously unlisted keys were silently stripped on save, causing edited values to revert on reload (fixes #123)
- Adds a delete action to the saved mentions list in the mention picker, with a confirmation dialog before removing a mention from the workspace library
- Adds a `DELETE /workspace-mentions/{workspaceMention}` endpoint, scoped to the current workspace

## Breaking Changes
None


---

Fixes #123