### PR TITLE
feat(posts): add "copy as draft" action for posts

### DIFF
--- a/app/Http/Controllers/Posts/PostController.php
+++ b/app/Http/Controllers/Posts/PostController.php
@@ -118,6 +118,12 @@ class PostController extends Controller
     {
         $request->user()->can('create', Post::class) ?: abort(403);
 
+        // Only terminal posts are eligible — mirror the client capability model
+        // so the endpoint contract can't be bypassed for a draft/scheduled post.
+        in_array($post->status, [
+            PostStatus::Published, PostStatus::Partial, PostStatus::Failed, PostStatus::Missed,
+        ], true) ?: abort(422, 'This post cannot be copied to a draft.');
+
         $draft = $duplicator->duplicate($post);
 
         return redirect()->route('posts.show', $draft)->with('success', 'Copied to a new draft.');

--- a/app/Http/Controllers/Posts/PostController.php
+++ b/app/Http/Controllers/Posts/PostController.php
@@ -15,6 +15,7 @@ use App\Models\AccountSet;
 use App\Models\Post;
 use App\Models\PostTarget;
 use App\Services\Posts\DraftService;
+use App\Services\Posts\PostDuplicator;
 use App\Services\Posts\PostStaleWriteException;
 use App\Support\PostListItem;
 use App\Support\PostView;
@@ -111,6 +112,15 @@ class PostController extends Controller
         }
 
         return response()->json(['post' => PostView::make($updated->fresh(['targets.account', 'media']))]);
+    }
+
+    public function duplicate(Request $request, Post $post, PostDuplicator $duplicator): RedirectResponse
+    {
+        $request->user()->can('create', Post::class) ?: abort(403);
+
+        $draft = $duplicator->duplicate($post);
+
+        return redirect()->route('posts.show', $draft)->with('success', 'Copied to a new draft.');
     }
 
     public function destroy(Request $request, Post $post): RedirectResponse

