### PR TITLE
fix(compose): calibrate GD decode limit and surface upload errors

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,8 @@ use App\Models\PostMedia;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Services\Auth\Socialite\ThreadsProvider;
+use App\Services\Media\ImageCompressor;
+use App\Services\Media\ImageToJpegConverter;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Auth\Events\Login;
@@ -44,7 +46,13 @@ class AppServiceProvider extends ServiceProvider
     #[Override]
     public function register(): void
     {
-        //
+        // Both classes take $maxPixels as a constructor default (a config() call can't be
+        // a default expression), so the publish/convert pipeline needs this binding to
+        // actually honor the configured decode guard rather than always falling back to
+        // the compile-time constant.
+        $this->app->when([ImageCompressor::class, ImageToJpegConverter::class])
+            ->needs('$maxPixels')
+            ->give(fn (): int => (int) config('media.max_image_pixels', ImageCompressor::DEFAULT_MAX_PIXELS));
     }
 
     /**

--- a/app/Services/Media/ImageCompressor.php
+++ b/app/Services/Media/ImageCompressor.php
@@ -18,7 +18,7 @@ use Throwable;
  */
 class ImageCompressor
 {
-    public const int DEFAULT_MAX_PIXELS = 50_000_000;
+    public const int DEFAULT_MAX_PIXELS = 16_000_000;
 
     private const int QUALITY_CEIL = 92;
 
@@ -33,8 +33,11 @@ class ImageCompressor
     /**
      * @param  int  $maxPixels  Decode guard: images whose pixel count exceeds this are left
      *                          untouched rather than decoded, so a decompression-bomb (tiny
-     *                          file, enormous canvas) cannot OOM the publish worker. The
-     *                          default comfortably exceeds every platform's max dimensions.
+     *                          file, enormous canvas) cannot OOM the publish worker. GD peak
+     *                          memory is ~2 x (W x H x 4 bytes) since scale() clones the
+     *                          source canvas, so the default is calibrated to stay under a
+     *                          256M worker memory_limit while still passing standard ~12MP
+     *                          phone photos.
      */
     public function __construct(private readonly int $maxPixels = self::DEFAULT_MAX_PIXELS) {}
 

--- a/config/media.php
+++ b/config/media.php
@@ -6,5 +6,14 @@ return [
     // calibrated to stay under a 256M worker memory_limit. Images over this are
     // shipped untouched by the compressor, rejected by the JPEG converter, or
     // refused at upload, rather than OOMing the worker.
-    'max_image_pixels' => (int) env('MEDIA_MAX_IMAGE_PIXELS', 16_000_000),
+    //
+    // Validate the override to a positive integer: a zero/negative/non-numeric value
+    // would make the two decode guards disagree (ImageCompressor would skip
+    // compression while ImageToJpegConverter rejects every image), so an invalid
+    // override falls back to the calibrated default rather than being trusted.
+    'max_image_pixels' => filter_var(
+        env('MEDIA_MAX_IMAGE_PIXELS'),
+        FILTER_VALIDATE_INT,
+        ['options' => ['default' => 16_000_000, 'min_range' => 1]],
+    ),
 ];

--- a/config/media.php
+++ b/config/media.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    // Decode guard for GD image processing in the publish worker. Peak GD memory is
+    // ~2 x (W x H x 4 bytes) because ->scale() clones the source canvas, so this is
+    // calibrated to stay under a 256M worker memory_limit. Images over this are
+    // shipped untouched by the compressor, rejected by the JPEG converter, or
+    // refused at upload, rather than OOMing the worker.
+    'max_image_pixels' => (int) env('MEDIA_MAX_IMAGE_PIXELS', 16_000_000),
+];

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -26,9 +26,15 @@ stderr_logfile_maxbytes=0
 # in-flight job before exiting; stopwaitsecs gives it room to do so.
 # Guarded: idles when QUEUE_WORKER_ENABLED=false — set that to run the worker as a
 # separate service/container instead (e.g. in a cloud deployment).
+# --memory recycles the worker between jobs once its RSS crosses the threshold, as
+# hygiene against gradual accumulation and to avoid the container OOM-killing it —
+# it does not by itself prevent a single job from exhausting memory mid-decode.
+# Default assumes the container's PHP_MEMORY_LIMIT (512M); if a deployment runs the
+# worker on a smaller memory_limit (e.g. a 256M service), set QUEUE_WORKER_MEMORY_MB
+# comfortably below that limit.
 [program:worker]
 process_name=%(program_name)s_%(process_num)02d
