### PR TITLE
fix(posts): fix cursor pagination crash on page 2 of posts feed

### DIFF
--- a/app/Http/Controllers/Posts/PostController.php
+++ b/app/Http/Controllers/Posts/PostController.php
@@ -76,10 +76,25 @@ class PostController extends Controller
                     ->where('status', '!=', PostStatus::Deleted->value)
                     ->when($status !== '' && $status !== 'all', fn ($query) => $query->where('status', $status))
             )
-                ->orderByRaw('COALESCE(scheduled_at, created_at) DESC')
+                // Order by the effective timeline date. Cursor pagination cannot
+                // build its keyset WHERE clause from a raw orderBy (those orders
+                // carry no direction and get stripped, crashing page 2), so the
+                // expression is aliased to a real column and ordered by the alias.
+                // `id` is the unique tiebreaker keyset pagination requires.
+                ->select('posts.*')
+                ->selectRaw('COALESCE(scheduled_at, created_at) as sort_key')
+                ->orderByDesc('sort_key')
+                ->orderByDesc('id')
                 ->cursorPaginate(20)
                 ->withQueryString()
-                ->through(fn (Post $post): array => PostListItem::make($post)))->defer(),
+                // The cursor's keyset is (sort_key, id), so both must survive the
+                // item transform — the paginator reads them off each emitted row to
+                // encode the next cursor. `id` is already in PostListItem; carry the
+                // computed `sort_key` alongside it.
+                ->through(fn (Post $post): array => [
+                    ...PostListItem::make($post),
+                    'sort_key' => $post->getAttribute('sort_key'),
+                ]))->defer(),
             'filters' => ['status' => $status ?: 'all', 'set' => $set, 'platform' => $platform, 'q' => $q],
             'sets' => $sets,
             'counts' => $counts,

--- a/app/Support/Notifications/NotificationPresenter.php
+++ b/app/Support/Notifications/NotificationPresenter.php
@@ -43,7 +43,10 @@ class NotificationPresenter
             ->cursorPaginate(
                 self::PER_PAGE,
                 ['*'],
-                'cursor',
+                // A dedicated cursor name (not the default 'cursor') so a null
+                // cursor here never falls back to reading another cursor-paginated
+                // page's ?cursor= query param off the shared request.
+                'notifications',
                 $cursor !== null ? Cursor::fromEncoded($cursor) : null,
             );
 

--- a/tests/Feature/NotificationFeedTest.php
+++ b/tests/Feature/NotificationFeedTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use App\Enums\WorkspaceRole;
 use App\Models\User;
 use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
 use App\Notifications\PostPublishedNotification;
 use App\Support\Notifications\NotificationPresenter;