--- a/app/Services/Posts/PostDuplicator.php
+++ b/app/Services/Posts/PostDuplicator.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Posts;
+
+use App\Enums\PostStatus;
+use App\Models\ConnectedAccount;
+use App\Models\Post;
+use App\Models\PostMedia;
+use App\Models\PostTarget;
+use App\Support\FileStorage;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class PostDuplicator
+{
+    /**
+     * Clone a post into a fresh draft: copy text, mentions, media (as new
+     * files + rows) and per-account targets, resetting all publish state.
+     * New draft targets rely on DB defaults for status/attempts/metrics
+     * (status defaults to `pending`), so only content fields are carried.
+     */
+    public function duplicate(Post $source): Post
+    {
+        return DB::transaction(function () use ($source): Post {
+            $source->loadMissing('media', 'targets');
+
+            $draft = Post::create([
+                'workspace_id' => $source->workspace_id,
+                'account_set_id' => $source->account_set_id,
+                'author_id' => $source->author_id,
+                'segments' => $source->segments,
+                'base_text' => $source->base_text,
+                'mentions' => $source->mentions,
+                'status' => PostStatus::Draft->value,
+                'auto_repost' => $source->auto_repost,
+            ]);
+
+            $mediaIdMap = $this->cloneMedia($source, $draft);
+            $this->cloneTargets($source, $draft, $mediaIdMap);
+
+            return $draft->load('targets', 'media');
+        });
+    }
+
+    /**
+     * Copy every media row and its backing file(s) onto the draft.
+     *
+     * @return array<string, string> old media id => new media id
+     */
+    private function cloneMedia(Post $source, Post $draft): array
+    {
+        $map = [];
+
+        foreach ($source->media as $media) {
+            $newSourcePath = $media->source_path === null
+                ? null
+                : $this->copyFile($media->source_disk ?? $media->disk, $media->source_path);
+
+            $copy = PostMedia::create([
+                'workspace_id' => $draft->workspace_id,
+                'post_id' => $draft->id,
+                'disk' => $media->disk,
+                'path' => $this->copyFile($media->disk, $media->path),
+                'mime' => $media->mime,
+                'size_bytes' => $media->size_bytes,
+                'width' => $media->width,
+                'height' => $media->height,
+                'alt_text' => $media->alt_text,
+                'position' => $media->position,
+                'kind' => $media->kind,
+                'duration_seconds' => $media->duration_seconds,
+                'source_disk' => $newSourcePath === null ? null : ($media->source_disk ?? $media->disk),
+                'source_path' => $newSourcePath,
+                'edit_settings' => $media->edit_settings,
+            ]);
+
+            $map[$media->id] = $copy->id;
+        }
+
+        return $map;
+    }
+
+    private function copyFile(string $disk, string $path): string
+    {
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+        $newPath = 'media/'.Str::uuid()->toString().($extension === '' ? '' : '.'.$extension);
+
+        FileStorage::disk($disk)->copy($path, $newPath);
+
+        return $newPath;
+    }
+
+    /**
+     * Recreate one target per still-existing account; skip accounts that were
+     * hard-deleted. Publish/metric fields fall back to their DB defaults.
+     *
+     * @param  array<string, string>  $mediaIdMap
+     */
+    private function cloneTargets(Post $source, Post $draft, array $mediaIdMap): void
+    {
+        $existingAccountIds = ConnectedAccount::withoutGlobalScopes()
+            ->where('workspace_id', $source->workspace_id)
+            ->whereIn('id', $source->targets->pluck('connected_account_id'))
+            ->pluck('id')
+            ->all();
+
+        foreach ($source->targets as $target) {
+            if (! in_array($target->connected_account_id, $existingAccountIds, true)) {
+                continue;
+            }
+
+            PostTarget::create([
+                'post_id' => $draft->id,
+                'connected_account_id' => $target->connected_account_id,
+                'platform' => $target->platform->value,
+                'sections' => $target->sections,
+                'content_override' => $this->remapOverride($target->content_override, $mediaIdMap),
+                'auto_split' => $target->auto_split,
+                'format' => $target->format->value,
+            ]);
+        }
+    }
+
+    /**
+     * Point an override's `media_ids` at the cloned media rows.
+     *
+     * @param  array{text?: string|null, media_ids?: list<string>}|null  $override
+     * @param  array<string, string>  $mediaIdMap
+     * @return array{text?: string|null, media_ids?: list<string>}|null
+     */
+    private function remapOverride(?array $override, array $mediaIdMap): ?array
+    {
+        if ($override === null || ! isset($override['media_ids'])) {
+            return $override;
+        }
+
+        $override['media_ids'] = array_map(
+            static fn (string $id): string => $mediaIdMap[$id] ?? $id,
+            $override['media_ids'],
+        );
+
+        return $override;
+    }
+}

--- a/app/Services/Posts/PostDuplicator.php
+++ b/app/Services/Posts/PostDuplicator.php
@@ -12,6 +12,7 @@ use App\Models\PostTarget;
 use App\Support\FileStorage;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Throwable;
 
 class PostDuplicator
 {
@@ -20,49 +21,92 @@ class PostDuplicator
      * files + rows) and per-account targets, resetting all publish state.
      * New draft targets rely on DB defaults for status/attempts/metrics
      * (status defaults to `pending`), so only content fields are carried.