-command=/bin/bash -c 'if [ "$QUEUE_WORKER_ENABLED" != "false" ]; then exec php /var/www/html/artisan queue:work --tries=3 --max-time=3600; else echo "[worker] disabled (QUEUE_WORKER_ENABLED=false); idling"; exec sleep infinity; fi'
+command=/bin/bash -c 'if [ "$QUEUE_WORKER_ENABLED" != "false" ]; then exec php /var/www/html/artisan queue:work --tries=3 --max-time=3600 --memory=${QUEUE_WORKER_MEMORY_MB:-400}; else echo "[worker] disabled (QUEUE_WORKER_ENABLED=false); idling"; exec sleep infinity; fi'
 autostart=true
 autorestart=true
 numprocs=%(ENV_QUEUE_WORKER_COUNT)s

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -26,15 +26,22 @@ stderr_logfile_maxbytes=0
 # in-flight job before exiting; stopwaitsecs gives it room to do so.
 # Guarded: idles when QUEUE_WORKER_ENABLED=false — set that to run the worker as a
 # separate service/container instead (e.g. in a cloud deployment).
-# --memory recycles the worker between jobs once its RSS crosses the threshold, as
-# hygiene against gradual accumulation and to avoid the container OOM-killing it —
-# it does not by itself prevent a single job from exhausting memory mid-decode.
-# Default assumes the container's PHP_MEMORY_LIMIT (512M); if a deployment runs the
-# worker on a smaller memory_limit (e.g. a 256M service), set QUEUE_WORKER_MEMORY_MB
-# comfortably below that limit.
+#
+# --memory recycles the long-lived worker between jobs once its usage crosses the
+# threshold, as hygiene against gradual accumulation (queue:work is a single
+# long-lived process that decodes images via GD across many jobs). It is checked
+# BETWEEN jobs, so the threshold must sit far enough below the worker's real PHP
+# memory_limit to leave room for a single job's peak decode; a threshold at or above
+# memory_limit never fires, because PHP fatals first (the SHOUTRRR-D OOM: the worker
+# had a 256M limit but the old default recycled at 400M, i.e. never).
+#
+# So derive the threshold from the actual memory_limit rather than hardcoding it:
+# reserve ~160MB headroom for one max-size decode (the 16M-pixel upload ceiling peaks
+# at ~2 x 16M x 4B ≈ 128MB plus source/encode buffers), floored at 64MB. Override
+# explicitly with QUEUE_WORKER_MEMORY_MB when a deployment needs a different value.
 [program:worker]
 process_name=%(program_name)s_%(process_num)02d
-command=/bin/bash -c 'if [ "$QUEUE_WORKER_ENABLED" != "false" ]; then exec php /var/www/html/artisan queue:work --tries=3 --max-time=3600 --memory=${QUEUE_WORKER_MEMORY_MB:-400}; else echo "[worker] disabled (QUEUE_WORKER_ENABLED=false); idling"; exec sleep infinity; fi'
+command=/bin/bash -c 'if [ "$QUEUE_WORKER_ENABLED" != "false" ]; then RAW=$(php -r "echo trim(ini_get(\"memory_limit\"));"); case "$RAW" in ""|-1) MB=512 ;; *[Gg]) MB=$(( ${RAW%[Gg]} * 1024 )) ;; *[Mm]) MB=${RAW%[Mm]} ;; *[Kk]) MB=$(( ${RAW%[Kk]} / 1024 )) ;; *) MB=$(( RAW / 1048576 )) ;; esac; MEM=${QUEUE_WORKER_MEMORY_MB:-$(( MB > 224 ? MB - 160 : MB * 2 / 3 ))}; [ "$MEM" -lt 64 ] && MEM=64; echo "[worker] php memory_limit=${RAW}; queue:work --memory=${MEM}MB"; exec php /var/www/html/artisan queue:work --tries=3 --max-time=3600 --memory="$MEM"; else echo "[worker] disabled (QUEUE_WORKER_ENABLED=false); idling"; exec sleep infinity; fi'
 autostart=true
 autorestart=true
 numprocs=%(ENV_QUEUE_WORKER_COUNT)s

--- a/resources/js/components/compose/__tests__/media-chips.test.ts
+++ b/resources/js/components/compose/__tests__/media-chips.test.ts
@@ -28,4 +28,11 @@ describe('media chips', () => {
         // Image chips are editable only when the item is not a GIF.
         expect(chips).toContain('Boolean(onImageClick) && !isGif');
     });
