### PR TITLE
feat(compose): add toggle to select/deselect all accounts

### DIFF
--- a/app/Http/Controllers/Posts/PublishController.php
+++ b/app/Http/Controllers/Posts/PublishController.php
@@ -34,6 +34,12 @@ class PublishController extends Controller
             ], 402);
         }
 
+        if ($post->loadMissing('targets')->targets->isEmpty()) {
+            return response()->json([
+                'message' => 'Select at least one account to publish.',
+            ], 422);
+        }
+
         $blocked = $precheck->blockingTargets($post->loadMissing(['targets.account', 'media']));
         if ($blocked !== []) {
             return response()->json([

--- a/app/Http/Controllers/Posts/PublishController.php
+++ b/app/Http/Controllers/Posts/PublishController.php
@@ -27,17 +27,17 @@ class PublishController extends Controller
 
         $workspace = $post->workspace()->firstOrFail();
 
+        if ($post->loadMissing('targets')->targets->isEmpty()) {
+            return response()->json([
+                'message' => 'Select at least one account to publish.',
+            ], 422);
+        }
+
         if (! $subscriptions->canPublish($workspace)) {
             return response()->json([
                 'message' => 'Subscribe to publish this post.',
                 'billing_url' => route('billing.index'),
             ], 402);
-        }
-
-        if ($post->loadMissing('targets')->targets->isEmpty()) {
-            return response()->json([
-                'message' => 'Select at least one account to publish.',
-            ], 422);
         }
 
         $blocked = $precheck->blockingTargets($post->loadMissing(['targets.account', 'media']));

--- a/app/Http/Requests/Post/StorePostRequest.php
+++ b/app/Http/Requests/Post/StorePostRequest.php
@@ -33,7 +33,7 @@ class StorePostRequest extends FormRequest
             'mentions.*.handles.linkedin' => ['nullable', 'string'],
             'mentions.*.handles.linkedin_urn' => ['nullable', 'string', 'max:255'],
             'destination' => ['required', 'array'],
-            'destination.kind' => ['required', Rule::in(['all', 'set', 'account', 'accounts'])],
+            'destination.kind' => ['required', Rule::in(['all', 'none', 'set', 'account', 'accounts'])],
             'destination.id' => ['nullable', 'string', 'required_if:destination.kind,set,account'],
             'destination.ids' => ['array', 'required_if:destination.kind,accounts'],
             'destination.ids.*' => ['string'],

--- a/app/Http/Requests/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/Post/UpdatePostRequest.php
@@ -33,7 +33,7 @@ class UpdatePostRequest extends FormRequest
             'mentions.*.handles.linkedin' => ['nullable', 'string'],
             'mentions.*.handles.linkedin_urn' => ['nullable', 'string', 'max:255'],
             'destination' => ['required', 'array'],
-            'destination.kind' => ['required', Rule::in(['all', 'set', 'account', 'accounts'])],
+            'destination.kind' => ['required', Rule::in(['all', 'none', 'set', 'account', 'accounts'])],
             'destination.id' => ['nullable', 'string', 'required_if:destination.kind,set,account'],
             'destination.ids' => ['array', 'required_if:destination.kind,accounts'],
             'destination.ids.*' => ['string'],

--- a/app/Services/Posts/DraftService.php
+++ b/app/Services/Posts/DraftService.php
@@ -87,6 +87,7 @@ class DraftService
                 ->where('workspace_id', $workspaceId)
                 ->whereIn('id', $destination['ids'] ?? [])
                 ->pluck('id'),
+            'none' => collect(),
             default => ConnectedAccount::withoutGlobalScopes()
                 ->where('workspace_id', $workspaceId)
                 ->pluck('id'),

--- a/app/Support/PostView.php
+++ b/app/Support/PostView.php
@@ -88,6 +88,10 @@ final class PostView
             return ['kind' => 'set', 'id' => $post->account_set_id];
         }
 
+        if ($post->targets->isEmpty()) {
+            return ['kind' => 'none', 'id' => null];
+        }
+
         if ($post->targets->count() === 1) {
             return ['kind' => 'account', 'id' => $post->targets->first()->connected_account_id];
         }

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -1,5 +1,5 @@
 import { Link, useHttp, usePage } from '@inertiajs/react';
-import { Eye, Pin, Plug, TriangleAlert } from 'lucide-react';
+import { AtSign, Eye, Pin, Plug, TriangleAlert } from 'lucide-react';
 import { useEffect, useReducer, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -161,6 +161,9 @@ function accountIdsFor(
         const selected = new Set(destination.ids);
 
         return accounts.filter((a) => selected.has(a.id)).map((a) => a.id);
+    }
+    if (destination.kind === 'none') {
+        return [];
     }
 
     return accounts.map((a) => a.id);
@@ -1300,6 +1303,13 @@ export default function Composer({
                             Connect an account to publish
                         </Link>
                     </div>
+                ) : destinationAccountIds.length === 0 ? (
+                    <div className="px-4 pb-3.5 sm:px-[26px]">
+                        <span className="inline-flex items-center gap-1.5 rounded-md border border-dashed border-border px-2.5 py-1 text-[12px] tracking-[-0.005em] text-muted-foreground">
+                            <AtSign className="size-3.5" aria-hidden />
+                            Select at least one account to publish
+                        </span>
+                    </div>
                 ) : null}
 
                 {activeAccount && activeNotices.length > 0 && (
@@ -1509,7 +1519,10 @@ export default function Composer({
                         <SubmitBar
                             tray={state.scheduleTray}
                             postId={state.postId}
-                            disabled={accounts.length === 0}
+                            disabled={
+                                accounts.length === 0 ||
+                                destinationAccountIds.length === 0
+                            }
                             attentionHandles={attentionAccounts.map(
                                 (account) => account.handle,
                             )}

--- a/resources/js/components/compose/destination-selector.test.tsx
+++ b/resources/js/components/compose/destination-selector.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import DestinationSelector from '@/components/compose/destination-selector';
+import type { Account, Destination } from '@/types/compose';
+
+function account(id: string, handle: string): Account {
+    return {
+        id,
+        platform: 'x',
+        handle,
+        display_name: handle,
+        avatar_url: null,
+        status: 'active',
+        max_text_length: 280,
+        x_premium: false,
+    };
+}
+
+const accounts = [account('a1', '@one'), account('a2', '@two')];
+
+function open(destination: Destination) {
+    const onChange = vi.fn();
+    render(
+        <DestinationSelector
+            accounts={accounts}
+            sets={[]}
+            destination={destination}
+            onChange={onChange}
+        />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Post destination' }));
+
+    return onChange;
+}
+
+describe('DestinationSelector "All accounts" toggle', () => {
+    it('deselects everything when all accounts are selected', () => {
+        const onChange = open({ kind: 'all' });
+
+        fireEvent.click(screen.getByRole('button', { name: /all accounts/i }));
+
+        expect(onChange).toHaveBeenCalledWith({ kind: 'none' });
+    });
+
+    it('selects everything when nothing is selected', () => {
+        const onChange = open({ kind: 'none' });
+
+        fireEvent.click(screen.getByRole('button', { name: /all accounts/i }));
+
+        expect(onChange).toHaveBeenCalledWith({ kind: 'all' });
+    });
+
+    it('lets the last account be deselected down to none', () => {
+        const onChange = open({ kind: 'account', id: 'a1' });
+
+        fireEvent.click(screen.getByRole('button', { name: /@one/i }));
+
+        expect(onChange).toHaveBeenCalledWith({ kind: 'none' });
+    });
+});
+
+describe('DestinationSelector trigger label', () => {
+    it('reads "No accounts" for an empty selection', () => {
+        render(
+            <DestinationSelector
+                accounts={accounts}
+                sets={[]}
+                destination={{ kind: 'none' }}
+                onChange={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.getByRole('button', { name: 'Post destination' }),
+        ).toHaveTextContent('No accounts');
+    });
+});

--- a/resources/js/components/compose/destination-selector.tsx
+++ b/resources/js/components/compose/destination-selector.tsx
@@ -107,6 +107,9 @@ function selectedAccountIds(
             []
         );
     }
+    if (destination.kind === 'none') {
+        return [];
+    }
 
     return accounts.map((a) => a.id);
 }
@@ -125,6 +128,9 @@ function destinationFromIds(
     accounts: Account[],
     preferredSet: AccountSet | null = null,
 ): Destination {
+    if (ids.length === 0) {
+        return { kind: 'none' };
+    }
     if (ids.length === accounts.length) {
         return { kind: 'all' };
     }
@@ -144,6 +150,9 @@ function triggerLabel(
     accounts: Account[],
     sets: AccountSet[],
 ): string {
+    if (selectedIds.length === 0) {
+        return 'No accounts';
+    }
     if (selectedIds.length === accounts.length) {
         return 'All accounts';
     }
@@ -169,19 +178,20 @@ export default function DestinationSelector({
     const selectedIds = selectedAccountIds(destination, accounts, sets);
     const selected = new Set(selectedIds);
     const label = triggerLabel(destination, selectedIds, accounts, sets);
+    const allSelected =
+        accounts.length > 0 && selectedIds.length === accounts.length;
 
-    function chooseAll() {
-        onChange({ kind: 'all' });
+    // "All accounts" toggles the whole roster: on when nothing (or a subset) is
+    // selected, off when everything is. Clearing to none leaves publishing
+    // disabled until the user picks the specific accounts they want.
+    function toggleAll() {
+        onChange(allSelected ? { kind: 'none' } : { kind: 'all' });
     }
 
     function toggleAccount(accountId: string) {
         const next = selected.has(accountId)
             ? selectedIds.filter((id) => id !== accountId)
             : [...selectedIds, accountId];
-
-        if (next.length === 0) {
-            return;
-        }
 
         onChange(destinationFromIds(next, accounts));
     }
@@ -194,10 +204,6 @@ export default function DestinationSelector({
         const next = allSetAccountsSelected
             ? selectedIds.filter((id) => !setIds.has(id))
             : [...new Set([...selectedIds, ...set.connected_account_ids])];
-
-        if (next.length === 0) {
-            return;
-        }
 
         onChange(destinationFromIds(next, accounts, set));
     }
@@ -224,10 +230,7 @@ export default function DestinationSelector({
                 <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
                     Sets
                 </div>
-                <OptionButton
-                    selected={selectedIds.length === accounts.length}
-                    onClick={chooseAll}
-                >
+                <OptionButton selected={allSelected} onClick={toggleAll}>
                     <SetVisual />
                     All accounts
                 </OptionButton>

--- a/resources/js/lib/compose/composer-state.ts
+++ b/resources/js/lib/compose/composer-state.ts
@@ -391,7 +391,9 @@ function hydrate(post: PostView): ComposerState {
                       post.destination.ids &&
                       post.destination.ids.length > 0
                     ? { kind: 'accounts', ids: post.destination.ids }
-                    : { kind: 'all' },
+                    : post.destination.kind === 'none'
+                      ? { kind: 'none' }
+                      : { kind: 'all' },
         autoSplitByAccount,
         formatByAccount,
         overrideByAccount,

--- a/resources/js/types/compose.ts
+++ b/resources/js/types/compose.ts
@@ -37,6 +37,7 @@ export type MentionPlaceholder = {
 
 export type Destination =
     | { kind: 'all' }
+    | { kind: 'none' }
     | { kind: 'set'; id: string }
     | { kind: 'account'; id: string }
     | { kind: 'accounts'; ids: string[] };

--- a/tests/Feature/Posts/ComposeApiTest.php
+++ b/tests/Feature/Posts/ComposeApiTest.php
@@ -73,6 +73,28 @@ test('POST /posts accepts a custom accounts destination', function () {
         ->assertJsonCount(2, 'post.targets');
 });
 
+test('PUT /posts/{post} accepts a "none" destination and clears every target', function () {
+    [$user, $workspace, $accounts] = actingMember(2);
+    $created = test()->postJson('/posts', [
+        'base_text' => 'a',
+        'segments' => ['a'],
+        'destination' => ['kind' => 'all'],
+    ])->assertCreated()->json('post');
+
+    expect($created['targets'])->toHaveCount(2);
+
+    test()->putJson("/posts/{$created['id']}", [
+        'base_text' => 'a',
+        'segments' => ['a'],
+        'destination' => ['kind' => 'none'],
+        'targets' => [],
+        'expected_updated_at' => $created['updated_at'],
+    ])
+        ->assertOk()
+        ->assertJsonPath('post.destination.kind', 'none')
+        ->assertJsonCount(0, 'post.targets');
+});
+
 test('PUT /posts/{post} autosaves edits and returns the new baseline', function () {
     [$user, $workspace, $accounts] = actingMember(1);
     $created = test()->postJson('/posts', ['base_text' => 'a', 'segments' => ['a'], 'destination' => ['kind' => 'all']])->json('post');

--- a/tests/Feature/Posts/DisabledAccountTargetingTest.php
+++ b/tests/Feature/Posts/DisabledAccountTargetingTest.php
@@ -48,6 +48,19 @@ test('draft targeting never snapshots a disabled account', function () {
     expect($ids)->toBe([$enabled->id]);
 });
 
+test('a "none" destination resolves to zero target accounts', function () {
+    [$user, $workspace, $enabled, $disabled] = ownerWithDisabledAccount();
+
+    Context::add('workspace_id', $workspace->id);
+
+    $ids = app(DraftService::class)->resolveDestinationAccountIds(
+        $workspace->id,
+        ['kind' => 'none'],
+    );
+
+    expect($ids)->toBe([]);
+});
+
 test('the composer and shell exclude disabled accounts', function () {
     [$user, $workspace, $enabled, $disabled] = ownerWithDisabledAccount();
 

--- a/tests/Feature/Posts/PostViewTest.php
+++ b/tests/Feature/Posts/PostViewTest.php
@@ -33,3 +33,18 @@ test('it serializes a post with targets, media, and advisory issues', function (
         ->and($view['media'])->toHaveCount(1)
         ->and($view)->not->toHaveKey('secret');
 });
+
+test('a post with no targets serializes as a "none" destination', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['owner_id' => $user->id]);
+    Context::add('workspace_id', $workspace->id);
+
+    // A workspace with connected accounts, but a post that targets none of them.
+    ConnectedAccount::factory()->create(['workspace_id' => $workspace->id, 'platform' => Platform::X->value]);
+    $post = Post::factory()->create(['workspace_id' => $workspace->id, 'author_id' => $user->id]);
+
+    $view = PostView::make($post->fresh(['targets.account', 'media']));
+
+    expect($view['destination']['kind'])->toBe('none')
+        ->and($view['targets'])->toHaveCount(0);
+});

--- a/tests/Feature/Publishing/PublishEndpointTest.php
+++ b/tests/Feature/Publishing/PublishEndpointTest.php
@@ -42,6 +42,19 @@ test('publish-now sets the post publishing and dispatches targets', function () 
     Bus::assertDispatchedTimes(PublishPostTarget::class, 1);
 });
 
+test('publish-now is blocked (422) when the post has no targets and does not dispatch', function () {
+    Bus::fake();
+    [$user, $workspace] = publishingMember();
+    $post = Post::factory()->create(['workspace_id' => $workspace->id, 'status' => PostStatus::Draft]);
+
+    test()->postJson("/posts/{$post->id}/publish")
+        ->assertStatus(422)
+        ->assertJsonPath('message', 'Select at least one account to publish.');
+
+    expect($post->refresh()->status)->toBe(PostStatus::Draft);
+    Bus::assertNotDispatched(PublishPostTarget::class);
+});
+
 test('publish-now is blocked across workspaces', function () {
     publishingMember();
     $foreign = Post::factory()->create();


### PR DESCRIPTION
## Summary
- Add a "none" destination state so clicking "All accounts" now toggles between selecting and deselecting every connected account, and individual accounts can be deselected down to zero (closes #141)
- Show an inline "Select at least one account to publish" hint and disable submit when no accounts are selected
- Reject publish requests server-side with a 422 when a post has no targets, instead of silently publishing to nothing
- Update `destination.kind` validation, `DraftService`, and `PostView` serialization to support and round-trip the new `none` kind

## Breaking Changes
- API consumers sending `destination.kind` must now also handle the new `none` value on read; posts with zero targets now serialize as `{"kind": "none"}` instead of falling through to `all`


---

Fixes #141