### PR TITLE
Use curl based healthcheck with app's route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -181,6 +181,7 @@ ENV PHP_OPCACHE_ENABLE=${PHP_OPCACHE_ENABLE} \
     APP_BASE_DIR=/var/www/html \
     SSL_MODE=${SSL_MODE} \
     OCTANE_SERVER=frankenphp \
+    HEALTHCHECK_PATH=/up \
     QUEUE_WORKER_COUNT=${QUEUE_WORKER_COUNT}
 
 # Supervisor supervises the web/worker/scheduler/ssr processes


### PR DESCRIPTION
When running with docker compose, the override works fine. When running with plain docker run, the image's built-in healthcheck is used and fails. Adding HEALTHCHECK_PATH=/up to the Dockerfile's ENV overrides the base image's default. Since Docker layers ENV values (last wins), the HEALTHCHECK instruction then curls http://localhost:8080/up