+     *
+     * Backing files are copied *before* the DB transaction — a media disk is a
+     * private S3 bucket in production, and a blocking network copy has no place
+     * holding a DB connection/locks open. Any file written is tracked so a
+     * failure anywhere rolls back the rows *and* deletes the orphaned copies.
      */
     public function duplicate(Post $source): Post
     {
-        return DB::transaction(function () use ($source): Post {
-            $source->loadMissing('media', 'targets');
+        $source->loadMissing('media', 'targets');
 
-            $draft = Post::create([
-                'workspace_id' => $source->workspace_id,
-                'account_set_id' => $source->account_set_id,
-                'author_id' => $source->author_id,
-                'segments' => $source->segments,
-                'base_text' => $source->base_text,
-                'mentions' => $source->mentions,
-                'status' => PostStatus::Draft->value,
-                'auto_repost' => $source->auto_repost,
-            ]);
+        /** @var list<array{0: string, 1: string}> $copiedPaths */
+        $copiedPaths = [];
 
-            $mediaIdMap = $this->cloneMedia($source, $draft);
-            $this->cloneTargets($source, $draft, $mediaIdMap);
+        try {
+            $mediaPlan = $this->copyMediaFiles($source, $copiedPaths);
 
-            return $draft->load('targets', 'media');
-        });
+            return DB::transaction(function () use ($source, $mediaPlan): Post {
+                $draft = Post::create([
+                    'workspace_id' => $source->workspace_id,
+                    'account_set_id' => $source->account_set_id,
+                    'author_id' => $source->author_id,
+                    'segments' => $source->segments,
+                    'base_text' => $source->base_text,
+                    'mentions' => $source->mentions,
+                    'status' => PostStatus::Draft->value,
+                    'auto_repost' => $source->auto_repost,
+                ]);
+
+                $mediaIdMap = $this->createMediaRows($draft, $mediaPlan);
+                $this->cloneTargets($source, $draft, $mediaIdMap);
+
+                return $draft->load('targets', 'media');
+            });
+        } catch (Throwable $e) {
+            foreach ($copiedPaths as [$disk, $path]) {
+                FileStorage::disk($disk)->delete($path);
+            }
+
+            throw $e;
+        }
     }
 
     /**
-     * Copy every media row and its backing file(s) onto the draft.
+     * Copy each media file (and any retained pre-edit source) to a fresh path,
+     * recording every written path in $copiedPaths for rollback cleanup.
      *
+     * @param  list<array{0: string, 1: string}>  $copiedPaths
+     * @return list<array{media: PostMedia, path: string, source_path: string|null}>
+     */
+    private function copyMediaFiles(Post $source, array &$copiedPaths): array
+    {
+        $plan = [];
+
+        foreach ($source->media as $media) {
+            $path = $this->copyFile($media->disk, $media->path);
+            $copiedPaths[] = [$media->disk, $path];
+
+            $sourcePath = null;
+            if ($media->source_path !== null) {
+                $sourceDisk = $media->source_disk ?? $media->disk;
+                $sourcePath = $this->copyFile($sourceDisk, $media->source_path);
+                $copiedPaths[] = [$sourceDisk, $sourcePath];
+            }
+
+            $plan[] = ['media' => $media, 'path' => $path, 'source_path' => $sourcePath];
+        }
+
+        return $plan;
+    }
+
+    /**
+     * Create the draft's media rows from the pre-copied files.
+     *
+     * @param  list<array{media: PostMedia, path: string, source_path: string|null}>  $plan
      * @return array<string, string> old media id => new media id
      */
