### PR TITLE
fix(publish): recover orphaned queue redeliveries instead of failing

### DIFF
--- a/app/Jobs/PublishPostTarget.php
+++ b/app/Jobs/PublishPostTarget.php
@@ -194,10 +194,19 @@ class PublishPostTarget implements ShouldQueue
      *   - all segments posted  → mark Published (the run just died before recording it);
      *   - some segments posted → re-dispatch to resume the thread (bounded by MAX_ATTEMPTS);
      *   - nothing posted       → mark terminally Failed.
+     *
+     * A redelivery can land up to `retry_after` after the orphan was created, so the
+     * target may already be terminal (a parallel retry finished it, the user deleted the
+     * post, or the platform was frozen). Mirror handle()'s terminal guard first so we
+     * never resurrect a Deleted post, re-notify a Published one, or clobber a Skipped one.
      */
     public function failed(Throwable $e): void
     {
         $target = $this->target->fresh() ?? $this->target;
+
+        if (in_array($target->status, self::TERMINAL, true)) {
+            return;
+        }
 
         $segmentCount = count($target->sections ?? []);
         $postedCount = count($this->postedRemoteIds($target));
@@ -226,7 +235,7 @@ class PublishPostTarget implements ShouldQueue
     {
         return array_values(array_filter(
             $target->remote_ids ?? [],
-            static fn (string $id): bool => $id !== '',
+            static fn (string $remoteId): bool => $remoteId !== '',
         ));
     }
 

--- a/app/Jobs/PublishPostTarget.php
+++ b/app/Jobs/PublishPostTarget.php
@@ -182,21 +182,101 @@ class PublishPostTarget implements ShouldQueue
     }
 
     /**
-     * Runs when the job throws an uncaught exception. Closes the open attempt row and
-     * marks the target terminally Failed so it is never left stuck on `publishing`.
-     * An uncaught throw is unexpected, so we do NOT auto-retry it.
+     * Runs when the job fails — either an uncaught throw from handle() or, more
+     * insidiously, an orphaned queue reservation: a worker that died mid-run
+     * (deploy/OOM/crash) leaves its reserved message behind, the database queue
+     * re-delivers it after `retry_after`, and because `tries=1` the redelivery is
+     * rejected as "attempted too many times" BEFORE handle() (and its terminal-status
+     * guard) can run. Rather than blindly bury the target as Failed, reconcile against
+     * the segment ids already persisted mid-run (BlueskyPublishConnector saves each
+     * uri before sending the next), so a post that actually went out — or partly did —
+     * is not lost:
+     *   - all segments posted  → mark Published (the run just died before recording it);
+     *   - some segments posted → re-dispatch to resume the thread (bounded by MAX_ATTEMPTS);
+     *   - nothing posted       → mark terminally Failed.
      */
     public function failed(Throwable $e): void
     {
         $target = $this->target->fresh() ?? $this->target;
 
-        $attempt = $target->attemptLogs()->whereNull('finished_at')->latest('id')->first();
+        $segmentCount = count($target->sections ?? []);
+        $postedCount = count($this->postedRemoteIds($target));
 
-        $attempt?->forceFill([
-            'status' => 'failed',
-            'error_message' => Str::limit($e->getMessage(), 1000),
-            'finished_at' => Date::now(),
+        if ($segmentCount > 0 && $postedCount >= $segmentCount) {
+            $this->reconcilePublished($target);
+
+            return;
+        }
+
+        if ($postedCount > 0 && $target->attempts < self::MAX_ATTEMPTS) {
+            $this->resumePartial($target);
+
+            return;
+        }
+
+        $this->markFailed($target, $e);
+    }
+
+    /**
+     * The non-empty AT-URIs already persisted for this target, in segment order.
+     *
+     * @return list<string>
+     */
+    private function postedRemoteIds(PostTarget $target): array
+    {
+        return array_values(array_filter(
+            $target->remote_ids ?? [],
+            static fn (string $id): bool => $id !== '',
+        ));
+    }
+
+    /**
+     * A worker died after every segment was posted but before onSuccess recorded it.
+     * Recover the target to Published so the author is not wrongly told it failed.
+     */
+    private function reconcilePublished(PostTarget $target): void
+    {
+        $remoteIds = $this->postedRemoteIds($target);
+
+        $target->forceFill([
+            'status' => PostTargetStatus::Published->value,
+            'remote_id' => $remoteIds[0] ?? $target->remote_id,
+            'remote_ids' => $remoteIds,
+            'posted_at' => $target->posted_at ?? Date::now(),
+            'error_kind' => null,
+            'error_message' => null,
+            'next_attempt_at' => null,
         ])->save();
+
+        $this->closeOpenAttempt($target, 'published');
+
+        app(PostStatusRollup::class)->recompute($target->post()->firstOrFail());
+
+        $this->notifyPublished($target);
+    }
+
+    /**
+     * A worker died mid-thread. Re-dispatch so handle() resumes from the persisted
+     * remote_ids (posting only the unsent segments) rather than abandoning a
+     * half-published thread as Failed.
+     */
+    private function resumePartial(PostTarget $target): void
+    {
+        $this->closeOpenAttempt($target, 'retrying');
+
+        $target->forceFill([
+            'status' => PostTargetStatus::Publishing->value,
+            'next_attempt_at' => Date::now(),
+        ])->save();
+
+        app(PostStatusRollup::class)->recompute($target->post()->firstOrFail());
+
+        self::dispatch($target->fresh());
+    }
+
+    private function markFailed(PostTarget $target, Throwable $e): void
+    {
+        $this->closeOpenAttempt($target, 'failed', Str::limit($e->getMessage(), 1000));
 
         $target->forceFill([
             'status' => PostTargetStatus::Failed->value,
@@ -207,6 +287,26 @@ class PublishPostTarget implements ShouldQueue
         app(PostStatusRollup::class)->recompute($target->post()->firstOrFail());
 
         $this->notifyFailed($target, ErrorKind::Unknown);
+    }
+
+    /**
+     * Close the currently-open attempt row (the one this dead run left unfinished).
+     */
+    private function closeOpenAttempt(PostTarget $target, string $status, ?string $errorMessage = null): void
+    {
+        $attempt = $target->attemptLogs()->whereNull('finished_at')->latest('id')->first();
+
+        if ($attempt === null) {
+            return;
+        }
+
+        $fields = ['status' => $status, 'finished_at' => Date::now()];
+
+        if ($errorMessage !== null) {
+            $fields['error_message'] = $errorMessage;
+        }
+
+        $attempt->forceFill($fields)->save();
     }
 
     /**

--- a/tests/Feature/Publishing/PublishPostTargetTest.php
+++ b/tests/Feature/Publishing/PublishPostTargetTest.php
@@ -340,6 +340,25 @@ test('failed() gives up on a partial thread once the attempt budget is exhausted
     Bus::assertNotDispatched(PublishPostTarget::class);
 });
 
+test('failed() is a no-op when the target already reached a terminal state', function () {
+    Bus::fake();
+    // A redelivery can fire up to retry_after after the orphan was created, by which
+    // point another path may have deleted the post. failed() must not resurrect it.
+    $target = publishTarget(['one', 'two']);
+    $target->forceFill([
+        'status' => PostTargetStatus::Deleted->value,
+        'remote_ids' => ['111', '222'],
+        'remote_id' => '111',
+    ])->save();
+
+    (new PublishPostTarget($target->fresh()))->failed(
+        new MaxAttemptsExceededException('App\Jobs\PublishPostTarget has been attempted too many times.'),
+    );
+
+    expect($target->refresh()->status)->toBe(PostTargetStatus::Deleted);
+    Bus::assertNotDispatched(PublishPostTarget::class);
+});
+
 test('failed() with no posted segments marks the target failed', function () {
     $target = publishTarget(['one']);
     $target->forceFill(['status' => PostTargetStatus::Publishing->value])->save();

--- a/tests/Feature/Publishing/PublishPostTargetTest.php
+++ b/tests/Feature/Publishing/PublishPostTargetTest.php
@@ -12,6 +12,7 @@ use App\Services\Publishing\BackoffSchedule;
 use App\Services\Publishing\PostStatusRollup;
 use App\Services\Publishing\PublishConnectorRegistry;
 use App\Services\Publishing\TokenManager;
+use Illuminate\Queue\MaxAttemptsExceededException;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Date;
 
@@ -255,6 +256,99 @@ test('an uncaught exception closes the attempt and marks the target failed (neve
         ->and($attempt->finished_at)->not->toBeNull();
 
     expect($target->post->refresh()->status)->toBe(PostStatus::Failed);
+});
+
+test('failed() reconciles a fully-posted target to published (orphaned redelivery)', function () {
+    // Simulates the SHOUTRRR-E scenario: a worker died after every segment was
+    // posted; the DB queue redelivered the reserved message and tries=1 rejected it
+    // as "attempted too many times" before handle() could record success.
+    $target = publishTarget(['one', 'two']);
+    $target->forceFill([
+        'status' => PostTargetStatus::Publishing->value,
+        'remote_ids' => ['111', '222'],
+        'remote_id' => '111',
+    ])->save();
+
+    PostTargetAttempt::create([
+        'post_target_id' => $target->id,
+        'attempt_no' => 1,
+        'status' => 'retrying',
+        'started_at' => now(),
+    ]);
+
+    (new PublishPostTarget($target->fresh()))->failed(
+        new MaxAttemptsExceededException('App\Jobs\PublishPostTarget has been attempted too many times.'),
+    );
+
+    $target->refresh();
+    expect($target->status)->toBe(PostTargetStatus::Published)
+        ->and($target->remote_id)->toBe('111')
+        ->and($target->remote_ids)->toBe(['111', '222'])
+        ->and($target->posted_at)->not->toBeNull()
+        ->and($target->error_message)->toBeNull();
+
+    $attempt = PostTargetAttempt::where('post_target_id', $target->id)->latest('id')->first();
+    expect($attempt->status)->toBe('published')
+        ->and($attempt->finished_at)->not->toBeNull();
+
+    expect($target->post->refresh()->status)->toBe(PostStatus::Published);
+});
+
+test('failed() resumes a partially-posted thread instead of failing it', function () {
+    Bus::fake();
+    $target = publishTarget(['one', 'two']);
+    $target->forceFill([
+        'status' => PostTargetStatus::Publishing->value,
+        'attempts' => 1,
+        'remote_ids' => ['111'],
+        'remote_id' => '111',
+    ])->save();
+
+    PostTargetAttempt::create([
+        'post_target_id' => $target->id,
+        'attempt_no' => 1,
+        'status' => 'retrying',
+        'started_at' => now(),
+    ]);
+
+    (new PublishPostTarget($target->fresh()))->failed(new RuntimeException('worker killed mid-thread'));
+
+    $target->refresh();
+    expect($target->status)->toBe(PostTargetStatus::Publishing)
+        ->and($target->next_attempt_at)->not->toBeNull();
+
+    $attempt = PostTargetAttempt::where('post_target_id', $target->id)->latest('id')->first();
+    expect($attempt->status)->toBe('retrying')
+        ->and($attempt->finished_at)->not->toBeNull();
+
+    Bus::assertDispatched(PublishPostTarget::class);
+});
+
+test('failed() gives up on a partial thread once the attempt budget is exhausted', function () {
+    Bus::fake();
+    $target = publishTarget(['one', 'two']);
+    $target->forceFill([
+        'status' => PostTargetStatus::Publishing->value,
+        'attempts' => 5,
+        'remote_ids' => ['111'],
+        'remote_id' => '111',
+    ])->save();
+
+    (new PublishPostTarget($target->fresh()))->failed(new RuntimeException('still broken'));
+
+    expect($target->refresh()->status)->toBe(PostTargetStatus::Failed);
+    Bus::assertNotDispatched(PublishPostTarget::class);
+});
+
+test('failed() with no posted segments marks the target failed', function () {
+    $target = publishTarget(['one']);
+    $target->forceFill(['status' => PostTargetStatus::Publishing->value])->save();
+
+    (new PublishPostTarget($target->fresh()))->failed(new RuntimeException('boom'));
+
+    $target->refresh();
+    expect($target->status)->toBe(PostTargetStatus::Failed)
+        ->and($target->error_message)->not->toBeNull();
 });
 
 test('job has tries=1 and a timeout below the queue retry_after', function () {


### PR DESCRIPTION
## Summary
- Fixes a bug where a worker crashing mid-publish (deploy/OOM/crash) could cause a Bluesky thread that was fully or partially posted to be wrongly marked as `Failed` when the database queue redelivered the orphaned job and `tries=1` rejected it before `handle()` could run.
- `PublishPostTarget::failed()` now reconciles against the segment ids already persisted mid-run: if every segment posted, the target is recovered to `Published`; if some segments posted, the job re-dispatches to resume the thread (bounded by `MAX_ATTEMPTS`); only when nothing posted is the target marked terminally `Failed`.
- Adds test coverage for full recovery, partial-thread resume, attempt-budget exhaustion, and the original no-segments-posted failure path.
