### PR TITLE
feat(icons): migrate from lucide-react to hugeicons

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,8 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@fontsource-variable/noto-sans": "^5.2.10",
+        "@hugeicons/core-free-icons": "^4.2.3",
+        "@hugeicons/react": "^1.1.9",
         "@inertiajs/react": "^3.0.0",
         "@inertiajs/vite": "^3.0.0",
         "@laravel/passkeys": "^0.2.0",
@@ -197,6 +199,10 @@
     "@fontsource-variable/noto-sans": ["@fontsource-variable/noto-sans@5.2.10", "", {}, "sha512-wyFgKkFu7jki5kEL8qv7avjQ8rxHX0J/nhLWvbR9T0hOH1HRKZEvb9EW9lMjZfWHHfEzKkYf5J+NadwgCS7TXA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@hugeicons/core-free-icons": ["@hugeicons/core-free-icons@4.2.3", "", {}, "sha512-fpiU0qFZkv4ABi23xJ2m4qNr0BBfuIaYjPboN8WDA6aj9D+OzXa7eykxKOpACZRuGbDz1U9S5DsNx1d5KNnsgA=="],
+
+    "@hugeicons/react": ["@hugeicons/react@1.1.9", "", { "peerDependencies": { "react": ">=16.0.0" } }, "sha512-O+lWSWjbijoAvMCxn4K2bQWCGN5+mP1y5j+X99j23mXMj+s0X25fs71T6t9YJLaBodwmZdaewD27dzS/PiboQw=="],
 
     "@inertiajs/core": ["@inertiajs/core@3.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "es-toolkit": "^1.33.0", "laravel-precognition": "^2.0.0" }, "peerDependencies": { "axios": "^1.15.2" }, "optionalPeers": ["axios"] }, "sha512-6tEe5vtjwXJj68h0nkz84WkeZ8XA0phJ8ep1l/V+im62KTzlZTw9sxlmf8uNKu4seleXVw+idw48svxUCWla/Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,6 @@
         "html-to-image": "^1.11.13",
         "input-otp": "^1.4.2",
         "laravel-vite-plugin": "^3.0.0",
-        "lucide-react": "^1.17.0",
         "mediabunny": "^1.49.0",
         "motion": "^12.40.0",
         "next-themes": "^0.4.6",
@@ -1009,8 +1008,6 @@
     "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
 
     "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
-
-    "lucide-react": ["lucide-react@1.17.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/components.json
+++ b/components.json
@@ -17,7 +17,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "iconLibrary": "lucide",
+  "iconLibrary": "hugeicons",
   "rtl": false,
   "menuColor": "inverted-translucent",
   "menuAccent": "subtle",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@fontsource-variable/noto-sans": "^5.2.10",
+        "@hugeicons/core-free-icons": "^4.2.3",
+        "@hugeicons/react": "^1.1.9",
         "@inertiajs/react": "^3.0.0",
         "@inertiajs/vite": "^3.0.0",
         "@laravel/passkeys": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
         "html-to-image": "^1.11.13",
         "input-otp": "^1.4.2",
         "laravel-vite-plugin": "^3.0.0",
-        "lucide-react": "^1.17.0",
         "mediabunny": "^1.49.0",
         "motion": "^12.40.0",
         "next-themes": "^0.4.6",

--- a/resources/js/components/accounts/account-card.tsx
+++ b/resources/js/components/accounts/account-card.tsx
@@ -1,5 +1,4 @@
 import { Form } from '@inertiajs/react';
-import { RefreshCw, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
 import ConnectedAccountController from '@/actions/App/Http/Controllers/ConnectedAccounts/ConnectedAccountController';
@@ -17,6 +16,7 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
+import { RefreshCw, Trash2 } from '@/components/ui/icons';
 import { Input } from '@/components/ui/input';
 import {
     InputGroup,

--- a/resources/js/components/accounts/connect-buttons.tsx
+++ b/resources/js/components/accounts/connect-buttons.tsx
@@ -1,5 +1,4 @@
 import { Form } from '@inertiajs/react';
-import { AtSign, ChevronDown, Loader2, Plus } from 'lucide-react';
 import { useState } from 'react';
 
 import BlueskyConnectionController from '@/actions/App/Http/Controllers/ConnectedAccounts/BlueskyConnectionController';
@@ -31,6 +30,7 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { AtSign, ChevronDown, Loader2, Plus } from '@/components/ui/icons';
 import { Input } from '@/components/ui/input';
 import {
     InputGroup,

--- a/resources/js/components/analytics/metric-delta.tsx
+++ b/resources/js/components/analytics/metric-delta.tsx
@@ -1,6 +1,5 @@
-import { ArrowDown, ArrowUp } from 'lucide-react';
-
 import { Badge } from '@/components/ui/badge';
+import { ArrowDown, ArrowUp } from '@/components/ui/icons';
 import { cn } from '@/lib/utils';
 
 /** Signed, thousands-grouped delta: `+342`, `−1,204`, `0`. */

--- a/resources/js/components/auth/manage-passkeys.tsx
+++ b/resources/js/components/auth/manage-passkeys.tsx
@@ -1,10 +1,10 @@
 import { router } from '@inertiajs/react';
-import { KeyRound } from 'lucide-react';
 
 import { destroy } from '@/actions/Laravel/Passkeys/Http/Controllers/PasskeyRegistrationController';
 import PasskeyItem from '@/components/auth/passkey-item';
 import PasskeyRegistration from '@/components/auth/passkey-register';
 import Heading from '@/components/common/heading';
+import { KeyRound } from '@/components/ui/icons';
 import type { Passkey } from '@/types/auth';
 
 export type Props = {

--- a/resources/js/components/auth/manage-two-factor.tsx
+++ b/resources/js/components/auth/manage-two-factor.tsx
@@ -1,11 +1,11 @@
 import { Form } from '@inertiajs/react';
-import { ShieldCheck } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import TwoFactorRecoveryCodes from '@/components/auth/two-factor-recovery-codes';
 import TwoFactorSetupModal from '@/components/auth/two-factor-setup-modal';
 import Heading from '@/components/common/heading';
 import { Button } from '@/components/ui/button';
+import { ShieldCheck } from '@/components/ui/icons';
 import { useTwoFactorAuth } from '@/hooks/auth/use-two-factor-auth';
 import { disable, enable } from '@/routes/two-factor';
 

--- a/resources/js/components/auth/passkey-item.tsx
+++ b/resources/js/components/auth/passkey-item.tsx
@@ -1,4 +1,3 @@
-import { KeyRound, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -11,6 +10,7 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
+import { KeyRound, Trash2 } from '@/components/ui/icons';
 import type { Passkey } from '@/types/auth';
 
 type Props = {

--- a/resources/js/components/auth/passkey-verify.tsx
+++ b/resources/js/components/auth/passkey-verify.tsx
@@ -1,11 +1,11 @@
 import type { UrlMethodPair } from '@inertiajs/core';
 import { router } from '@inertiajs/react';
 import { usePasskeyVerify } from '@laravel/passkeys/react';
-import { KeyRound } from 'lucide-react';
 
 import InputError from '@/components/common/input-error';
 import OrSeparator from '@/components/common/or-separator';
 import { Button } from '@/components/ui/button';
+import { KeyRound } from '@/components/ui/icons';
 import { Spinner } from '@/components/ui/spinner';
 
 type Props = {

--- a/resources/js/components/auth/password-input.tsx
+++ b/resources/js/components/auth/password-input.tsx
@@ -1,7 +1,7 @@
-import { Eye, EyeOff } from 'lucide-react';
 import type { ComponentProps, Ref } from 'react';
 import { useState } from 'react';
 
+import { Eye, EyeOff } from '@/components/ui/icons';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 

--- a/resources/js/components/auth/two-factor-recovery-codes.tsx
+++ b/resources/js/components/auth/two-factor-recovery-codes.tsx
@@ -1,5 +1,4 @@
 import { Form } from '@inertiajs/react';
-import { Eye, EyeOff, LockKeyhole, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import AlertError from '@/components/common/alert-error';
@@ -11,6 +10,7 @@ import {
     CardHeader,
     CardTitle,
 } from '@/components/ui/card';
+import { Eye, EyeOff, LockKeyhole, RefreshCw } from '@/components/ui/icons';
 import { regenerateRecoveryCodes } from '@/routes/two-factor';
 
 type Props = {

--- a/resources/js/components/auth/two-factor-setup-modal.tsx
+++ b/resources/js/components/auth/two-factor-setup-modal.tsx
@@ -1,6 +1,5 @@
 import { Form } from '@inertiajs/react';
 import { REGEXP_ONLY_DIGITS } from 'input-otp';
-import { Check, Copy, ScanLine } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import AlertError from '@/components/common/alert-error';
@@ -13,6 +12,7 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
+import { Check, Copy, ScanLine } from '@/components/ui/icons';
 import {
     InputOTP,
     InputOTPGroup,

--- a/resources/js/components/common/alert-error.tsx
+++ b/resources/js/components/common/alert-error.tsx
@@ -1,6 +1,5 @@
-import { AlertCircleIcon } from 'lucide-react';
-
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { AlertCircle } from '@/components/ui/icons';
 
 export default function AlertError({
     errors,
@@ -11,7 +10,7 @@ export default function AlertError({
 }) {
     return (
         <Alert variant="destructive">
-            <AlertCircleIcon />
+            <AlertCircle />
             <AlertTitle>{title || 'Something went wrong.'}</AlertTitle>
             <AlertDescription>
                 <ul className="list-inside list-disc text-sm">

--- a/resources/js/components/common/theme-toggle.tsx
+++ b/resources/js/components/common/theme-toggle.tsx
@@ -1,5 +1,3 @@
-import { Monitor, Moon, Sun } from 'lucide-react';
-
 import { Button } from '@/components/ui/button';
 import {
     DropdownMenu,
@@ -7,6 +5,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Monitor, Moon, Sun } from '@/components/ui/icons';
 import type { Appearance } from '@/hooks/use-appearance';
 import { useAppearance } from '@/hooks/use-appearance';
 

--- a/resources/js/components/compose/boost-popover.tsx
+++ b/resources/js/components/compose/boost-popover.tsx
@@ -1,8 +1,8 @@
 import { Popover as PopoverPrimitive } from '@base-ui/react/popover';
 import { Link } from '@inertiajs/react';
-import { Check, Rocket } from 'lucide-react';
 import { useState } from 'react';
 
+import { Check, Rocket } from '@/components/ui/icons';
 import { cn } from '@/lib/utils';
 import { index as accountsRoute } from '@/routes/accounts';
 import type { Account } from '@/types/compose';

--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -1,4 +1,3 @@
-import { ImagePlay, Paperclip, Shuffle, Smile, Split } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useRef } from 'react';
 
@@ -6,6 +5,13 @@ import type { BoostValue } from '@/components/compose/boost-popover';
 import { BoostPopover } from '@/components/compose/boost-popover';
 import { EmojiPopover } from '@/components/compose/emoji-popover';
 import { GifPopover } from '@/components/compose/gif-popover';
+import {
+    ImagePlay,
+    Paperclip,
+    Shuffle,
+    Smile,
+    Split,
+} from '@/components/ui/icons';
 import { Kbd } from '@/components/ui/kbd';
 import {
     Tooltip,

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -1,11 +1,11 @@
 import { Link, useHttp, usePage } from '@inertiajs/react';
-import { AtSign, Eye, Pin, Plug, TriangleAlert } from 'lucide-react';
 import { useEffect, useReducer, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import PostGifController from '@/actions/App/Http/Controllers/Gifs/PostGifController';
 import WorkspaceMentionController from '@/actions/App/Http/Controllers/WorkspaceMentionController';
 import { useConfirm } from '@/components/common/confirm-dialog';
+import { AtSign, Eye, Pin, Plug, TriangleAlert } from '@/components/ui/icons';
 import { useAutosave } from '@/hooks/compose/use-autosave';
 import { useEmojiPreferences } from '@/hooks/compose/use-emoji-preferences';
 import { useImageEditor } from '@/hooks/compose/use-image-editor';

--- a/resources/js/components/compose/destination-selector.tsx
+++ b/resources/js/components/compose/destination-selector.tsx
@@ -1,9 +1,14 @@
 import { router } from '@inertiajs/react';
-import { AlertTriangle, Check, ChevronDown, Layers } from 'lucide-react';
 import type React from 'react';
 
 import { PlatformGlyph } from '@/components/common/platform-glyph';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+    AlertTriangle,
+    Check,
+    ChevronDown,
+    Layers,
+} from '@/components/ui/icons';
 import {
     Popover,
     PopoverContent,

--- a/resources/js/components/compose/editor-body.tsx
+++ b/resources/js/components/compose/editor-body.tsx
@@ -1,5 +1,4 @@
 import { EditorContent, useEditor } from '@tiptap/react';
-import { Split } from 'lucide-react';
 import type { ReactNode, Ref } from 'react';
 import {
     forwardRef,
@@ -12,6 +11,7 @@ import { createPortal } from 'react-dom';
 
 import EmojiSuggestPopover from '@/components/compose/emoji-suggest-popover';
 import MentionPicker from '@/components/compose/mention-picker';
+import { Split } from '@/components/ui/icons';
 import { Popover, PopoverContent } from '@/components/ui/popover';
 import { useEmojiTypeahead } from '@/hooks/compose/use-emoji-typeahead';
 import { activeSegmentRef } from '@/lib/compose/active-segment';

--- a/resources/js/components/compose/gif-picker.tsx
+++ b/resources/js/components/compose/gif-picker.tsx
@@ -1,7 +1,7 @@
-import { Loader2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { GifTile } from '@/components/compose/gif-tile';
+import { Loader2 } from '@/components/ui/icons';
 import { useGifSearch } from '@/hooks/compose/use-gif-search';
 import {
     FAVORITES_KEY,

--- a/resources/js/components/compose/gif-tile.tsx
+++ b/resources/js/components/compose/gif-tile.tsx
@@ -1,6 +1,6 @@
-import { Heart } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 
+import { Heart } from '@/components/ui/icons';
 import { cn } from '@/lib/utils';
 import type { GifItem } from '@/types/gifs';
 

--- a/resources/js/components/compose/image-editor.tsx
+++ b/resources/js/components/compose/image-editor.tsx
@@ -1,4 +1,3 @@
-import { ChevronDown, Crop, Trash2, Wand2, X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
@@ -9,6 +8,7 @@ import {
     DialogDescription,
     DialogTitle,
 } from '@/components/ui/dialog';
+import { ChevronDown, Crop, Trash2, Wand2, X } from '@/components/ui/icons';
 import { cropToBlob, loadImage } from '@/lib/image-editor/crop';
 import { rasterizeStage } from '@/lib/image-editor/export';
 import {

--- a/resources/js/components/compose/media-chips.tsx
+++ b/resources/js/components/compose/media-chips.tsx
@@ -1,7 +1,7 @@
-import { Eye, EyeOff, Film, X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useRef, useState } from 'react';
 
+import { Eye, EyeOff, Film, X } from '@/components/ui/icons';
 import {
     Tooltip,
     TooltipContent,

--- a/resources/js/components/compose/mention-picker.tsx
+++ b/resources/js/components/compose/mention-picker.tsx
@@ -1,12 +1,3 @@
-import {
-    ArrowLeft,
-    Building2,
-    Info,
-    Pencil,
-    Plus,
-    Trash2,
-    X,
-} from 'lucide-react';
 import { useEffect, useMemo, useRef, useState, type RefObject } from 'react';
 
 import { PlatformGlyph } from '@/components/common/platform-glyph';
@@ -19,6 +10,15 @@ import {
     CommandList,
     CommandSeparator,
 } from '@/components/ui/command';
+import {
+    ArrowLeft,
+    Building2,
+    Info,
+    Pencil,
+    Plus,
+    Trash2,
+    X,
+} from '@/components/ui/icons';
 import {
     InputGroup,
     InputGroupAddon,

--- a/resources/js/components/compose/pick-time-popover.tsx
+++ b/resources/js/components/compose/pick-time-popover.tsx
@@ -1,10 +1,10 @@
 import { Link } from '@inertiajs/react';
-import { CalendarClock } from 'lucide-react';
 import { useState } from 'react';
 
 import { showOverview as workspaceSettings } from '@/actions/App/Http/Controllers/Settings/WorkspaceSettingsController';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
+import { CalendarClock } from '@/components/ui/icons';
 import {
     Popover,
     PopoverContent,

--- a/resources/js/components/compose/platform-preview-panel.tsx
+++ b/resources/js/components/compose/platform-preview-panel.tsx
@@ -1,3 +1,5 @@
+import { PlatformGlyph } from '@/components/common/platform-glyph';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
     BarChart3,
     CheckCircle2,
@@ -5,10 +7,7 @@ import {
     Heart,
     MessageCircle,
     Repeat2,
-} from 'lucide-react';
-
-import { PlatformGlyph } from '@/components/common/platform-glyph';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+} from '@/components/ui/icons';
 import type {
     PlatformPreview,
     PlatformPreviewItem,

--- a/resources/js/components/compose/platform-tabs.tsx
+++ b/resources/js/components/compose/platform-tabs.tsx
@@ -1,9 +1,9 @@
 import { router } from '@inertiajs/react';
-import { AlertTriangle, ChevronDown } from 'lucide-react';
 import type React from 'react';
 import { useState } from 'react';
 
 import { PlatformGlyph } from '@/components/common/platform-glyph';
+import { AlertTriangle, ChevronDown } from '@/components/ui/icons';
 import {
     Popover,
     PopoverContent,

--- a/resources/js/components/compose/preview/facebook-preview.tsx
+++ b/resources/js/components/compose/preview/facebook-preview.tsx
@@ -1,3 +1,4 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
     Globe,
     Heart,
@@ -6,9 +7,7 @@ import {
     Share2,
     ThumbsUp,
     X,
-} from 'lucide-react';
-
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+} from '@/components/ui/icons';
 import type { PlatformPreview } from '@/lib/compose/platform-preview';
 import { LinkedText } from '@/lib/linked-text';
 import { cn } from '@/lib/utils';

--- a/resources/js/components/compose/preview/instagram-preview.tsx
+++ b/resources/js/components/compose/preview/instagram-preview.tsx
@@ -1,16 +1,16 @@
+import { useRef, useState } from 'react';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
     Bookmark,
     ChevronLeft,
     ChevronRight,
     Heart,
-    ImageIcon,
+    Image,
     MessageCircle,
     MoreHorizontal,
     Send,
-} from 'lucide-react';
-import { useRef, useState } from 'react';
-
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+} from '@/components/ui/icons';
 import type { PlatformPreview } from '@/lib/compose/platform-preview';
 import { LinkedText } from '@/lib/linked-text';
 import { cn } from '@/lib/utils';
@@ -204,7 +204,7 @@ function InstagramFeedPost({ preview }: { preview: PlatformPreview }) {
             ) : (
                 <div className="grid aspect-square w-full place-items-center bg-muted/60 text-center">
                     <div className="space-y-1.5 px-6 text-muted-foreground">
-                        <ImageIcon className="mx-auto size-6" aria-hidden />
+                        <Image className="mx-auto size-6" aria-hidden />
                         <p className="text-[12px] leading-4">
                             Add a photo or video — Instagram posts always
                             include media.

--- a/resources/js/components/compose/preview/preview-video.tsx
+++ b/resources/js/components/compose/preview/preview-video.tsx
@@ -1,6 +1,6 @@
-import { Volume2, VolumeX } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
+import { Volume2, VolumeX } from '@/components/ui/icons';
 import { cn } from '@/lib/utils';
 
 type Props = {

--- a/resources/js/components/compose/preview/reels-frame.tsx
+++ b/resources/js/components/compose/preview/reels-frame.tsx
@@ -1,3 +1,6 @@
+import type { ReactNode } from 'react';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
     Bookmark,
     Film,
@@ -8,10 +11,7 @@ import {
     Send,
     Share2,
     ThumbsUp,
-} from 'lucide-react';
-import type { ReactNode } from 'react';
-
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+} from '@/components/ui/icons';
 import type { PlatformPreview } from '@/lib/compose/platform-preview';
 import { LinkedText } from '@/lib/linked-text';
 import { cn } from '@/lib/utils';

--- a/resources/js/components/compose/preview/story-frame.tsx
+++ b/resources/js/components/compose/preview/story-frame.tsx
@@ -1,14 +1,13 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
     Clapperboard,
     Heart,
-    ImageIcon,
+    Image,
     Send,
     Share2,
     ThumbsUp,
     X,
-} from 'lucide-react';
-
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+} from '@/components/ui/icons';
 import type { PlatformPreview } from '@/lib/compose/platform-preview';
 import { cn } from '@/lib/utils';
 
@@ -67,10 +66,7 @@ export function StoryFrame({
                                     aria-hidden
                                 />
                             ) : (
-                                <ImageIcon
-                                    className="mx-auto size-6"
-                                    aria-hidden
-                                />
+                                <Image className="mx-auto size-6" aria-hidden />
                             )}
                             <p className="text-[12px] leading-4">
                                 Add a photo or video to preview your story

--- a/resources/js/components/compose/preview/threads-preview.tsx
+++ b/resources/js/components/compose/preview/threads-preview.tsx
@@ -1,6 +1,5 @@
-import { MoreHorizontal } from 'lucide-react';
-
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { MoreHorizontal } from '@/components/ui/icons';
 import type {
     PlatformPreview,
     PlatformPreviewItem,

--- a/resources/js/components/compose/schedule-tray.tsx
+++ b/resources/js/components/compose/schedule-tray.tsx
@@ -1,6 +1,5 @@
-import { Clock, ListChecks, Zap } from 'lucide-react';
-import type { ComponentType } from 'react';
-
+import { Clock, ListChecks, Zap } from '@/components/ui/icons';
+import type { IconComponent } from '@/components/ui/icons';
 import type { QueueSlotState } from '@/hooks/compose/use-next-slot';
 import type { ScheduleTray as TrayState } from '@/lib/compose/composer-state';
 import { cn } from '@/lib/utils';
@@ -70,7 +69,7 @@ export function ScheduleTray({ tray, onChange, tz, queueState }: Props) {
 }
 
 type TabProps = {
-    icon: ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+    icon: IconComponent;
     label: string;
     active: boolean;
     onClick: () => void;

--- a/resources/js/components/compose/segment-media-row.tsx
+++ b/resources/js/components/compose/segment-media-row.tsx
@@ -1,8 +1,8 @@
-import { ImagePlay, Paperclip, X } from 'lucide-react';
 import type { DragEvent, ReactNode } from 'react';
 import { useRef, useState } from 'react';
 
 import { GifPopover } from '@/components/compose/gif-popover';
+import { ImagePlay, Paperclip, X } from '@/components/ui/icons';
 import {
     Tooltip,
     TooltipContent,

--- a/resources/js/components/compose/submit-bar.tsx
+++ b/resources/js/components/compose/submit-bar.tsx
@@ -1,11 +1,11 @@
 import { Link, router, useHttp } from '@inertiajs/react';
-import { Send } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 
 import ComposerController from '@/actions/App/Http/Controllers/Posts/ComposerController';
 import PostingScheduleController from '@/actions/App/Http/Controllers/Posts/PostingScheduleController';
 import PostScheduleController from '@/actions/App/Http/Controllers/Posts/PostScheduleController';
+import { Send } from '@/components/ui/icons';
 import {
     Tooltip,
     TooltipContent,

--- a/resources/js/components/compose/target-status-chips.tsx
+++ b/resources/js/components/compose/target-status-chips.tsx
@@ -1,6 +1,5 @@
-import { Check, ExternalLink, RotateCw, X } from 'lucide-react';
-
 import { PlatformGlyph } from '@/components/common/platform-glyph';
+import { Check, ExternalLink, RotateCw, X } from '@/components/ui/icons';
 import { Spinner } from '@/components/ui/spinner';
 import {
     Tooltip,

--- a/resources/js/components/compose/video-editor.tsx
+++ b/resources/js/components/compose/video-editor.tsx
@@ -1,4 +1,3 @@
-import { Crop, Pause, Play, Volume1, Volume2, VolumeX, X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 
@@ -8,6 +7,15 @@ import {
     DialogDescription,
     DialogTitle,
 } from '@/components/ui/dialog';
+import {
+    Crop,
+    Pause,
+    Play,
+    Volume1,
+    Volume2,
+    VolumeX,
+    X,
+} from '@/components/ui/icons';
 import { centeredCropForRatio } from '@/lib/image-editor/layout';
 import type { CropRect } from '@/lib/image-editor/settings';
 import { cn } from '@/lib/utils';

--- a/resources/js/components/dashboard/recent-feed.tsx
+++ b/resources/js/components/dashboard/recent-feed.tsx
@@ -1,5 +1,4 @@
 import { Link } from '@inertiajs/react';
-import { Inbox } from 'lucide-react';
 import { useState } from 'react';
 
 import { FilterTabs } from '@/components/common/filter-tabs';
@@ -15,6 +14,7 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/components/ui/empty';
+import { Inbox } from '@/components/ui/icons';
 import { index as postsRoute } from '@/routes/posts';
 
 type FilterId = 'all' | 'scheduled' | 'published' | 'draft';

--- a/resources/js/components/feedback/feedback-widget.tsx
+++ b/resources/js/components/feedback/feedback-widget.tsx
@@ -1,11 +1,11 @@
 import { useHttp, usePage } from '@inertiajs/react';
 import { toBlob } from 'html-to-image';
-import { MessageSquarePlus } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import FeedbackController from '@/actions/App/Http/Controllers/FeedbackController';
 import { Button } from '@/components/ui/button';
+import { MessageSquarePlus } from '@/components/ui/icons';
 import {
     Popover,
     PopoverContent,

--- a/resources/js/components/layout/app-header.tsx
+++ b/resources/js/components/layout/app-header.tsx
@@ -1,5 +1,4 @@
 import { Link, usePage } from '@inertiajs/react';
-import { BookOpen, Folder, LayoutGrid, Menu, Search } from 'lucide-react';
 
 import AppLogo from '@/components/layout/app-logo';
 import AppLogoIcon from '@/components/layout/app-logo-icon';
@@ -12,6 +11,13 @@ import {
     DropdownMenuContent,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+    BookOpen,
+    Folder,
+    LayoutGrid,
+    Menu,
+    Search,
+} from '@/components/ui/icons';
 import {
     NavigationMenu,
     NavigationMenuItem,

--- a/resources/js/components/layout/app-sidebar-header.tsx
+++ b/resources/js/components/layout/app-sidebar-header.tsx
@@ -1,9 +1,8 @@
-import { Search } from 'lucide-react';
-
 import { ThemeToggle } from '@/components/common/theme-toggle';
 import { Breadcrumbs } from '@/components/layout/breadcrumbs';
 import { openCommandPalette } from '@/components/layout/command-palette';
 import { NotificationBell } from '@/components/notifications/notification-bell';
+import { Search } from '@/components/ui/icons';
 import { Kbd } from '@/components/ui/kbd';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { useLivePropsPoll } from '@/hooks/use-live-props';

--- a/resources/js/components/layout/app-sidebar.tsx
+++ b/resources/js/components/layout/app-sidebar.tsx
@@ -1,4 +1,11 @@
 import { Link, router, usePage } from '@inertiajs/react';
+import { useEffect } from 'react';
+
+import PostingScheduleController from '@/actions/App/Http/Controllers/Posts/PostingScheduleController';
+import AppLogo from '@/components/layout/app-logo';
+import { NavUser } from '@/components/layout/nav-user';
+import { SidebarFooterCard } from '@/components/layout/sidebar-footer-card';
+import type { IconComponent } from '@/components/ui/icons';
 import {
     Blocks,
     CalendarDays,
@@ -16,14 +23,7 @@ import {
     Shield,
     Users,
     Wrench,
-    type LucideIcon,
-} from 'lucide-react';
-import { useEffect } from 'react';
-
-import PostingScheduleController from '@/actions/App/Http/Controllers/Posts/PostingScheduleController';
-import AppLogo from '@/components/layout/app-logo';
-import { NavUser } from '@/components/layout/nav-user';
-import { SidebarFooterCard } from '@/components/layout/sidebar-footer-card';
+} from '@/components/ui/icons';
 import { Kbd } from '@/components/ui/kbd';
 import {
     Sidebar,
@@ -69,20 +69,20 @@ import { index as postsRoute } from '@/routes/posts';
 type NavItem = {
     title: string;
     href: NonNullable<Parameters<typeof Link>[0]['href']>;
-    icon: LucideIcon;
+    icon: IconComponent;
 };
 
 export const workspaceSettingsLabel = 'Workspace';
 export const instanceSettingsLabel = 'Instance settings';
 
-const workspaceSettingsIcons: Record<WorkspaceSettingsNavKey, LucideIcon> = {
+const workspaceSettingsIcons: Record<WorkspaceSettingsNavKey, IconComponent> = {
     overview: Settings,
     members: Users,
     apiKeys: KeyRound,
     subscription: CreditCard,
 };
 
-const instanceSettingsIcons: Record<InstanceSettingsNavKey, LucideIcon> = {
+const instanceSettingsIcons: Record<InstanceSettingsNavKey, IconComponent> = {
     general: Wrench,
     polling: RefreshCw,
     platforms: Blocks,

--- a/resources/js/components/layout/command-palette.tsx
+++ b/resources/js/components/layout/command-palette.tsx
@@ -1,17 +1,4 @@
 import { router, usePage } from '@inertiajs/react';
-import {
-    Building2,
-    CalendarDays,
-    FileText,
-    ListChecks,
-    LogOut,
-    Moon,
-    Pencil,
-    Plug,
-    Settings,
-    Share2,
-    Wrench,
-} from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import PostingScheduleController from '@/actions/App/Http/Controllers/Posts/PostingScheduleController';
@@ -27,6 +14,19 @@ import {
     CommandList,
     CommandSeparator,
 } from '@/components/ui/command';
+import {
+    Building2,
+    CalendarDays,
+    FileText,
+    ListChecks,
+    LogOut,
+    Moon,
+    Pencil,
+    Plug,
+    Settings,
+    Share2,
+    Wrench,
+} from '@/components/ui/icons';
 import { useAppearance } from '@/hooks/use-appearance';
 import { parseDateJump } from '@/lib/command/parse-date-jump';
 import {

--- a/resources/js/components/layout/command-palette/compose-destination-page.tsx
+++ b/resources/js/components/layout/command-palette/compose-destination-page.tsx
@@ -1,7 +1,7 @@
 import { router } from '@inertiajs/react';
-import { ListChecks, Pencil, Share2 } from 'lucide-react';
 
 import { CommandGroup, CommandItem } from '@/components/ui/command';
+import { ListChecks, Pencil, Share2 } from '@/components/ui/icons';
 
 interface Account {
     id: string;

--- a/resources/js/components/layout/command-palette/connect-platform-page.tsx
+++ b/resources/js/components/layout/command-palette/connect-platform-page.tsx
@@ -1,7 +1,7 @@
 import { router } from '@inertiajs/react';
-import { Plug } from 'lucide-react';
 
 import { CommandGroup, CommandItem } from '@/components/ui/command';
+import { Plug } from '@/components/ui/icons';
 import {
     connect as accountConnect,
     index as accountsRoute,

--- a/resources/js/components/layout/command-palette/posts-group.tsx
+++ b/resources/js/components/layout/command-palette/posts-group.tsx
@@ -1,10 +1,9 @@
-import { FileText } from 'lucide-react';
-
 import {
     CommandGroup,
     CommandItem,
     CommandSeparator,
 } from '@/components/ui/command';
+import { FileText } from '@/components/ui/icons';
 import type { RecentItem } from '@/lib/command/recents';
 import { show as postShow } from '@/routes/posts';
 

--- a/resources/js/components/layout/command-palette/theme-page.tsx
+++ b/resources/js/components/layout/command-palette/theme-page.tsx
@@ -1,6 +1,5 @@
-import { Moon, Settings, Sun } from 'lucide-react';
-
 import { CommandGroup, CommandItem } from '@/components/ui/command';
+import { Moon, Settings, Sun } from '@/components/ui/icons';
 import type { Appearance } from '@/hooks/use-appearance';
 
 interface ThemePageProps {

--- a/resources/js/components/layout/nav-user.tsx
+++ b/resources/js/components/layout/nav-user.tsx
@@ -1,5 +1,4 @@
 import { usePage } from '@inertiajs/react';
-import { ChevronsUpDown } from 'lucide-react';
 
 import { UserInfo } from '@/components/layout/user-info';
 import { UserMenuContent } from '@/components/layout/user-menu-content';
@@ -8,6 +7,7 @@ import {
     DropdownMenuContent,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { ChevronsUpDown } from '@/components/ui/icons';
 import {
     SidebarMenu,
     SidebarMenuButton,

--- a/resources/js/components/layout/sidebar-footer-card.tsx
+++ b/resources/js/components/layout/sidebar-footer-card.tsx
@@ -1,7 +1,7 @@
 import { Link, usePage } from '@inertiajs/react';
-import { Heart, Star } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
+import { Heart, Star } from '@/components/ui/icons';
 
 export function formatStars(count: number): string {
     if (count < 1000) {

--- a/resources/js/components/layout/user-menu-content.tsx
+++ b/resources/js/components/layout/user-menu-content.tsx
@@ -1,5 +1,4 @@
 import { Link } from '@inertiajs/react';
-import { LogOut, Settings } from 'lucide-react';
 
 import { UserInfo } from '@/components/layout/user-info';
 import {
@@ -8,6 +7,7 @@ import {
     DropdownMenuLabel,
     DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
+import { LogOut, Settings } from '@/components/ui/icons';
 import { useMobileNavigation } from '@/hooks/use-mobile-navigation';
 import { logout } from '@/routes';
 import { edit } from '@/routes/profile';

--- a/resources/js/components/notifications/notification-bell.tsx
+++ b/resources/js/components/notifications/notification-bell.tsx
@@ -1,8 +1,8 @@
 import { Link, router, useHttp, usePage } from '@inertiajs/react';
-import { Bell, Loader2, Trash2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Bell, Loader2, Trash2 } from '@/components/ui/icons';
 import {
     Popover,
     PopoverContent,

--- a/resources/js/components/onboarding/getting-started-card.tsx
+++ b/resources/js/components/onboarding/getting-started-card.tsx
@@ -1,16 +1,5 @@
 import { Link, router } from '@inertiajs/react';
 import {
-    Check,
-    ChevronDown,
-    ChevronRight,
-    Circle,
-    Clock,
-    PenLine,
-    Radio,
-    UserPlus,
-    X,
-} from 'lucide-react';
-import {
     AnimatePresence,
     domAnimation,
     LazyMotion,
@@ -20,6 +9,17 @@ import {
 import { useState, useSyncExternalStore } from 'react';
 
 import { Button } from '@/components/ui/button';
+import {
+    Check,
+    ChevronDown,
+    ChevronRight,
+    Circle,
+    Clock,
+    PenLine,
+    Radio,
+    UserPlus,
+    X,
+} from '@/components/ui/icons';
 import { cn } from '@/lib/utils';
 import {
     dismiss as dismissRoute,

--- a/resources/js/components/posts/calendar/agenda-list.tsx
+++ b/resources/js/components/posts/calendar/agenda-list.tsx
@@ -1,9 +1,9 @@
 import { router } from '@inertiajs/react';
-import { Plus } from 'lucide-react';
 
 import ComposerController from '@/actions/App/Http/Controllers/Posts/ComposerController';
 import { PlatformGlyphStack } from '@/components/common/platform-glyph-stack';
 import type { PostRowData, PostStatus } from '@/components/posts/post-row';
+import { Plus } from '@/components/ui/icons';
 import { useSchedulingTimezone } from '@/hooks/posts/use-scheduling-timezone';
 import { dayjs, toUserTz, weekRange } from '@/lib/datetime/dayjs';
 import type { Dayjs } from '@/lib/datetime/dayjs';

--- a/resources/js/components/posts/calendar/calendar-header.tsx
+++ b/resources/js/components/posts/calendar/calendar-header.tsx
@@ -1,12 +1,12 @@
-import {
-    Calendar as CalendarIcon,
-    ChevronLeft,
-    ChevronRight,
-} from 'lucide-react';
 import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
+import {
+    Calendar as CalendarIcon,
+    ChevronLeft,
+    ChevronRight,
+} from '@/components/ui/icons';
 import {
     Popover,
     PopoverContent,

--- a/resources/js/components/posts/post-page-actions.tsx
+++ b/resources/js/components/posts/post-page-actions.tsx
@@ -1,13 +1,4 @@
 import { Link, router, useHttp, usePage } from '@inertiajs/react';
-import {
-    CalendarClock,
-    CalendarX,
-    Copy,
-    MessageCircle,
-    RotateCw,
-    Share2,
-    Trash2,
-} from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import ComposerController from '@/actions/App/Http/Controllers/Posts/ComposerController';
@@ -19,6 +10,15 @@ import {
     PickTimePopover,
 } from '@/components/compose/pick-time-popover';
 import { Button } from '@/components/ui/button';
+import {
+    CalendarClock,
+    CalendarX,
+    Copy,
+    MessageCircle,
+    RotateCw,
+    Share2,
+    Trash2,
+} from '@/components/ui/icons';
 import { useSchedulingTimezone } from '@/hooks/posts/use-scheduling-timezone';
 import { dayjs } from '@/lib/datetime/dayjs';
 import { postCapabilities } from '@/lib/posts/capabilities';

--- a/resources/js/components/posts/post-row-actions.tsx
+++ b/resources/js/components/posts/post-row-actions.tsx
@@ -1,6 +1,5 @@
 import { router } from '@inertiajs/react';
 import dayjs from 'dayjs';
-import { MoreHorizontal } from 'lucide-react';
 import { useState } from 'react';
 
 import ComposerController from '@/actions/App/Http/Controllers/Posts/ComposerController';
@@ -18,6 +17,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { MoreHorizontal } from '@/components/ui/icons';
 import { useSchedulingTimezone } from '@/hooks/posts/use-scheduling-timezone';
 import { removeById, replaceById } from '@/lib/optimistic';
 import { postCapabilities } from '@/lib/posts/capabilities';

--- a/resources/js/components/posts/post-row.tsx
+++ b/resources/js/components/posts/post-row.tsx
@@ -1,11 +1,11 @@
 import { router } from '@inertiajs/react';
-import { Film, Image as ImageIcon } from 'lucide-react';
 import { Fragment } from 'react';
 
 import ComposerController from '@/actions/App/Http/Controllers/Posts/ComposerController';
 import { PlatformGlyph } from '@/components/common/platform-glyph';
 import type { ChipTarget } from '@/components/compose/target-status-chips';
 import { Badge } from '@/components/ui/badge';
+import { Film, Image } from '@/components/ui/icons';
 import { dayjs } from '@/lib/datetime/dayjs';
 import { postStatusMeta } from '@/lib/posts/status';
 import { cn } from '@/lib/utils';
@@ -88,7 +88,7 @@ function MediaThumb({
                     {preview.kind === 'video' ? (
                         <Film size={16} strokeWidth={1.75} />
                     ) : (
-                        <ImageIcon size={16} strokeWidth={1.75} />
+                        <Image size={16} strokeWidth={1.75} />
                     )}
                 </div>
             )}

--- a/resources/js/components/posts/published-post-view.tsx
+++ b/resources/js/components/posts/published-post-view.tsx
@@ -1,13 +1,4 @@
 import { Deferred, router, useHttp, usePage } from '@inertiajs/react';
-import {
-    CheckCircle2,
-    ExternalLink,
-    Eye,
-    Heart,
-    MessageCircle,
-    RefreshCw,
-    Repeat2,
-} from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -16,6 +7,15 @@ import { PlatformGlyph } from '@/components/common/platform-glyph';
 import { TargetStatusChips } from '@/components/compose/target-status-chips';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
+import {
+    CheckCircle2,
+    ExternalLink,
+    Eye,
+    Heart,
+    MessageCircle,
+    RefreshCw,
+    Repeat2,
+} from '@/components/ui/icons';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { dayjs } from '@/lib/datetime/dayjs';
@@ -59,9 +59,9 @@ const METRIC_ICON: Record<EngagementKey, typeof Heart> = {
 };
 
 /**
- * lucide's MessageCircle is drawn heavier (and carries a chat tail) than the
- * leaner Repeat2/Eye/Heart glyphs, so at a shared box it reads oversized in a
- * tight number row. A hair smaller brings it back to optical parity.
+ * MessageCircle is drawn heavier (and carries a chat tail) than the leaner
+ * Repeat2/Eye/Heart glyphs, so at a shared box it reads oversized in a tight
+ * number row. A hair smaller brings it back to optical parity.
  */
 const METRIC_ICON_CLASS: Partial<Record<EngagementKey, string>> = {
     comments: 'size-[0.875rem]',

--- a/resources/js/components/queue/add-time-popover.tsx
+++ b/resources/js/components/queue/add-time-popover.tsx
@@ -1,7 +1,7 @@
-import { Plus } from 'lucide-react';
 import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Plus } from '@/components/ui/icons';
 import {
     Popover,
     PopoverContent,

--- a/resources/js/components/queue/cadence-overview.tsx
+++ b/resources/js/components/queue/cadence-overview.tsx
@@ -1,5 +1,4 @@
-import { CalendarClock } from 'lucide-react';
-
+import { CalendarClock } from '@/components/ui/icons';
 import { type Dayjs } from '@/lib/datetime/dayjs';
 import {
     DISPLAY_DAYS,

--- a/resources/js/components/queue/quick-add-toolbar.tsx
+++ b/resources/js/components/queue/quick-add-toolbar.tsx
@@ -1,7 +1,7 @@
-import { Copy } from 'lucide-react';
 import type { Dispatch, SetStateAction } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Copy } from '@/components/ui/icons';
 import {
     copyMondayToWeekdays,
     mergeSlots,

--- a/resources/js/components/settings/appearance-tabs.tsx
+++ b/resources/js/components/settings/appearance-tabs.tsx
@@ -1,7 +1,7 @@
-import type { LucideIcon } from 'lucide-react';
-import { Monitor, Moon, Sun } from 'lucide-react';
 import type { HTMLAttributes } from 'react';
 
+import type { IconComponent } from '@/components/ui/icons';
+import { Monitor, Moon, Sun } from '@/components/ui/icons';
 import type { Appearance } from '@/hooks/use-appearance';
 import { useAppearance } from '@/hooks/use-appearance';
 import { cn } from '@/lib/utils';
@@ -12,7 +12,7 @@ export default function AppearanceToggleTab({
 }: HTMLAttributes<HTMLDivElement>) {
     const { appearance, updateAppearance } = useAppearance();
 
-    const tabs: { value: Appearance; icon: LucideIcon; label: string }[] = [
+    const tabs: { value: Appearance; icon: IconComponent; label: string }[] = [
         { value: 'light', icon: Sun, label: 'Light' },
         { value: 'dark', icon: Moon, label: 'Dark' },
         { value: 'system', icon: Monitor, label: 'System' },

--- a/resources/js/components/settings/create-api-key-dialog.tsx
+++ b/resources/js/components/settings/create-api-key-dialog.tsx
@@ -1,5 +1,4 @@
 import { Form } from '@inertiajs/react';
-import { CalendarIcon, Plus } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -16,6 +15,7 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
+import { Calendar as CalendarIcon, Plus } from '@/components/ui/icons';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {

--- a/resources/js/components/settings/invite-member-dialog.tsx
+++ b/resources/js/components/settings/invite-member-dialog.tsx
@@ -1,5 +1,4 @@
 import { Form } from '@inertiajs/react';
-import { UserPlus } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -15,6 +14,7 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
+import { UserPlus } from '@/components/ui/icons';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {

--- a/resources/js/components/settings/member-role-helpers.tsx
+++ b/resources/js/components/settings/member-role-helpers.tsx
@@ -1,4 +1,4 @@
-import { Crown, Shield, User } from 'lucide-react';
+import { Crown, Shield, User } from '@/components/ui/icons';
 
 export function roleIcon(role: string) {
     switch (role) {

--- a/resources/js/components/settings/members-table.tsx
+++ b/resources/js/components/settings/members-table.tsx
@@ -1,5 +1,3 @@
-import { Crown, MoreVertical, Trash2 } from 'lucide-react';
-
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -10,6 +8,7 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Crown, MoreVertical, Trash2 } from '@/components/ui/icons';
 import {
     Table,
     TableBody,

--- a/resources/js/components/settings/pending-invitations-table.tsx
+++ b/resources/js/components/settings/pending-invitations-table.tsx
@@ -1,8 +1,7 @@
-import { Mail, Trash2 } from 'lucide-react';
-
 import Heading from '@/components/common/heading';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Mail, Trash2 } from '@/components/ui/icons';
 import {
     Table,
     TableBody,

--- a/resources/js/components/socialite/provider-icon.tsx
+++ b/resources/js/components/socialite/provider-icon.tsx
@@ -1,9 +1,9 @@
-import { Globe } from 'lucide-react';
 import type { ReactElement, SVGProps } from 'react';
 
 import GoogleIcon from '@/components/socialite/icons/google-icon';
 import LinkedInIcon from '@/components/socialite/icons/linkedin-icon';
 import XIcon from '@/components/socialite/icons/x-icon';
+import { Globe } from '@/components/ui/icons';
 
 const ICONS: Record<string, (props: SVGProps<SVGSVGElement>) => ReactElement> =
     {

--- a/resources/js/components/ui/__tests__/sonner.test.tsx
+++ b/resources/js/components/ui/__tests__/sonner.test.tsx
@@ -21,11 +21,11 @@ beforeAll(() => {
 });
 
 const INTENTS = [
-    { fire: toast.success, message: 'Published', type: 'success', icon: 'lucide-circle-check' },
-    { fire: toast.error, message: 'Publish failed', type: 'error', icon: 'lucide-octagon-x' },
-    { fire: toast.warning, message: 'Nearly out of room', type: 'warning', icon: 'lucide-triangle-alert' },
-    { fire: toast.info, message: 'Draft autosaved', type: 'info', icon: 'lucide-info' },
-    { fire: toast.loading, message: 'Publishing', type: 'loading', icon: 'lucide-loader-circle' },
+    { fire: toast.success, message: 'Published', type: 'success' },
+    { fire: toast.error, message: 'Publish failed', type: 'error' },
+    { fire: toast.warning, message: 'Nearly out of room', type: 'warning' },
+    { fire: toast.info, message: 'Draft autosaved', type: 'info' },
+    { fire: toast.loading, message: 'Publishing', type: 'loading' },
 ] as const;
 
 async function toastElement(message: string): Promise<HTMLElement> {
@@ -60,12 +60,15 @@ describe('Toaster intent styling contract', () => {
 
         const icons: string[] = [];
 
-        for (const { message, icon } of INTENTS) {
+        for (const { message } of INTENTS) {
             const li = await toastElement(message);
             const svg = li.querySelector('[data-icon] svg');
 
-            expect(svg).toHaveClass(icon);
-            icons.push(icon);
+            expect(svg).not.toBeNull();
+            // hugeicons doesn't add a per-icon class (or any library class at
+            // all), so identity has to be checked via the actual path markup
+            // rather than a class name.
+            icons.push(svg!.innerHTML);
         }
 
         // Redundant non-color encoding (WCAG 1.4.1): color alone must not be

--- a/resources/js/components/ui/breadcrumb.tsx
+++ b/resources/js/components/ui/breadcrumb.tsx
@@ -3,7 +3,7 @@ import { mergeProps } from "@base-ui/react/merge-props"
 import { useRender } from "@base-ui/react/use-render"
 
 import { cn } from "@/lib/utils"
-import { ChevronRightIcon, MoreHorizontalIcon } from "lucide-react"
+import { ChevronRight, MoreHorizontal } from '@/components/ui/icons';
 
 function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
   return (
@@ -86,7 +86,7 @@ function BreadcrumbSeparator({
       {...props}
     >
       {children ?? (
-        <ChevronRightIcon />
+        <ChevronRight />
       )}
     </li>
   )
@@ -107,7 +107,7 @@ function BreadcrumbEllipsis({
       )}
       {...props}
     >
-      <MoreHorizontalIcon
+      <MoreHorizontal
       />
       <span className="sr-only">More</span>
     </span>

--- a/resources/js/components/ui/calendar.tsx
+++ b/resources/js/components/ui/calendar.tsx
@@ -8,7 +8,7 @@ import {
 
 import { cn } from "@/lib/utils"
 import { Button, buttonVariants } from "@/components/ui/button"
-import { ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon } from "lucide-react"
+import { ChevronLeft, ChevronRight, ChevronDown } from '@/components/ui/icons';
 
 function Calendar({
   className,
@@ -145,18 +145,18 @@ function Calendar({
         Chevron: ({ className, orientation, ...props }) => {
           if (orientation === "left") {
             return (
-              <ChevronLeftIcon className={cn("size-4", className)} {...props} />
+              <ChevronLeft className={cn("size-4", className)} {...props} />
             )
           }
 
           if (orientation === "right") {
             return (
-              <ChevronRightIcon className={cn("size-4", className)} {...props} />
+              <ChevronRight className={cn("size-4", className)} {...props} />
             )
           }
 
           return (
-            <ChevronDownIcon className={cn("size-4", className)} {...props} />
+            <ChevronDown className={cn("size-4", className)} {...props} />
           )
         },
         DayButton: ({ ...props }) => (

--- a/resources/js/components/ui/checkbox.tsx
+++ b/resources/js/components/ui/checkbox.tsx
@@ -3,7 +3,7 @@
 import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
 
 import { cn } from "@/lib/utils"
-import { CheckIcon } from "lucide-react"
+import { Check } from '@/components/ui/icons';
 
 function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
   return (
@@ -19,7 +19,7 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
         data-slot="checkbox-indicator"
         className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
       >
-        <CheckIcon
+        <Check
         />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>

--- a/resources/js/components/ui/command.tsx
+++ b/resources/js/components/ui/command.tsx
@@ -13,7 +13,7 @@ import {
   InputGroup,
   InputGroupAddon,
 } from "@/components/ui/input-group"
-import { SearchIcon, CheckIcon } from "lucide-react"
+import { Search, Check } from '@/components/ui/icons';
 
 function Command({
   className,
@@ -82,7 +82,7 @@ function CommandInput({
           {...props}
         />
         <InputGroupAddon>
-          <SearchIcon className="size-4 shrink-0 opacity-50" />
+          <Search className="size-4 shrink-0 opacity-50" />
         </InputGroupAddon>
       </InputGroup>
     </div>
@@ -162,7 +162,7 @@ function CommandItem({
       {...props}
     >
       {children}
-      <CheckIcon className="ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100" />
+      <Check className="ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100" />
     </CommandPrimitive.Item>
   )
 }

--- a/resources/js/components/ui/dialog.tsx
+++ b/resources/js/components/ui/dialog.tsx
@@ -3,7 +3,7 @@ import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import { XIcon } from "lucide-react"
+import { X } from '@/components/ui/icons';
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
@@ -68,7 +68,7 @@ function DialogContent({
               />
             }
           >
-            <XIcon
+            <X
             />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>

--- a/resources/js/components/ui/dropdown-menu.tsx
+++ b/resources/js/components/ui/dropdown-menu.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Menu as MenuPrimitive } from "@base-ui/react/menu"
 
 import { cn } from "@/lib/utils"
-import { ChevronRightIcon, CheckIcon } from "lucide-react"
+import { ChevronRight, Check } from '@/components/ui/icons';
 
 function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
   return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
@@ -124,7 +124,7 @@ function DropdownMenuSubTrigger({
       {...props}
     >
       {children}
-      <ChevronRightIcon className="ml-auto" />
+      <ChevronRight className="ml-auto" />
     </MenuPrimitive.SubmenuTrigger>
   )
 }
@@ -178,7 +178,7 @@ function DropdownMenuCheckboxItem({
         data-slot="dropdown-menu-checkbox-item-indicator"
       >
         <MenuPrimitive.CheckboxItemIndicator>
-          <CheckIcon
+          <Check
           />
         </MenuPrimitive.CheckboxItemIndicator>
       </span>
@@ -219,7 +219,7 @@ function DropdownMenuRadioItem({
         data-slot="dropdown-menu-radio-item-indicator"
       >
         <MenuPrimitive.RadioItemIndicator>
-          <CheckIcon
+          <Check
           />
         </MenuPrimitive.RadioItemIndicator>
       </span>

--- a/resources/js/components/ui/icon.tsx
+++ b/resources/js/components/ui/icon.tsx
@@ -1,7 +1,7 @@
-import type { LucideIcon } from 'lucide-react';
+import type { IconComponent } from '@/components/ui/icons';
 
 interface IconProps {
-    iconNode?: LucideIcon | null;
+    iconNode?: IconComponent | null;
     className?: string;
 }
 

--- a/resources/js/components/ui/icons.tsx
+++ b/resources/js/components/ui/icons.tsx
@@ -69,7 +69,7 @@ import {
     Message02Icon,
     MessageAdd01Icon,
     MinusSignIcon,
-    MoonIcon,
+    Moon02Icon,
     MoreHorizontalIcon,
     MoreVerticalIcon,
     MusicNote01Icon,
@@ -202,7 +202,7 @@ export const MessageSquarePlus = icon(MessageAdd01Icon);
 export const MessagesSquare = icon(Message02Icon);
 export const Minus = icon(MinusSignIcon);
 export const Monitor = icon(ComputerIcon);
-export const Moon = icon(MoonIcon);
+export const Moon = icon(Moon02Icon);
 export const MoreHorizontal = icon(MoreHorizontalIcon);
 export const MoreVertical = icon(MoreVerticalIcon);
 export const Music2 = icon(MusicNote01Icon);

--- a/resources/js/components/ui/icons.tsx
+++ b/resources/js/components/ui/icons.tsx
@@ -1,0 +1,239 @@
+import { HugeiconsIcon } from '@hugeicons/react';
+import type { HugeiconsProps, IconSvgElement } from '@hugeicons/react';
+import {
+    Alert02Icon,
+    AlertCircleIcon,
+    ArchiveIcon,
+    ArrowDown01Icon,
+    ArrowLeft01Icon,
+    ArrowUp01Icon,
+    ArrowUpRight01Icon,
+    AtSignIcon,
+    AttachmentIcon,
+    BarChartIcon,
+    BellIcon,
+    BlocksIcon,
+    BookOpen01Icon,
+    BookTextIcon,
+    Bookmark01Icon,
+    BotIcon,
+    BubbleChatIcon,
+    Building02Icon,
+    Calendar01Icon,
+    CalendarClockIcon,
+    CalendarDaysIcon,
+    CalendarXIcon,
+    Cancel01Icon,
+    ChartColumnIcon,
+    CheckCheckIcon,
+    CheckIcon,
+    CheckListIcon,
+    ChevronDownIcon,
+    ChevronLeftIcon,
+    ChevronRightIcon,
+    ChevronUpIcon,
+    CircleCheckIcon,
+    CircleIcon,
+    ClapperboardIcon,
+    Clock01Icon,
+    ComputerIcon,
+    CopyIcon,
+    CreditCardIcon,
+    CropIcon,
+    CrownIcon,
+    Delete02Icon,
+    ExternalLinkIcon,
+    EyeIcon,
+    EyeOffIcon,
+    File02Icon,
+    Film01Icon,
+    FilterIcon,
+    Folder01Icon,
+    GlobeIcon,
+    HeartIcon,
+    Home01Icon,
+    Image01Icon,
+    ImagePlayIcon,
+    InboxIcon,
+    InformationCircleIcon,
+    Key01Icon,
+    Layers01Icon,
+    LayoutGridIcon,
+    Loading03Icon,
+    LockIcon,
+    Logout01Icon,
+    MagicWand01Icon,
+    Mail01Icon,
+    Menu01Icon,
+    Message01Icon,
+    Message02Icon,
+    MessageAdd01Icon,
+    MinusSignIcon,
+    MoonIcon,
+    MoreHorizontalIcon,
+    MoreVerticalIcon,
+    MusicNote01Icon,
+    OctagonXIcon,
+    PanelLeftIcon,
+    PauseCircleIcon,
+    PauseIcon,
+    PencilEdit01Icon,
+    PencilIcon,
+    PinIcon,
+    PlayIcon,
+    Plug01Icon,
+    PlusSignIcon,
+    RadioIcon,
+    RefreshIcon,
+    RepeatIcon,
+    RocketIcon,
+    RotateClockwiseIcon,
+    ScanIcon,
+    Search01Icon,
+    SearchRemoveIcon,
+    SecurityCheckIcon,
+    SentIcon,
+    Settings01Icon,
+    Share01Icon,
+    Shield01Icon,
+    ShuffleIcon,
+    SmileIcon,
+    SplitIcon,
+    StarIcon,
+    Sun01Icon,
+    ThumbsUpIcon,
+    TrendingUpDownIcon,
+    UnfoldMoreIcon,
+    UserAdd01Icon,
+    UserGroupIcon,
+    UserIcon,
+    VolumeHighIcon,
+    VolumeLowIcon,
+    VolumeMute01Icon,
+    Wrench01Icon,
+    ZapIcon,
+} from '@hugeicons/core-free-icons';
+import type { ComponentType } from 'react';
+
+export type IconComponent = ComponentType<HugeiconsProps>;
+
+function icon(data: IconSvgElement): IconComponent {
+    return function Icon(props: HugeiconsProps) {
+        return <HugeiconsIcon icon={data} {...props} />;
+    };
+}
+
+export const AlertCircle = icon(AlertCircleIcon);
+export const AlertTriangle = icon(Alert02Icon);
+export const Archive = icon(ArchiveIcon);
+export const ArrowDown = icon(ArrowDown01Icon);
+export const ArrowLeft = icon(ArrowLeft01Icon);
+export const ArrowUp = icon(ArrowUp01Icon);
+export const ArrowUpRight = icon(ArrowUpRight01Icon);
+export const AtSign = icon(AtSignIcon);
+export const BarChart3 = icon(BarChartIcon);
+export const Bell = icon(BellIcon);
+export const Blocks = icon(BlocksIcon);
+export const BookOpen = icon(BookOpen01Icon);
+export const BookText = icon(BookTextIcon);
+export const Bookmark = icon(Bookmark01Icon);
+export const Bot = icon(BotIcon);
+export const Building2 = icon(Building02Icon);
+export const Calendar = icon(Calendar01Icon);
+export const CalendarClock = icon(CalendarClockIcon);
+export const CalendarDays = icon(CalendarDaysIcon);
+export const CalendarX = icon(CalendarXIcon);
+export const ChartColumn = icon(ChartColumnIcon);
+export const Check = icon(CheckIcon);
+export const CheckCheck = icon(CheckCheckIcon);
+export const CheckCircle2 = icon(CircleCheckIcon);
+export const ChevronDown = icon(ChevronDownIcon);
+export const ChevronLeft = icon(ChevronLeftIcon);
+export const ChevronRight = icon(ChevronRightIcon);
+export const ChevronUp = icon(ChevronUpIcon);
+export const ChevronsUpDown = icon(UnfoldMoreIcon);
+export const Circle = icon(CircleIcon);
+export const CircleAlert = icon(AlertCircleIcon);
+export const CircleCheck = icon(CircleCheckIcon);
+export const Clapperboard = icon(ClapperboardIcon);
+export const Clock = icon(Clock01Icon);
+export const Copy = icon(CopyIcon);
+export const CreditCard = icon(CreditCardIcon);
+export const Crop = icon(CropIcon);
+export const Crown = icon(CrownIcon);
+export const ExternalLink = icon(ExternalLinkIcon);
+export const Eye = icon(EyeIcon);
+export const EyeOff = icon(EyeOffIcon);
+export const FileText = icon(File02Icon);
+export const Film = icon(Film01Icon);
+export const Filter = icon(FilterIcon);
+export const Folder = icon(Folder01Icon);
+export const Globe = icon(GlobeIcon);
+export const Heart = icon(HeartIcon);
+export const Home = icon(Home01Icon);
+export const Image = icon(Image01Icon);
+export const ImagePlay = icon(ImagePlayIcon);
+export const Inbox = icon(InboxIcon);
+export const Info = icon(InformationCircleIcon);
+export const KeyRound = icon(Key01Icon);
+export const Layers = icon(Layers01Icon);
+export const LayoutGrid = icon(LayoutGridIcon);
+export const Loader2 = icon(Loading03Icon);
+export const LoaderCircle = icon(Loading03Icon);
+export const LockKeyhole = icon(LockIcon);
+export const LogOut = icon(Logout01Icon);
+export const Mail = icon(Mail01Icon);
+export const Menu = icon(Menu01Icon);
+export const MessageCircle = icon(Message01Icon);
+export const MessageSquare = icon(BubbleChatIcon);
+export const MessageSquarePlus = icon(MessageAdd01Icon);
+export const MessagesSquare = icon(Message02Icon);
+export const Minus = icon(MinusSignIcon);
+export const Monitor = icon(ComputerIcon);
+export const Moon = icon(MoonIcon);
+export const MoreHorizontal = icon(MoreHorizontalIcon);
+export const MoreVertical = icon(MoreVerticalIcon);
+export const Music2 = icon(MusicNote01Icon);
+export const OctagonX = icon(OctagonXIcon);
+export const PanelLeft = icon(PanelLeftIcon);
+export const Paperclip = icon(AttachmentIcon);
+export const Pause = icon(PauseIcon);
+export const PauseCircle = icon(PauseCircleIcon);
+export const PenLine = icon(PencilEdit01Icon);
+export const Pencil = icon(PencilIcon);
+export const Pin = icon(PinIcon);
+export const Play = icon(PlayIcon);
+export const Plug = icon(Plug01Icon);
+export const Plus = icon(PlusSignIcon);
+export const Radio = icon(RadioIcon);
+export const RefreshCw = icon(RefreshIcon);
+export const Repeat2 = icon(RepeatIcon);
+export const Rocket = icon(RocketIcon);
+export const RotateCw = icon(RotateClockwiseIcon);
+export const ScanLine = icon(ScanIcon);
+export const Search = icon(Search01Icon);
+export const SearchX = icon(SearchRemoveIcon);
+export const Send = icon(SentIcon);
+export const Settings = icon(Settings01Icon);
+export const Share2 = icon(Share01Icon);
+export const Shield = icon(Shield01Icon);
+export const ShieldCheck = icon(SecurityCheckIcon);
+export const Shuffle = icon(ShuffleIcon);
+export const Smile = icon(SmileIcon);
+export const Split = icon(SplitIcon);
+export const Star = icon(StarIcon);
+export const Sun = icon(Sun01Icon);
+export const ThumbsUp = icon(ThumbsUpIcon);
+export const Trash2 = icon(Delete02Icon);
+export const TrendingUp = icon(TrendingUpDownIcon);
+export const TriangleAlert = icon(Alert02Icon);
+export const User = icon(UserIcon);
+export const UserPlus = icon(UserAdd01Icon);
+export const Users = icon(UserGroupIcon);
+export const Volume1 = icon(VolumeLowIcon);
+export const Volume2 = icon(VolumeHighIcon);
+export const VolumeX = icon(VolumeMute01Icon);
+export const Wand2 = icon(MagicWand01Icon);
+export const Wrench = icon(Wrench01Icon);
+export const X = icon(Cancel01Icon);
+export const Zap = icon(ZapIcon);

--- a/resources/js/components/ui/icons.tsx
+++ b/resources/js/components/ui/icons.tsx
@@ -178,6 +178,7 @@ export const Info = icon(InformationCircleIcon);
 export const KeyRound = icon(Key01Icon);
 export const Layers = icon(Layers01Icon);
 export const LayoutGrid = icon(LayoutGridIcon);
+export const ListChecks = icon(CheckListIcon);
 export const Loader2 = icon(Loading03Icon);
 export const LoaderCircle = icon(Loading03Icon);
 export const LockKeyhole = icon(LockIcon);

--- a/resources/js/components/ui/icons.tsx
+++ b/resources/js/components/ui/icons.tsx
@@ -115,11 +115,22 @@ import {
 } from '@hugeicons/core-free-icons';
 import type { ComponentType } from 'react';
 
-export type IconComponent = ComponentType<HugeiconsProps>;
+export type IconProps = Omit<HugeiconsProps, 'strokeWidth'> & {
+    strokeWidth?: string | number;
+};
+export type IconComponent = ComponentType<IconProps>;
 
 function icon(data: IconSvgElement): IconComponent {
-    return function Icon(props: HugeiconsProps) {
-        return <HugeiconsIcon icon={data} {...props} />;
+    return function Icon({ strokeWidth, ...props }: IconProps) {
+        return (
+            <HugeiconsIcon
+                icon={data}
+                strokeWidth={
+                    strokeWidth === undefined ? undefined : Number(strokeWidth)
+                }
+                {...props}
+            />
+        );
     };
 }
 

--- a/resources/js/components/ui/input-otp.tsx
+++ b/resources/js/components/ui/input-otp.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { OTPInput, OTPInputContext } from "input-otp"
 
 import { cn } from "@/lib/utils"
-import { MinusIcon } from "lucide-react"
+import { Minus } from '@/components/ui/icons';
 
 function InputOTP({
   className,
@@ -76,7 +76,7 @@ function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
       role="separator"
       {...props}
     >
-      <MinusIcon
+      <Minus
       />
     </div>
   )

--- a/resources/js/components/ui/navigation-menu.tsx
+++ b/resources/js/components/ui/navigation-menu.tsx
@@ -2,7 +2,7 @@ import { NavigationMenu as NavigationMenuPrimitive } from "@base-ui/react/naviga
 import { cva } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
-import { ChevronDownIcon } from "lucide-react"
+import { ChevronDown } from '@/components/ui/icons';
 
 function NavigationMenu({
   align = "start",
@@ -71,7 +71,7 @@ function NavigationMenuTrigger({
       {...props}
     >
       {children}{" "}
-      <ChevronDownIcon className="relative top-px ml-1 size-3 transition duration-300 group-data-popup-open/navigation-menu-trigger:rotate-180 group-data-open/navigation-menu-trigger:rotate-180" aria-hidden="true" />
+      <ChevronDown className="relative top-px ml-1 size-3 transition duration-300 group-data-popup-open/navigation-menu-trigger:rotate-180 group-data-open/navigation-menu-trigger:rotate-180" aria-hidden="true" />
     </NavigationMenuPrimitive.Trigger>
   )
 }

--- a/resources/js/components/ui/select.tsx
+++ b/resources/js/components/ui/select.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import { Select as SelectPrimitive } from "@base-ui/react/select"
 
 import { cn } from "@/lib/utils"
-import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+import { ChevronDown, Check, ChevronUp } from '@/components/ui/icons';
 
 const Select = SelectPrimitive.Root
 
@@ -49,7 +49,7 @@ function SelectTrigger({
       {children}
       <SelectPrimitive.Icon
         render={
-          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+          <ChevronDown className="pointer-events-none size-4 text-muted-foreground" />
         }
       />
     </SelectPrimitive.Trigger>
@@ -133,7 +133,7 @@ function SelectItem({
           <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
         }
       >
-        <CheckIcon className="pointer-events-none" />
+        <Check className="pointer-events-none" />
       </SelectPrimitive.ItemIndicator>
     </SelectPrimitive.Item>
   )
@@ -165,7 +165,7 @@ function SelectScrollUpButton({
       )}
       {...props}
     >
-      <ChevronUpIcon
+      <ChevronUp
       />
     </SelectPrimitive.ScrollUpArrow>
   )
@@ -184,7 +184,7 @@ function SelectScrollDownButton({
       )}
       {...props}
     >
-      <ChevronDownIcon
+      <ChevronDown
       />
     </SelectPrimitive.ScrollDownArrow>
   )

--- a/resources/js/components/ui/sheet.tsx
+++ b/resources/js/components/ui/sheet.tsx
@@ -5,7 +5,7 @@ import { Dialog as SheetPrimitive } from "@base-ui/react/dialog"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import { XIcon } from "lucide-react"
+import { X } from '@/components/ui/icons';
 
 function Sheet({ ...props }: SheetPrimitive.Root.Props) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />
@@ -70,7 +70,7 @@ function SheetContent({
               />
             }
           >
-            <XIcon
+            <X
             />
             <span className="sr-only">Close</span>
           </SheetPrimitive.Close>

--- a/resources/js/components/ui/sidebar.tsx
+++ b/resources/js/components/ui/sidebar.tsx
@@ -23,7 +23,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { PanelLeftIcon } from "lucide-react"
+import { PanelLeft } from '@/components/ui/icons';
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
@@ -271,7 +271,7 @@ function SidebarTrigger({
       }}
       {...props}
     >
-      <PanelLeftIcon />
+      <PanelLeft />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   )

--- a/resources/js/components/ui/sonner.tsx
+++ b/resources/js/components/ui/sonner.tsx
@@ -1,12 +1,6 @@
 import { useAppearance } from '@/hooks/use-appearance';
 import { useFlashToast } from '@/hooks/use-flash-toast';
-import {
-    CircleCheckIcon,
-    InfoIcon,
-    Loader2Icon,
-    OctagonXIcon,
-    TriangleAlertIcon,
-} from 'lucide-react';
+import { CircleCheck, Info, Loader2, OctagonX, TriangleAlert } from '@/components/ui/icons';
 import { Toaster as Sonner, type ToasterProps } from 'sonner';
 
 function Toaster({ ...props }: ToasterProps) {
@@ -20,11 +14,11 @@ function Toaster({ ...props }: ToasterProps) {
             className="toaster group"
             position="bottom-right"
             icons={{
-                success: <CircleCheckIcon className="size-4" />,
-                info: <InfoIcon className="size-4" />,
-                warning: <TriangleAlertIcon className="size-4" />,
-                error: <OctagonXIcon className="size-4" />,
-                loading: <Loader2Icon className="size-4 animate-spin" />,
+                success: <CircleCheck className="size-4" />,
+                info: <Info className="size-4" />,
+                warning: <TriangleAlert className="size-4" />,
+                error: <OctagonX className="size-4" />,
+                loading: <Loader2 className="size-4 animate-spin" />,
             }}
             style={
                 {

--- a/resources/js/components/ui/spinner.tsx
+++ b/resources/js/components/ui/spinner.tsx
@@ -1,9 +1,9 @@
 import { cn } from "@/lib/utils"
-import { Loader2Icon } from "lucide-react"
+import { Loader2 } from '@/components/ui/icons';
 
 function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
   return (
-    <Loader2Icon role="status" aria-label="Loading" className={cn("size-4 animate-spin", className)} {...props} />
+    <Loader2 role="status" aria-label="Loading" className={cn("size-4 animate-spin", className)} {...props} />
   )
 }
 

--- a/resources/js/components/workspace/create-workspace-dialog.tsx
+++ b/resources/js/components/workspace/create-workspace-dialog.tsx
@@ -1,5 +1,4 @@
 import { Form } from '@inertiajs/react';
-import { Loader2 } from 'lucide-react';
 
 import WorkspaceController from '@/actions/App/Http/Controllers/WorkspaceController';
 import InputError from '@/components/common/input-error';
@@ -11,6 +10,7 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
+import { Loader2 } from '@/components/ui/icons';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 

--- a/resources/js/components/workspace/workspace-selector.tsx
+++ b/resources/js/components/workspace/workspace-selector.tsx
@@ -1,5 +1,4 @@
 import { usePage } from '@inertiajs/react';
-import { Check, ChevronsUpDown, Loader2, Plus, Users } from 'lucide-react';
 import { useState } from 'react';
 
 import {
@@ -8,6 +7,13 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+    Check,
+    ChevronsUpDown,
+    Loader2,
+    Plus,
+    Users,
+} from '@/components/ui/icons';
 import {
     SidebarMenu,
     SidebarMenuButton,

--- a/resources/js/pages/accounts/connect-meta.tsx
+++ b/resources/js/pages/accounts/connect-meta.tsx
@@ -1,5 +1,4 @@
 import { Head, router } from '@inertiajs/react';
-import { Plug } from 'lucide-react';
 import { useState } from 'react';
 
 import ConnectedAccountController from '@/actions/App/Http/Controllers/ConnectedAccounts/ConnectedAccountController';
@@ -15,6 +14,7 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/components/ui/empty';
+import { Plug } from '@/components/ui/icons';
 
 export type MetaAsset = {
     key: string;

--- a/resources/js/pages/accounts/index.tsx
+++ b/resources/js/pages/accounts/index.tsx
@@ -1,5 +1,4 @@
 import { Head, router, usePage } from '@inertiajs/react';
-import { CircleAlert, Plug, X as XIcon } from 'lucide-react';
 import { useState } from 'react';
 
 import BlueskyOAuthController from '@/actions/App/Http/Controllers/ConnectedAccounts/BlueskyOAuthController';
@@ -17,6 +16,7 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/components/ui/empty';
+import { CircleAlert, Plug, X } from '@/components/ui/icons';
 import { removeById } from '@/lib/optimistic';
 
 export const ACCOUNT_GRID_CLASS = 'grid grid-cols-1 gap-4 lg:grid-cols-2';
@@ -173,7 +173,7 @@ export default function ConnectedAccounts({
                         aria-label="Dismiss"
                         className="absolute top-3 right-3 text-muted-foreground transition-colors hover:text-foreground"
                     >
-                        <XIcon className="size-4" />
+                        <X className="size-4" />
                     </button>
                 </Alert>
             )}

--- a/resources/js/pages/analytics/index.tsx
+++ b/resources/js/pages/analytics/index.tsx
@@ -1,5 +1,4 @@
 import { Head, Link } from '@inertiajs/react';
-import { PauseCircle, TrendingUp } from 'lucide-react';
 import { lazy, Suspense } from 'react';
 
 import { StatTile } from '@/components/analytics/stat-tile';
@@ -13,6 +12,7 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/components/ui/empty';
+import { PauseCircle, TrendingUp } from '@/components/ui/icons';
 import { dayjs } from '@/lib/datetime/dayjs';
 import { disabledPlatformLabels } from '@/lib/platforms';
 import { cn } from '@/lib/utils';

--- a/resources/js/pages/auth/forgot-password.tsx
+++ b/resources/js/pages/auth/forgot-password.tsx
@@ -1,10 +1,10 @@
 // Components
 import { Form, Head } from '@inertiajs/react';
-import { LoaderCircle } from 'lucide-react';
 
 import InputError from '@/components/common/input-error';
 import TextLink from '@/components/common/text-link';
 import { Button } from '@/components/ui/button';
+import { LoaderCircle } from '@/components/ui/icons';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { login } from '@/routes';

--- a/resources/js/pages/auth/workspace-invitation.tsx
+++ b/resources/js/pages/auth/workspace-invitation.tsx
@@ -1,8 +1,8 @@
 import { Head, Link } from '@inertiajs/react';
-import { Calendar, User, Users } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Calendar, User, Users } from '@/components/ui/icons';
 
 type Props = {
     invitation: {

--- a/resources/js/pages/compose/index.tsx
+++ b/resources/js/pages/compose/index.tsx
@@ -1,10 +1,10 @@
 import { Head, Link, usePage } from '@inertiajs/react';
-import { ArrowLeft, PenLine } from 'lucide-react';
 
 import Composer from '@/components/compose/composer';
 import { PostPageActions } from '@/components/posts/post-page-actions';
 import { PublishedPostView } from '@/components/posts/published-post-view';
 import { Button } from '@/components/ui/button';
+import { ArrowLeft, PenLine } from '@/components/ui/icons';
 import { usePostStatusPoll } from '@/hooks/compose/use-post-status-poll';
 import { firstLineTitle } from '@/lib/compose/composer-state';
 import { dashboard } from '@/routes';

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,5 +1,4 @@
 import { Deferred, Head, Link, router, usePage } from '@inertiajs/react';
-import { Plug } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 
 import Composer from '@/components/compose/composer';
@@ -16,6 +15,7 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/components/ui/empty';
+import { Plug } from '@/components/ui/icons';
 import { parseDestinationParam } from '@/lib/compose/composer-state';
 import { shouldShowDashboardNoAccountsNotice } from '@/lib/dashboard/accounts';
 import { dashboard } from '@/routes';

--- a/resources/js/pages/engagement/components/quick-reply-box.tsx
+++ b/resources/js/pages/engagement/components/quick-reply-box.tsx
@@ -1,5 +1,4 @@
 import { useHttp, usePage } from '@inertiajs/react';
-import { ImagePlay, Paperclip, Smile } from 'lucide-react';
 import { useEffect, useRef, useState, type RefObject } from 'react';
 
 import ReplyImageEditController from '@/actions/App/Http/Controllers/Engagement/ReplyImageEditController';
@@ -13,6 +12,7 @@ import EditorBody, {
 import { EmojiPopover } from '@/components/compose/emoji-popover';
 import { GifPopover } from '@/components/compose/gif-popover';
 import { Button } from '@/components/ui/button';
+import { ImagePlay, Paperclip, Smile } from '@/components/ui/icons';
 import { Kbd } from '@/components/ui/kbd';
 import {
     Tooltip,

--- a/resources/js/pages/engagement/components/reply-filters.tsx
+++ b/resources/js/pages/engagement/components/reply-filters.tsx
@@ -1,5 +1,4 @@
 import { router } from '@inertiajs/react';
-import { Check, ChevronDown, FileText, X } from 'lucide-react';
 import { useState } from 'react';
 
 import { PlatformGlyph } from '@/components/common/platform-glyph';
@@ -13,6 +12,7 @@ import {
     CommandItem,
     CommandList,
 } from '@/components/ui/command';
+import { Check, ChevronDown, FileText, X } from '@/components/ui/icons';
 import {
     Popover,
     PopoverContent,

--- a/resources/js/pages/engagement/components/reply-stream.tsx
+++ b/resources/js/pages/engagement/components/reply-stream.tsx
@@ -1,7 +1,6 @@
-import { CheckCheck } from 'lucide-react';
-
 import { PlatformGlyph } from '@/components/common/platform-glyph';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { CheckCheck } from '@/components/ui/icons';
 import { cn } from '@/lib/utils';
 
 import { atHandle, initials, relativeTime } from '../helpers';

--- a/resources/js/pages/engagement/components/reply-thread.tsx
+++ b/resources/js/pages/engagement/components/reply-thread.tsx
@@ -1,6 +1,5 @@
-import { ExternalLink, Heart, Trash2 } from 'lucide-react';
-
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { ExternalLink, Heart, Trash2 } from '@/components/ui/icons';
 import { Skeleton } from '@/components/ui/skeleton';
 import { platformLabel, postPermalink } from '@/lib/posts/permalink';
 import { cn } from '@/lib/utils';

--- a/resources/js/pages/engagement/index.tsx
+++ b/resources/js/pages/engagement/index.tsx
@@ -1,13 +1,4 @@
 import { Deferred, Head, Link, router, useHttp } from '@inertiajs/react';
-import {
-    Archive,
-    ArrowUp,
-    ChevronDown,
-    Inbox,
-    MessagesSquare,
-    PauseCircle,
-    SearchX,
-} from 'lucide-react';
 import { useEffect, useRef, useState, type RefObject } from 'react';
 import { toast } from 'sonner';
 
@@ -29,6 +20,15 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/components/ui/empty';
+import {
+    Archive,
+    ArrowUp,
+    ChevronDown,
+    Inbox,
+    MessagesSquare,
+    PauseCircle,
+    SearchX,
+} from '@/components/ui/icons';
 import { Kbd } from '@/components/ui/kbd';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';

--- a/resources/js/pages/error.tsx
+++ b/resources/js/pages/error.tsx
@@ -1,8 +1,8 @@
 import { Head, Link } from '@inertiajs/react';
-import { ArrowLeft, Home } from 'lucide-react';
 
 import AppLogoIcon from '@/components/layout/app-logo-icon';
 import { Button } from '@/components/ui/button';
+import { ArrowLeft, Home } from '@/components/ui/icons';
 import { home } from '@/routes';
 
 type Props = {

--- a/resources/js/pages/mcp/landing.tsx
+++ b/resources/js/pages/mcp/landing.tsx
@@ -1,8 +1,8 @@
 import { Head, Link } from '@inertiajs/react';
-import { ArrowUpRight, BookText, Bot, Home } from 'lucide-react';
 
 import AppLogoIcon from '@/components/layout/app-logo-icon';
 import { Button } from '@/components/ui/button';
+import { ArrowUpRight, BookText, Bot, Home } from '@/components/ui/icons';
 import { home } from '@/routes';
 
 const DOCS_URL = 'https://shoutrrr.com/docs/mcp';

--- a/resources/js/pages/messages/components/quick-message-box.tsx
+++ b/resources/js/pages/messages/components/quick-message-box.tsx
@@ -1,5 +1,4 @@
 import { usePage } from '@inertiajs/react';
-import { AlertTriangle, ImagePlay, Paperclip, Smile } from 'lucide-react';
 import { useState, type RefObject } from 'react';
 
 import ConversationGifController from '@/actions/App/Http/Controllers/Gifs/ConversationGifController';
@@ -8,6 +7,12 @@ import ConversationVideoUploadController from '@/actions/App/Http/Controllers/Me
 import { EmojiPopover } from '@/components/compose/emoji-popover';
 import { GifPopover } from '@/components/compose/gif-popover';
 import { Button } from '@/components/ui/button';
+import {
+    AlertTriangle,
+    ImagePlay,
+    Paperclip,
+    Smile,
+} from '@/components/ui/icons';
 import { Kbd } from '@/components/ui/kbd';
 import { Textarea } from '@/components/ui/textarea';
 import { useAttachments } from '@/hooks/compose/use-attachments';

--- a/resources/js/pages/messages/index.tsx
+++ b/resources/js/pages/messages/index.tsx
@@ -1,5 +1,4 @@
 import { Deferred, Head, router, useHttp } from '@inertiajs/react';
-import { Archive, Inbox, MessagesSquare, SearchX } from 'lucide-react';
 import { useEffect, useRef, useState, type RefObject } from 'react';
 import { toast } from 'sonner';
 
@@ -13,6 +12,7 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/components/ui/empty';
+import { Archive, Inbox, MessagesSquare, SearchX } from '@/components/ui/icons';
 import { Kbd } from '@/components/ui/kbd';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';

--- a/resources/js/pages/posts/index.tsx
+++ b/resources/js/pages/posts/index.tsx
@@ -6,7 +6,6 @@ import {
     router,
     usePage,
 } from '@inertiajs/react';
-import { Filter, Inbox, Search, SearchX, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { FilterTabs } from '@/components/common/filter-tabs';
@@ -31,6 +30,7 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/components/ui/empty';
+import { Filter, Inbox, Search, SearchX, X } from '@/components/ui/icons';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { dashboard } from '@/routes';

--- a/resources/js/pages/settings/instance-admins.tsx
+++ b/resources/js/pages/settings/instance-admins.tsx
@@ -1,5 +1,4 @@
 import { Form, Head, router, usePage } from '@inertiajs/react';
-import { Crown, MoreVertical, Search, Trash2, UserPlus } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -16,6 +15,13 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+    Crown,
+    MoreVertical,
+    Search,
+    Trash2,
+    UserPlus,
+} from '@/components/ui/icons';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {

--- a/resources/js/pages/settings/workspace/api-keys.tsx
+++ b/resources/js/pages/settings/workspace/api-keys.tsx
@@ -1,5 +1,4 @@
 import { Head, router, usePage } from '@inertiajs/react';
-import { Check, Copy, KeyRound, MoreHorizontal } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -31,6 +30,7 @@ import {
     EmptyMedia,
     EmptyTitle,
 } from '@/components/ui/empty';
+import { Check, Copy, KeyRound, MoreHorizontal } from '@/components/ui/icons';
 import { Input } from '@/components/ui/input';
 import {
     Table,

--- a/resources/js/pages/settings/workspace/overview.tsx
+++ b/resources/js/pages/settings/workspace/overview.tsx
@@ -1,5 +1,4 @@
 import { Form, Head, router } from '@inertiajs/react';
-import { ChevronsUpDown } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -17,6 +16,7 @@ import {
     CommandItem,
     CommandList,
 } from '@/components/ui/command';
+import { ChevronsUpDown } from '@/components/ui/icons';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {

--- a/resources/js/types/navigation.ts
+++ b/resources/js/types/navigation.ts
@@ -1,6 +1,7 @@
 import type { InertiaLinkProps } from '@inertiajs/react';
-import type { LucideIcon } from 'lucide-react';
 import type { HTMLAttributeAnchorTarget } from 'react';
+
+import type { IconComponent } from '@/components/ui/icons';
 
 export type BreadcrumbItem = {
     title: string;
@@ -10,7 +11,7 @@ export type BreadcrumbItem = {
 export type NavItem = {
     title: string;
     href: NonNullable<InertiaLinkProps['href']>;
-    icon?: LucideIcon | null;
+    icon?: IconComponent | null;
     isActive?: boolean;
     target?: HTMLAttributeAnchorTarget;
 };


### PR DESCRIPTION
## Summary
- Add `@hugeicons/react` + `@hugeicons/core-free-icons` and introduce a central icon registry (`resources/js/components/ui/icons.tsx`) exposing lucide-compatible named exports (e.g. `Check`, `X`, `ChevronDown`) backed by hugeicons
- Replace the `LucideIcon` type with a local `IconComponent` type so icon props aren't coupled to a specific icon library
- Route every remaining icon import across components and pages through the new registry instead of importing directly from `lucide-react`
- Remove the `lucide-react` dependency and update `components.json` `iconLibrary` to `hugeicons`
- Fix the dark-mode `Moon` icon to render a proper crescent shape

## Breaking Changes
- None for consumers of the app; internal icon imports must now go through `@/components/ui/icons` rather than `lucide-react`, which is no longer a dependency