-    private function cloneMedia(Post $source, Post $draft): array
+    private function createMediaRows(Post $draft, array $plan): array
     {
         $map = [];
 
-        foreach ($source->media as $media) {
-            $newSourcePath = $media->source_path === null
-                ? null
-                : $this->copyFile($media->source_disk ?? $media->disk, $media->source_path);
-
+        foreach ($plan as ['media' => $media, 'path' => $path, 'source_path' => $sourcePath]) {
             $copy = PostMedia::create([
                 'workspace_id' => $draft->workspace_id,
                 'post_id' => $draft->id,
                 'disk' => $media->disk,
-                'path' => $this->copyFile($media->disk, $media->path),
+                'path' => $path,
                 'mime' => $media->mime,
                 'size_bytes' => $media->size_bytes,
                 'width' => $media->width,
@@ -71,8 +115,8 @@ class PostDuplicator
                 'position' => $media->position,
                 'kind' => $media->kind,
                 'duration_seconds' => $media->duration_seconds,
-                'source_disk' => $newSourcePath === null ? null : ($media->source_disk ?? $media->disk),
-                'source_path' => $newSourcePath,
+                'source_disk' => $sourcePath === null ? null : ($media->source_disk ?? $media->disk),
+                'source_path' => $sourcePath,
                 'edit_settings' => $media->edit_settings,
             ]);
 

--- a/composer.lock
+++ b/composer.lock
@@ -1158,16 +1158,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
@@ -1266,7 +1266,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -1282,7 +1282,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",

--- a/resources/js/components/posts/post-page-actions.tsx
+++ b/resources/js/components/posts/post-page-actions.tsx
@@ -58,6 +58,7 @@ export function PostPageActions({ post }: Props) {
     const [rescheduling, setRescheduling] = useState(false);
     const [pickedAt, setPickedAt] = useState<string>(() => defaultPickedAt(tz));
     const [shareOpen, setShareOpen] = useState(false);
+    const [duplicating, setDuplicating] = useState(false);
 
     // Re-render each minute so the relative "going live" label stays current.
     const [, setTick] = useState(0);
@@ -76,7 +77,15 @@ export function PostPageActions({ post }: Props) {
     }
 
     function handleDuplicate() {
-        router.post(PostController.duplicate(post.id).url);
+        if (duplicating) {
+            return;
+        }
+        setDuplicating(true);
+        router.post(
+            PostController.duplicate(post.id).url,
+            {},
+            { onFinish: () => setDuplicating(false) },
+        );
     }
 
     function openReschedule() {
@@ -246,6 +255,7 @@ export function PostPageActions({ post }: Props) {
                             size="sm"
                             variant="outline"
                             aria-label="Copy as draft"
+                            disabled={duplicating}
                             onClick={handleDuplicate}
                         >
                             <Copy className="size-3.5" aria-hidden />

--- a/resources/js/components/posts/post-page-actions.tsx
+++ b/resources/js/components/posts/post-page-actions.tsx
@@ -2,6 +2,7 @@ import { Link, router, useHttp, usePage } from '@inertiajs/react';
 import {
     CalendarClock,
     CalendarX,
+    Copy,
     MessageCircle,
     RotateCw,
     Share2,
@@ -72,6 +73,10 @@ export function PostPageActions({ post }: Props) {
         router.visit(ComposerController.show(post.id).url, {
             preserveScroll: true,
         });
+    }
+
+    function handleDuplicate() {
+        router.post(PostController.duplicate(post.id).url);
     }
 
     function openReschedule() {
@@ -234,6 +239,19 @@ export function PostPageActions({ post }: Props) {
                         >
                             <Share2 className="size-3.5" aria-hidden />
                             <span className="hidden sm:inline">Share</span>
+                        </Button>
+                    )}
+                    {caps.canDuplicate && (
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            aria-label="Copy as draft"
+                            onClick={handleDuplicate}
+                        >
+                            <Copy className="size-3.5" aria-hidden />
+                            <span className="hidden sm:inline">
+                                Copy as draft
+                            </span>
                         </Button>
                     )}
                     {caps.canDelete && (

--- a/resources/js/components/posts/post-row-actions.tsx
+++ b/resources/js/components/posts/post-row-actions.tsx
@@ -72,6 +72,10 @@ export function PostRowActions({ post }: Props) {
         router.visit(ComposerController.show(post.id).url);
     }
 
+    function handleDuplicate() {
+        router.post(PostController.duplicate(post.id).url);
+    }
+
     function openSchedule() {
         setPickedAt(defaultPickedAt(tz));
         setMode('scheduling');
@@ -267,6 +271,11 @@ export function PostRowActions({ post }: Props) {
                     <DropdownMenuItem onClick={() => setShareOpen(true)}>
                         Share&hellip;
                     </DropdownMenuItem>
+                    {caps.canDuplicate && (
+                        <DropdownMenuItem onClick={handleDuplicate}>
+                            Copy as draft
+                        </DropdownMenuItem>
+                    )}
                     {caps.canDelete && (
                         <DropdownMenuItem
                             variant="destructive"

--- a/resources/js/components/posts/post-row-actions.tsx
+++ b/resources/js/components/posts/post-row-actions.tsx
@@ -67,13 +67,22 @@ export function PostRowActions({ post }: Props) {
     const [mode, setMode] = useState<Mode>('menu');
     const [pickedAt, setPickedAt] = useState<string>(() => defaultPickedAt(tz));
     const [shareOpen, setShareOpen] = useState(false);
+    const [duplicating, setDuplicating] = useState(false);
 
     function handleEdit() {
         router.visit(ComposerController.show(post.id).url);
     }
 
     function handleDuplicate() {
-        router.post(PostController.duplicate(post.id).url);
+        if (duplicating) {
+            return;
+        }
+        setDuplicating(true);
+        router.post(
+            PostController.duplicate(post.id).url,
+            {},
+            { onFinish: () => setDuplicating(false) },
+        );
     }
 
     function openSchedule() {
@@ -272,7 +281,10 @@ export function PostRowActions({ post }: Props) {
                         Share&hellip;
                     </DropdownMenuItem>
                     {caps.canDuplicate && (
-                        <DropdownMenuItem onClick={handleDuplicate}>
+                        <DropdownMenuItem
+                            disabled={duplicating}
+                            onClick={handleDuplicate}
+                        >
                             Copy as draft
                         </DropdownMenuItem>
                     )}

--- a/resources/js/lib/posts/__tests__/capabilities.test.ts
+++ b/resources/js/lib/posts/__tests__/capabilities.test.ts
@@ -19,25 +19,27 @@ function post(partial: Partial<PostView>): PostView {
 }
 
 describe('postCapabilities', () => {
-    it('draft: edit/schedule/delete', () => {
+    it('draft: edit/schedule/delete, no duplicate', () => {
         const c = postCapabilities(post({ status: 'draft' }));
         expect(c).toMatchObject({
             canEdit: true,
             canSchedule: true,
             canDelete: true,
             canReschedule: false,
+            canDuplicate: false,
         });
     });
-    it('scheduled: edit/reschedule/unschedule/delete', () => {
+    it('scheduled: edit/reschedule/unschedule/delete, no duplicate', () => {
         const c = postCapabilities(post({ status: 'scheduled' }));
         expect(c).toMatchObject({
             canReschedule: true,
             canUnschedule: true,
             canDelete: true,
             canSchedule: false,
+            canDuplicate: false,
         });
     });
-    it('failed with a failed target: delete + retry', () => {
+    it('failed with a failed target: delete + retry + duplicate', () => {
         const c = postCapabilities(
             post({
                 status: 'failed',
@@ -48,6 +50,23 @@ describe('postCapabilities', () => {
             canDelete: true,
             canRetry: true,
             canEdit: false,
+            canDuplicate: true,
+        });
+    });
+    it('published: delete + duplicate', () => {
+        const c = postCapabilities(post({ status: 'published' }));
+        expect(c).toMatchObject({
+            canDelete: true,
+            canDuplicate: true,
+            canRetry: false,
+        });
+    });
+    it('missed: reschedule + delete + duplicate', () => {
+        const c = postCapabilities(post({ status: 'missed' }));
+        expect(c).toMatchObject({
+            canReschedule: true,
+            canDelete: true,
+            canDuplicate: true,
         });
     });
     it('publishing/deleted: nothing', () => {

--- a/resources/js/lib/posts/capabilities.ts
+++ b/resources/js/lib/posts/capabilities.ts
@@ -7,6 +7,7 @@ export interface PostCapabilities {
     canUnschedule: boolean;
     canDelete: boolean;
     canRetry: boolean;
+    canDuplicate: boolean;
 }
 
 const NONE: PostCapabilities = {
@@ -16,6 +17,7 @@ const NONE: PostCapabilities = {
     canUnschedule: false,
     canDelete: false,
     canRetry: false,
+    canDuplicate: false,
 };
 
 export function postCapabilities(post: PostView): PostCapabilities {
@@ -43,11 +45,21 @@ export function postCapabilities(post: PostView): PostCapabilities {
         case 'missed':
             // A post the scheduler skipped as too stale: let the user reschedule
             // it back into the pipeline (→ scheduled) or discard it.
-            return { ...NONE, canReschedule: true, canDelete: true };
+            return {
+                ...NONE,
+                canReschedule: true,
+                canDelete: true,
+                canDuplicate: true,
+            };
         case 'published':
         case 'partial':
         case 'failed':
-            return { ...NONE, canDelete: true, canRetry: hasFailedTarget };
+            return {
+                ...NONE,
+                canDelete: true,
+                canRetry: hasFailedTarget,
+                canDuplicate: true,
+            };
         default:
             return NONE;
     }

--- a/routes/posts.php
+++ b/routes/posts.php
@@ -66,6 +66,7 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::put('posts/{post}', [PostController::class, 'update'])->name('posts.update');
     Route::get('posts/{post}', [ComposerController::class, 'show'])->name('posts.show');
     Route::delete('posts/{post}', [PostController::class, 'destroy'])->name('posts.destroy');
+    Route::post('posts/{post}/duplicate', [PostController::class, 'duplicate'])->name('posts.duplicate');
     Route::put('posts/{post}/schedule', [PostScheduleController::class, 'update'])->name('posts.schedule');
     Route::post('posts/{post}/queue', [PostQueueController::class, 'store'])->name('posts.queue');
     Route::post('posts/{post}/publish', [PublishController::class, 'store'])->name('posts.publish');

--- a/routes/posts.php
+++ b/routes/posts.php
@@ -66,7 +66,9 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::put('posts/{post}', [PostController::class, 'update'])->name('posts.update');
     Route::get('posts/{post}', [ComposerController::class, 'show'])->name('posts.show');
     Route::delete('posts/{post}', [PostController::class, 'destroy'])->name('posts.destroy');
-    Route::post('posts/{post}/duplicate', [PostController::class, 'duplicate'])->name('posts.duplicate');
+    // Throttled: each call copies every media file on the source post.
+    Route::post('posts/{post}/duplicate', [PostController::class, 'duplicate'])
+        ->middleware('throttle:30,1')->name('posts.duplicate');
     Route::put('posts/{post}/schedule', [PostScheduleController::class, 'update'])->name('posts.schedule');
     Route::post('posts/{post}/queue', [PostQueueController::class, 'store'])->name('posts.queue');
     Route::post('posts/{post}/publish', [PublishController::class, 'store'])->name('posts.publish');

--- a/tests/Feature/Posts/PostDuplicateTest.php
+++ b/tests/Feature/Posts/PostDuplicateTest.php
@@ -135,6 +135,19 @@ test('targets for deleted accounts are skipped', function (): void {
     expect($draft->targets()->count())->toBe(0);
 });
 
+test('a draft post is not eligible to be copied', function (): void {
+    $post = Post::factory()->for($this->workspace)->create([
+        'author_id' => $this->user->id,
+        'status' => PostStatus::Draft->value,
+    ]);
+
+    $this->actingAs($this->user)
+        ->post(route('posts.duplicate', $post))
+        ->assertStatus(422);
+
+    expect(Post::query()->where('status', PostStatus::Draft->value)->count())->toBe(1);
+});
+
 test('a post from another workspace cannot be duplicated', function (): void {
     $post = publishedPostWithMediaAndTarget($this->workspace, $this->user);
     [$other] = duplicateMember();

--- a/tests/Feature/Posts/PostDuplicateTest.php
+++ b/tests/Feature/Posts/PostDuplicateTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PostStatus;
+use App\Enums\PostTargetStatus;
+use App\Enums\WorkspaceRole;
+use App\Models\ConnectedAccount;
+use App\Models\Post;
+use App\Models\PostMedia;
+use App\Models\PostTarget;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * A workspace member whose current workspace + request Context are set, so
+ * post route-model binding resolves and the PostPolicy passes.
+ *
+ * @return array{0: User, 1: Workspace}
+ */
+function duplicateMember(): array
+{
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'role' => WorkspaceRole::Member,
+    ]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    Context::add('workspace_id', $workspace->id);
+
+    return [$user, $workspace];
+}
+
+/**
+ * A published post with one image (real fake file) and one published target
+ * carrying a per-account content override that references the media.
+ */
+function publishedPostWithMediaAndTarget(Workspace $workspace, User $user): Post
+{
+    $account = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+
+    $post = Post::factory()->for($workspace)->create([
+        'author_id' => $user->id,
+        'segments' => ['Hello world'],
+        'base_text' => 'Hello world',
+        'mentions' => [],
+        'status' => PostStatus::Published->value,
+        'published_at' => now(),
+        'auto_repost' => true,
+    ]);
+
+    Storage::disk('public')->put('media/original.jpg', 'IMG');
+    $media = PostMedia::factory()->for($workspace)->create([
+        'post_id' => $post->id,
+        'disk' => 'public',
+        'path' => 'media/original.jpg',
+        'position' => 0,
+    ]);
+
+    PostTarget::factory()->published()->create([
+        'post_id' => $post->id,
+        'connected_account_id' => $account->id,
+        'content_override' => ['text' => 'Custom', 'media_ids' => [$media->id]],
+    ]);
+
+    return $post->load('media', 'targets');
+}
+
+beforeEach(function (): void {
+    Storage::fake('public');
+    [$this->user, $this->workspace] = duplicateMember();
+});
+
+test('duplicating a published post creates a reset draft copy', function (): void {
+    $post = publishedPostWithMediaAndTarget($this->workspace, $this->user);
+
+    $response = $this->actingAs($this->user)->post(route('posts.duplicate', $post));
+
+    $draft = Post::query()->where('status', PostStatus::Draft->value)->firstOrFail();
+
+    $response->assertRedirect(route('posts.show', $draft));
+    expect($draft->id)->not->toBe($post->id)
+        ->and($draft->workspace_id)->toBe($this->workspace->id)
+        ->and($draft->segments)->toBe(['Hello world'])
+        ->and($draft->auto_repost)->toBeTrue()
+        ->and($draft->scheduled_at)->toBeNull()
+        ->and($draft->published_at)->toBeNull();
+});
+
+test('cloned media is a new file that survives deleting the original post', function (): void {
+    $post = publishedPostWithMediaAndTarget($this->workspace, $this->user);
+
+    $this->actingAs($this->user)->post(route('posts.duplicate', $post));
+
+    $draft = Post::query()->where('status', PostStatus::Draft->value)->firstOrFail();
+    $copy = $draft->media()->firstOrFail();
+
+    expect($copy->path)->not->toBe('media/original.jpg')
+        ->and(Storage::disk('public')->exists($copy->path))->toBeTrue();
+
+    $post->media()->firstOrFail()->delete();
+
+    expect(Storage::disk('public')->exists($copy->path))->toBeTrue();
+});
+
+test('cloned target is pending with overrides preserved and media ids remapped', function (): void {
+    $post = publishedPostWithMediaAndTarget($this->workspace, $this->user);
+
+    $this->actingAs($this->user)->post(route('posts.duplicate', $post));
+
+    $draft = Post::query()->where('status', PostStatus::Draft->value)->firstOrFail();
+    $target = $draft->targets()->firstOrFail();
+    $newMedia = $draft->media()->firstOrFail();
+
+    expect($target->status)->toBe(PostTargetStatus::Pending)
+        ->and($target->remote_id)->toBeNull()
+        ->and($target->posted_at)->toBeNull()
+        ->and($target->content_override['text'])->toBe('Custom')
+        ->and($target->content_override['media_ids'])->toBe([$newMedia->id]);
+});
+
+test('targets for deleted accounts are skipped', function (): void {
+    $post = publishedPostWithMediaAndTarget($this->workspace, $this->user);
+    $post->targets()->firstOrFail()->account->forceDelete();
+
+    $this->actingAs($this->user)->post(route('posts.duplicate', $post));
+
+    $draft = Post::query()->where('status', PostStatus::Draft->value)->firstOrFail();
+
+    expect($draft->targets()->count())->toBe(0);
+});
+
+test('a post from another workspace cannot be duplicated', function (): void {
+    $post = publishedPostWithMediaAndTarget($this->workspace, $this->user);
+    [$other] = duplicateMember();
+
+    $this->actingAs($other)
+        ->post(route('posts.duplicate', $post))
+        ->assertNotFound();
+});


### PR DESCRIPTION
## Summary
- Add a `PostDuplicator` service and `POST /posts/{post}/duplicate` endpoint that clones a post into a fresh draft, copying text, mentions, media (as new files), and per-account targets while resetting all publish state
- Skip cloning targets for connected accounts that no longer exist
- Add a "Copy as draft" action to the post row menu and post page, gated by a new `canDuplicate` capability (available for published, partial, failed, and missed posts)
- Add feature tests covering media/target cloning, override remapping, deleted-account handling, and cross-workspace access