+
+    it("CornerButton's always-visible variant does not override display (would break the icon's centering against the base grid layout)", () => {
+        const chips = source();
+
+        expect(chips).not.toMatch(/always\s*\?\s*'flex'/);
+        expect(chips).toContain('!always &&');
+    });
 });

--- a/resources/js/components/compose/media-chips.tsx
+++ b/resources/js/components/compose/media-chips.tsx
@@ -96,10 +96,12 @@ function CornerButton({
                 'absolute -top-1.5 -right-1.5 z-10 grid size-4 place-items-center rounded-full',
                 'border border-background bg-destructive text-[11px] leading-none text-destructive-foreground shadow-sm',
                 'transition-opacity hover:bg-destructive/90',
-                always
-                    ? 'flex'
-                    : // Always visible on touch (no hover); reveal on hover/focus on pointer devices.
-                      'max-md:opacity-100 md:opacity-0 md:group-focus-within/chip:opacity-100 md:group-hover/chip:opacity-100',
+                // `always` just needs to skip the hover-reveal opacity dance below —
+                // it must not touch `display`, or it fights the base `grid` and the
+                // icon loses `place-items-center`'s horizontal centering.
+                !always &&
+                    // Always visible on touch (no hover); reveal on hover/focus on pointer devices.
+                    'max-md:opacity-100 md:opacity-0 md:group-focus-within/chip:opacity-100 md:group-hover/chip:opacity-100',
             )}
         >
             {children}
@@ -401,7 +403,8 @@ export function MediaChips({
                                 ? 'Processing…'
                                 : p.status === 'uploading'
                                   ? 'Uploading…'
-                                  : 'Upload failed — dismiss and retry'}
+                                  : (p.errorMessage ??
+                                    'Upload failed — dismiss and retry')}
                         </TooltipContent>
                     </Tooltip>
                 );

--- a/resources/js/components/compose/segment-media-row.tsx
+++ b/resources/js/components/compose/segment-media-row.tsx
@@ -92,10 +92,12 @@ function CornerButton({
                 'absolute -top-1.5 -right-1.5 z-10 grid size-4 place-items-center rounded-full',
                 'border border-background bg-destructive text-[11px] leading-none text-destructive-foreground shadow-sm',
                 'transition-opacity hover:bg-destructive/90',
-                always
-                    ? 'flex'
-                    : // Always visible on touch (no hover); reveal on hover/focus on pointer devices.
-                      'max-md:opacity-100 md:opacity-0 md:group-focus-within/chip:opacity-100 md:group-hover/chip:opacity-100',
+                // `always` just needs to skip the hover-reveal opacity dance below —
+                // it must not touch `display`, or it fights the base `grid` and the
+                // icon loses `place-items-center`'s horizontal centering.
+                !always &&
+                    // Always visible on touch (no hover); reveal on hover/focus on pointer devices.
+                    'max-md:opacity-100 md:opacity-0 md:group-focus-within/chip:opacity-100 md:group-hover/chip:opacity-100',
             )}
         >
             {children}
@@ -392,7 +394,8 @@ export function SegmentMediaRow({
                                 ? 'Processing…'
                                 : p.status === 'uploading'
                                   ? 'Uploading…'
-                                  : 'Upload failed — dismiss and retry'}
+                                  : (p.errorMessage ??
+                                    'Upload failed — dismiss and retry')}
                         </TooltipContent>
                     </Tooltip>
                 );

--- a/resources/js/components/ui/icons.tsx
+++ b/resources/js/components/ui/icons.tsx
@@ -121,16 +121,11 @@ export type IconProps = Omit<HugeiconsProps, 'strokeWidth'> & {
 export type IconComponent = ComponentType<IconProps>;
 
 function icon(data: IconSvgElement): IconComponent {
-    return function Icon({ strokeWidth, ...props }: IconProps) {
-        return (
-            <HugeiconsIcon
-                icon={data}
-                strokeWidth={
-                    strokeWidth === undefined ? undefined : Number(strokeWidth)
-                }
-                {...props}
-            />
-        );
+    // Hugeicons' outline paths bake in strokeWidth: 1.5, ~25% thinner than the
+    // strokeWidth: 2 every call site was designed around under lucide-react. Default
+    // to 2 here so every icon keeps its original weight unless a call site overrides it.
+    return function Icon({ strokeWidth = 2, ...props }: IconProps) {
+        return <HugeiconsIcon icon={data} strokeWidth={Number(strokeWidth)} {...props} />;
     };
 }
 

--- a/resources/js/hooks/compose/__tests__/use-media-uploads.test.ts
+++ b/resources/js/hooks/compose/__tests__/use-media-uploads.test.ts
@@ -182,6 +182,32 @@ describe('useMediaUploads handleFiles', () => {
     });
 });
 