+use Illuminate\Pagination\Cursor;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 
@@ -72,6 +75,26 @@ test('the feed is scoped to the current workspace', function () {
         ->getJson(route('notifications.index'))
         ->assertOk()
         ->assertJsonCount(2, 'items');
+});
+
+test('a foreign cursor on another cursor-paginated page does not break the shared notifications prop', function () {
+    // Regression for SHOUTRRR-F: the posts index also cursor-paginates under the
+    // default 'cursor' query param. Loading /posts with a leftover posts cursor
+    // used to make the shared `notifications` prop (paginated with a null cursor)
+    // resolve that same ?cursor= value and blow up looking for `created_at`.
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->create(['current_workspace_id' => $workspace->id]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'role' => WorkspaceRole::Owner,
+    ]);
+
+    $foreignCursor = (new Cursor(['id' => 'not-a-notification-cursor'], true))->encode();
+
+    $this->actingAs($user)
+        ->get(route('posts.index', ['cursor' => $foreignCursor]))
+        ->assertOk();
 });
 
 test('the feed requires authentication', function () {

--- a/tests/Feature/Posts/PostScrollPaginationTest.php
+++ b/tests/Feature/Posts/PostScrollPaginationTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PostStatus;
+use App\Enums\WorkspaceRole;
+use App\Http\Middleware\HandleInertiaRequests;
+use App\Models\Post;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Context;
+
+beforeEach(function (): void {
+    $this->workspace = Workspace::factory()->create();
+    $this->user = User::factory()->create(['current_workspace_id' => $this->workspace->id]);
+    WorkspaceMembership::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'user_id' => $this->user->id,
+        'role' => WorkspaceRole::Owner,
+    ]);
+    Context::add('workspace_id', $this->workspace->id);
+});
+
+/**
+ * Fetch a page of the deferred/scroll `posts` prop the way the frontend does:
+ * a partial Inertia request scoped to `posts`, optionally carrying a cursor and
+ * the infinite-scroll append intent.
+ */
+function fetchPostsScrollPage(object $test, string $version, ?string $cursor = null): array
+{
+    $headers = [
+        'X-Inertia' => 'true',
+        'X-Inertia-Version' => $version,
+        'X-Inertia-Partial-Component' => 'posts/index',
+        'X-Inertia-Partial-Data' => 'posts',
+    ];
+
+    if ($cursor !== null) {
+        $headers['X-Inertia-Infinite-Scroll-Merge-Intent'] = 'append';
+    }
+
+    $response = $test->actingAs($test->user)
+        ->withHeaders($headers)
+        ->get(route('posts.index', $cursor !== null ? ['cursor' => $cursor] : []));
+
+    $response->assertOk();
+
+    return $response->json();
+}
+
+test('posts infinite scroll walks every page without crashing on page 2', function () {
+    // Mix scheduled and draft posts so the COALESCE(scheduled_at, created_at)
+    // ordering is actually exercised (drafts fall back to created_at).
+    $base = Carbon::parse('2026-01-01 00:00:00');
+    for ($i = 0; $i < 45; $i++) {
+        Post::factory()->for($this->workspace)->create([
+            'author_id' => $this->user->id,
+            'status' => $i % 2 === 0 ? PostStatus::Scheduled->value : PostStatus::Draft->value,
+            'scheduled_at' => $i % 2 === 0 ? $base->copy()->addMinutes($i) : null,
+            'created_at' => $base->copy()->addMinutes($i),
+        ]);
+    }
+
+    $version = (string) app(HandleInertiaRequests::class)
+        ->version(request());
+
+    // Page 1 (the deferred initial load).
+    $page1 = fetchPostsScrollPage($this, $version);
+    expect($page1['props']['posts']['data'])->toHaveCount(20);
+    $cursor = $page1['scrollProps']['posts']['nextPage'];
+    expect($cursor)->toBeString();
+
+    // Page 2 (infinite scroll) — this is the request that used to 500 with
+    // "Undefined array key 0" because the raw orderBy produced no keyset.
+    $page2 = fetchPostsScrollPage($this, $version, $cursor);
+    expect($page2['props']['posts']['data'])->toHaveCount(20);
+    expect($page2['mergeProps'] ?? [])->toContain('posts.data');
+    $cursor = $page2['scrollProps']['posts']['nextPage'];
+    expect($cursor)->toBeString();
+
+    // Page 3 (final 5) — cursor exhausts cleanly with no next page.
+    $page3 = fetchPostsScrollPage($this, $version, $cursor);
+    expect($page3['props']['posts']['data'])->toHaveCount(5);
+    expect($page3['scrollProps']['posts']['nextPage'])->toBeNull();
+
+    // Every post reachable exactly once across the three pages.
+    $ids = collect([$page1, $page2, $page3])
+        ->flatMap(fn (array $p): array => array_column($p['props']['posts']['data'], 'id'));
+    expect($ids)->toHaveCount(45)
+        ->and($ids->unique())->toHaveCount(45);
+});


### PR DESCRIPTION
## Summary
- Fixes a crash when loading page 2+ of the posts feed via infinite scroll. The feed's ordering used a raw `orderByRaw` expression, which Laravel's cursor paginator can't use to build its keyset `WHERE` clause, causing a 500 error on subsequent pages.
- Posts are now ordered using a proper `sort_key` column alias (`COALESCE(scheduled_at, created_at)`) plus `id` as a tiebreaker, so cursor pagination can correctly resolve the next page.
- Gave the notifications feed its own dedicated cursor query parameter (`notifications` instead of the default `cursor`) so a leftover cursor from the posts feed can no longer be mistakenly applied to the notifications prop.
- Added feature tests covering multi-page infinite scroll through the posts feed and the cross-feature cursor collision scenario.