+describe('useMediaUploads image upload failure', () => {
+    it('carries the server validation message onto the failed chip instead of a generic error', async () => {
+        render();
+        post.mockImplementation(
+            (
+                _url: string,
+                opts: { onError?: (errors: Record<string, string>) => void },
+            ) => {
+                opts.onError?.({ file: 'The image resolution is too large.' });
+
+                return Promise.reject(new Error('422'));
+            },
+        );
+
+        await act(async () => {
+            await handleFilesRef?.([imageFile()]);
+        });
+
+        expect(pendingRef).toHaveLength(1);
+        expect(pendingRef[0].status).toBe('error');
+        expect(pendingRef[0].errorMessage).toBe(
+            'The image resolution is too large.',
+        );
+    });
+});
+
 describe('useMediaUploads pending chip carries the segment it was targeting', () => {
     it('tags the pending chip with the segment active when the upload began, not wherever the caret moves to later', async () => {
         let active = 'b1';

--- a/resources/js/hooks/compose/use-media-uploads.ts
+++ b/resources/js/hooks/compose/use-media-uploads.ts
@@ -169,10 +169,12 @@ export function useMediaUploads({
         return { tempId, previewUrl };
     }
 
-    function failUpload(tempId: string): void {
+    function failUpload(tempId: string, errorMessage?: string): void {
         setPending((cur) =>
             cur.map((p) =>
-                p.tempId === tempId ? { ...p, status: 'error' } : p,
+                p.tempId === tempId
+                    ? { ...p, status: 'error', errorMessage }
+                    : p,
             ),
         );
     }
@@ -271,13 +273,20 @@ export function useMediaUploads({
 
         // transform injects the file at submit time (multipart upload).
         imageHttp.transform(() => ({ file }));
+        let validationMessage: string | undefined;
         try {
             const { media: result } = await imageHttp.post(ep.imageStore(id), {
+                onError: (errors) => {
+                    const first =
+                        errors?.file ?? Object.values(errors ?? {})[0];
+                    validationMessage =
+                        typeof first === 'string' ? first : undefined;
+                },
                 onNetworkError: () => undefined,
             });
             finishUpload(tempId, result, segmentRef, previewUrl);
         } catch {
-            failUpload(tempId);
+            failUpload(tempId, validationMessage);
         }
     }
 

--- a/resources/js/types/compose.ts
+++ b/resources/js/types/compose.ts
@@ -109,6 +109,8 @@ export type PendingUpload = {
     progress?: number;
     /** The thread segment this upload was targeting when it began. */
     segmentRef: string;
+    /** Server-provided reason for a failed upload (e.g. a validation message); falls back to a generic label when absent. */
+    errorMessage?: string;
 };
 
 export type TargetStatus =

--- a/tests/Feature/Posts/MediaApiTest.php
+++ b/tests/Feature/Posts/MediaApiTest.php
@@ -67,7 +67,9 @@ test('it rejects an image above the shipped pixel ceiling without any config ove
 
     // 5000x3500 = 17.5M pixels, above the shipped 16M default (config/media.php) —
     // proves the gate rejects on its own, not only when a test lowers the ceiling.
-    // The rule reads the header only, so no real 17.5M-pixel canvas is allocated.
+    // The validation rule itself reads the header only (no decode); the canvas that
+    // UploadedFile::fake() allocates here is one-off test fixture setup, not the code
+    // path under test.
     test()->post("/posts/{$post['id']}/media", [
         'file' => UploadedFile::fake()->image('huge.jpg', 5000, 3500)->size(300),
     ], ['Accept' => 'application/json'])

--- a/tests/Feature/Posts/MediaApiTest.php
+++ b/tests/Feature/Posts/MediaApiTest.php
@@ -61,6 +61,20 @@ test('it rejects an image whose resolution exceeds the pixel ceiling', function 
         ->assertJsonValidationErrors('file');
 });
 
+test('it rejects an image above the shipped pixel ceiling without any config override', function () {
+    Storage::fake('public');
+    [$user, $workspace, $post] = memberWithDraft();
+
+    // 5000x3500 = 17.5M pixels, above the shipped 16M default (config/media.php) —
+    // proves the gate rejects on its own, not only when a test lowers the ceiling.
+    // The rule reads the header only, so no real 17.5M-pixel canvas is allocated.
+    test()->post("/posts/{$post['id']}/media", [
+        'file' => UploadedFile::fake()->image('huge.jpg', 5000, 3500)->size(300),
+    ], ['Accept' => 'application/json'])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('file');
+});
+
 test('it rejects an upload to a post that is no longer editable', function () {
     Storage::fake('public');
     [$user, $workspace, $post] = memberWithDraft();

--- a/tests/Unit/ImageCompressorTest.php
+++ b/tests/Unit/ImageCompressorTest.php
@@ -156,3 +156,23 @@ test('an image exceeding the pixel guard is left untouched without decoding', fu
         ->and($result->bytes)->toBe($bytes)
         ->and($result->mime)->toBe('image/jpeg');
 });
+
+test('the container-resolved compressor honors a configured pixel ceiling', function () {
+    // AppServiceProvider binds $maxPixels from config('media.max_image_pixels') for
+    // container-resolved instances (the publish path), rather than always falling back
+    // to the compile-time default — this is what actually protects the queue worker.
+    config(['media.max_image_pixels' => 100]);
+
+    $bytes = compressorJpeg(1200, 1200); // 1.44M pixels
+
+    $result = app(ImageCompressor::class)->compressToFit($bytes, (int) (strlen($bytes) * 0.6), 'image/jpeg', WEBP_ALLOWED);
+
+    expect($result->wasCompressed)->toBeFalse()
+        ->and($result->bytes)->toBe($bytes)
+        ->and($result->mime)->toBe('image/jpeg');
+});
+
+test('the shipped default pixel ceiling is calibrated for a 256M worker', function () {
+    expect(ImageCompressor::DEFAULT_MAX_PIXELS)->toBe(16_000_000)
+        ->and(config('media.max_image_pixels'))->toBe(16_000_000);
+});

--- a/tests/Unit/Media/ImageToJpegConverterTest.php
+++ b/tests/Unit/Media/ImageToJpegConverterTest.php
@@ -126,3 +126,21 @@ it('refuses to decode a canvas beyond the pixel ceiling', function () {
 
     (new ImageToJpegConverter(maxPixels: 100))->convert($media);
 })->throws(ImageConversionFailed::class);
+
+it('the container-resolved converter honors a configured pixel ceiling', function () {
+    // AppServiceProvider binds $maxPixels from config('media.max_image_pixels') for
+    // container-resolved instances (the Instagram/Threads publish path), rather than
+    // always falling back to the compile-time default.
+    Storage::fake('public');
+    Storage::disk('public')->put('media/ws/huge.png', transparentPng(50, 50));
+
+    $media = PostMedia::factory()->create([
+        'disk' => 'public',
+        'path' => 'media/ws/huge.png',
+        'mime' => 'image/png',
+    ]);
+
+    config(['media.max_image_pixels' => 100]);
+
+    app(ImageToJpegConverter::class)->convert($media);
+})->throws(ImageConversionFailed::class);


### PR DESCRIPTION
## Summary
- Lower the image decode guard (`ImageCompressor::DEFAULT_MAX_PIXELS`) from 50M to 16M pixels and make it configurable via `config/media.php` (`MEDIA_MAX_IMAGE_PIXELS`), calibrated to stay under a 256M worker memory limit given GD's ~2x peak memory usage during scaling
- Bind the configured pixel ceiling in `AppServiceProvider` so container-resolved `ImageCompressor` and `ImageToJpegConverter` instances (the actual publish pipeline) honor the config value instead of always falling back to the compile-time default
- Add a `--memory` cap to the queue worker in `docker/supervisord.conf`, configurable via `QUEUE_WORKER_MEMORY_MB`, to recycle workers before they get OOM-killed
- Surface the server's validation message on failed image uploads instead of a generic "Upload failed" label
- Fix `CornerButton`'s "always visible" variant overriding `display` and breaking icon centering against the base grid layout
- Restore the original icon stroke width (2) as the default for the Hugeicons wrapper, since Hugeicons defaults to a thinner 1.5 than lucide-react

## Breaking Changes
None — `MEDIA_MAX_IMAGE_PIXELS` and `QUEUE_WORKER_MEMORY_MB` are optional env vars with sensible defaults.
