### PR TITLE
fix(gifs): scope media mixing-rule guard to target segment

### DIFF
--- a/app/Http/Controllers/Engagement/ReplyImageEditController.php
+++ b/app/Http/Controllers/Engagement/ReplyImageEditController.php
@@ -32,6 +32,11 @@ class ReplyImageEditController extends Controller
     public function update(UpdateReplyImageEditRequest $request, PostTargetReply $reply, PostMedia $media): JsonResponse
     {
         abort_unless($media->workspace_id === $reply->workspace_id, 404);
+        // Animated media (GIF, or a GIF-browser WebP) has no editor client-side;
+        // replacing one with a raster beautified frame would silently flatten the
+        // animation. A WebP is editable only when it is a beautifier output (it
+        // carries edit_settings) — a WebP without them is a GIF-browser animation.
+        abort_if($media->isAttachOnlyImage(), 422, 'Animated images cannot be edited.');
 
         $updated = $this->media->replaceBeautified(
             $media,

--- a/app/Http/Controllers/Gifs/PostGifController.php
+++ b/app/Http/Controllers/Gifs/PostGifController.php
@@ -24,20 +24,21 @@ class PostGifController extends Controller
 
         $validated = $request->validated();
 
-        // Composer media rows stay orphaned (`post_id` null) until
-        // DraftService::attachMedia() associates them on the next draft save,
-        // so media()->get() is empty for an unsaved draft and the mixing-rule
-        // guard below would have nothing to check. The composer therefore
-        // declares the media ids it currently holds, exactly as the reply box
-        // does — re-resolved here scoped to the post's workspace, so the ids
-        // cannot reach media the caller has no access to. Merged with the
-        // saved relation and de-duplicated, since a saved draft has both.
-        $declared = PostMedia::query()
+        // The mixing rules (one video OR images, a GIF on its own) apply per
+        // thread *segment*, not per post — a GIF in one segment must not be
+        // blocked by media the user placed in another. Segment membership lives
+        // in client state (composer.tsx `mediaForSegment`), so the composer
+        // declares exactly the target segment's media ids here, and we scope the
+        // guard to those alone rather than to the whole post's media() relation
+        // (which spans every segment). This mirrors ReplyGifController /
+        // ConversationGifController, whose surfaces have no segments. Ids are
+        // re-resolved workspace-scoped so they cannot reach media the caller has
+        // no access to; draft rows stay orphaned (`post_id` null) until the next
+        // save, so the client-declared set is the only reliable source anyway.
+        $existing = PostMedia::query()
             ->where('workspace_id', $post->workspace_id)
             ->whereIn('id', $validated['media_ids'] ?? [])
             ->get();
-
-        $existing = $post->media()->get()->concat($declared)->unique('id');
 
         try {
             $media = $this->attacher->attach(

--- a/app/Http/Controllers/Posts/PostImageEditController.php
+++ b/app/Http/Controllers/Posts/PostImageEditController.php
@@ -35,6 +35,11 @@ class PostImageEditController extends Controller
     {
         abort_unless($media->workspace_id === $post->workspace_id, 404);
         abort_unless($post->status->isEditable(), 422, 'This post can no longer be edited.');
+        // Animated media (GIF, or a GIF-browser WebP) has no editor client-side;
+        // replacing one with a raster beautified frame would silently flatten the
+        // animation. A WebP is editable only when it is a beautifier output (it
+        // carries edit_settings) — a WebP without them is a GIF-browser animation.
+        abort_if($media->isAttachOnlyImage(), 422, 'Animated images cannot be edited.');
 
         $updated = $this->media->replaceBeautified(
             $media,

--- a/app/Models/PostMedia.php
+++ b/app/Models/PostMedia.php
@@ -165,4 +165,22 @@ class PostMedia extends Model
     {
         return $this->kind === 'video';
     }
+
+    /**
+     * Whether this image is attach-only rather than editable. The raster
+     * beautifier would flatten an animation to a single frame, so animated media
+     * must never open the editor. Animation isn't visible from the mime alone —
+     * the GIF browser stores a "GIF" as the larger `image/webp` variant, the same
+     * mime the beautifier emits — so a WebP is treated as editable only when it is
+     * a beautifier output (it carries edit_settings). GIFs are always animated.
+     * Mirrors the client's isAttachOnlyImage() (resources/js/lib/compose/media-rules.ts).
+     */
+    public function isAttachOnlyImage(): bool
+    {
+        if ($this->mime === 'image/gif') {
+            return true;
+        }
+
+        return $this->mime === 'image/webp' && $this->edit_settings === null;
+    }
 }

--- a/resources/js/components/compose/__tests__/media-chips.test.ts
+++ b/resources/js/components/compose/__tests__/media-chips.test.ts
@@ -22,11 +22,14 @@ describe('media chips', () => {
         expect(chips).toContain('<Film');
     });
 
-    it('never marks a gif as editable (the beautifier would flatten it)', () => {
+    it('never marks an animated image as editable (the beautifier would flatten it)', () => {
         const chips = source();
 
-        // Image chips are editable only when the item is not a GIF.
-        expect(chips).toContain('Boolean(onImageClick) && !isGif');
+        // Animated images (GIF, or a GIF-browser WebP) are attach-only, decided by
+        // the shared isAttachOnlyImage() rule (mime + edit_settings).
+        expect(chips).toContain(
+            'Boolean(onImageClick) && !isAttachOnlyImage(m)',
+        );
     });
 
     it("CornerButton's always-visible variant does not override display (would break the icon's centering against the base grid layout)", () => {

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -340,11 +340,12 @@ export default function Composer({
                 postGifAttachment(
                     PostGifController.store.url({ post: postId }),
                     item,
-                    // Draft media rows stay orphaned (`post_id` null) until the
-                    // next save, so the post's media() relation cannot see what
-                    // the composer already holds. Declare it, the way the reply
-                    // box does, or the mixing-rule guard has nothing to check.
-                    state.media.map((m) => m.id),
+                    // Declare only the *target segment's* media, not the whole
+                    // post's: the mixing-rule guard is per-segment, so a GIF in
+                    // one thread must not be blocked by media in another. Draft
+                    // rows also stay orphaned (`post_id` null) until the next
+                    // save, so this client-declared set is what the guard checks.
+                    mediaForSegment(segmentRef).map((m) => m.id),
                 ),
             segmentRef,
         );

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/lib/compose/format-notices';
 import { postGifAttachment } from '@/lib/compose/gifs/attach';
 import {
+    isAttachOnlyImage,
     wouldMixVideoAndImages,
     wouldViolateBlueskyGif,
 } from '@/lib/compose/media-rules';
@@ -581,8 +582,9 @@ export default function Composer({
     // source + settings; a plain one is beautified from scratch.
     function openImage(mediaId: string) {
         const m = state.media.find((x) => x.id === mediaId);
-        // GIFs have no editor — the beautifier would flatten them to a static PNG.
-        if (!m || m.kind === 'video' || m.mime === 'image/gif') {
+        // Animated images (GIF, or a GIF-browser WebP) have no editor — the
+        // beautifier would flatten them to a still frame.
+        if (!m || m.kind === 'video' || isAttachOnlyImage(m)) {
             return;
         }
         // First-time beautify (the `raw` branch below) mints a new media id

--- a/resources/js/components/compose/media-chips.tsx
+++ b/resources/js/components/compose/media-chips.tsx
@@ -7,6 +7,7 @@ import {
     TooltipContent,
     TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { isAttachOnlyImage } from '@/lib/compose/media-rules';
 import { cn } from '@/lib/utils';
 import type { MediaView, PendingUpload, PlatformName } from '@/types/compose';
 
@@ -168,12 +169,13 @@ export function MediaChips({
                 const excluded = isExcluded(m.id);
                 const isGif = m.mime === 'image/gif';
                 // Videos open the trim editor; static images open the beautifier.
-                // GIFs open neither — the beautifier would flatten them to a static
-                // PNG — so they're attach-only.
+                // Animated images (GIF, or a GIF-browser WebP) open neither — the
+                // beautifier would flatten them to a still frame — so they're
+                // attach-only.
                 const canEdit =
                     m.kind === 'video'
                         ? Boolean(onVideoClick)
-                        : Boolean(onImageClick) && !isGif;
+                        : Boolean(onImageClick) && !isAttachOnlyImage(m);
                 const blueskyGif = activePlatform === 'bluesky' && isGif;
 
                 return (

--- a/resources/js/components/compose/segment-media-row.tsx
+++ b/resources/js/components/compose/segment-media-row.tsx
@@ -9,6 +9,7 @@ import {
     TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { getMediaDrag, setMediaDrag } from '@/lib/compose/media-dnd';
+import { isAttachOnlyImage } from '@/lib/compose/media-rules';
 import { cn } from '@/lib/utils';
 import type { MediaView, PendingUpload } from '@/types/compose';
 import type { GifItem } from '@/types/gifs';
@@ -214,14 +215,14 @@ export function SegmentMediaRow({
             onDrop={handleRowDrop}
         >
             {media.map((m, idx) => {
-                const isGif = m.mime === 'image/gif';
                 // Videos open the trim editor; static images open the beautifier.
-                // GIFs open neither — the beautifier would flatten them to a
-                // static PNG — so they're attach-only.
+                // Animated images (GIF, or a GIF-browser WebP) open neither — the
+                // beautifier would flatten them to a still frame — so they're
+                // attach-only.
                 const canEdit =
                     m.kind === 'video'
                         ? Boolean(onVideoClick)
-                        : Boolean(onImageClick) && !isGif;
+                        : Boolean(onImageClick) && !isAttachOnlyImage(m);
 
                 return (
                     <Tooltip key={m.id}>

--- a/resources/js/hooks/compose/use-attachments.tsx
+++ b/resources/js/hooks/compose/use-attachments.tsx
@@ -7,6 +7,7 @@ import { MediaChips } from '@/components/compose/media-chips';
 import { useMediaUploads } from '@/hooks/compose/use-media-uploads';
 import { postGifAttachment } from '@/lib/compose/gifs/attach';
 import {
+    isAttachOnlyImage,
     wouldMixVideoAndImages,
     wouldViolateBlueskyGif,
 } from '@/lib/compose/media-rules';
@@ -373,7 +374,10 @@ export function useAttachments({
 
     function openEditor(mediaId: string) {
         const m = media.find((x) => x.id === mediaId);
-        if (!m || m.kind === 'video') {
+        // Animated images (GIF, or a GIF-browser WebP) have no editor — the
+        // beautifier would flatten them to a still frame — so they're attach-only,
+        // matching composer.tsx `openImage`.
+        if (!m || m.kind === 'video' || isAttachOnlyImage(m)) {
             return;
         }
         if (m.edit_settings && m.source_url) {

--- a/resources/js/lib/compose/__tests__/media-rules.test.ts
+++ b/resources/js/lib/compose/__tests__/media-rules.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+    isAttachOnlyImage,
     wouldMixVideoAndImages,
     wouldViolateBlueskyGif,
 } from '@/lib/compose/media-rules';
@@ -102,5 +103,37 @@ describe('wouldMixVideoAndImages', () => {
         expect(wouldMixVideoAndImages([attached('video')], [mp4()])).toBe(
             false,
         );
+    });
+});
+
+describe('isAttachOnlyImage', () => {
+    const withSettings = (
+        mime: string,
+        editSettings: MediaView['edit_settings'],
+    ): Pick<MediaView, 'mime' | 'edit_settings'> => ({
+        mime,
+        edit_settings: editSettings,
+    });
+    // A beautifier output always carries edit_settings; the shape doesn't matter
+    // to the rule, only its non-null presence.
+    const beautified = { version: 1 } as MediaView['edit_settings'];
+
+    it('treats a GIF as attach-only', () => {
+        expect(isAttachOnlyImage(withSettings('image/gif', null))).toBe(true);
+    });
+
+    it('treats a WebP without edit_settings (GIF-browser attach) as attach-only', () => {
+        expect(isAttachOnlyImage(withSettings('image/webp', null))).toBe(true);
+    });
+
+    it('treats a beautified WebP (has edit_settings) as editable', () => {
+        expect(isAttachOnlyImage(withSettings('image/webp', beautified))).toBe(
+            false,
+        );
+    });
+
+    it('treats JPEG and PNG as editable', () => {
+        expect(isAttachOnlyImage(withSettings('image/jpeg', null))).toBe(false);
+        expect(isAttachOnlyImage(withSettings('image/png', null))).toBe(false);
     });
 });

--- a/resources/js/lib/compose/media-rules.ts
+++ b/resources/js/lib/compose/media-rules.ts
@@ -4,6 +4,26 @@ import type { MediaView } from '@/types/compose';
 const GIF_MIME = 'image/gif';
 
 /**
+ * Whether an image is attach-only rather than editable. The raster beautifier
+ * would flatten an animation to a single frame, so animated media must never
+ * open the editor. Animation isn't visible from the mime alone — Klipy stores a
+ * "GIF" as the larger `image/webp` variant, the same mime the beautifier itself
+ * emits — so we distinguish by provenance: a WebP is editable only when it's a
+ * beautifier output (it carries `edit_settings`). A WebP without `edit_settings`
+ * is a GIF-browser animation (or a raw upload we can't prove is static), so it's
+ * treated as attach-only. GIFs are always animated.
+ */
+export function isAttachOnlyImage(
+    media: Pick<MediaView, 'mime' | 'edit_settings'>,
+): boolean {
+    if (media.mime === GIF_MIME) {
+        return true;
+    }
+
+    return media.mime === 'image/webp' && media.edit_settings === null;
+}
+
+/**
  * A post carries one video OR images, never both. Given the already-attached
  * media and an incoming batch, returns whether the batch would mix the two — a
  * video joining images, or images joining a video.

--- a/tests/Feature/Engagement/ReplyImageEditTest.php
+++ b/tests/Feature/Engagement/ReplyImageEditTest.php
@@ -64,6 +64,19 @@ test('the reply store endpoint accepts a compact composed image', function (stri
     'webp' => ['out.webp', 'image/webp'],
 ]);
 
+test('the reply update endpoint rejects editing an animated gif', function () {
+    $gif = PostMedia::factory()->create([
+        'workspace_id' => $this->workspace->id, 'kind' => 'image', 'mime' => 'image/gif',
+    ]);
+
+    $this->actingAs($this->user)
+        ->put(route('engagement.image-edit.update', ['reply' => $this->reply, 'media' => $gif->id]), [
+            'composed' => UploadedFile::fake()->image('out.webp', 900, 600),
+            'settings' => editSettings(),
+        ])
+        ->assertStatus(422);
+});
+
 test('the reply update endpoint accepts a compact composed image', function () {
     $mediaId = $this->actingAs($this->user)
         ->post(route('engagement.image-edit.store', $this->reply), [

--- a/tests/Feature/Gifs/AttachGifEndpointTest.php
+++ b/tests/Feature/Gifs/AttachGifEndpointTest.php
@@ -33,6 +33,9 @@ beforeEach(function (): void {
     // NXDOMAIN in real DNS, and SafeImageFetcher resolves the host for real
     // before Http::fake ever intercepts the request (see GifAttacherTest).
     Http::fake([
+        // Clips route through SafeVideoFetcher, which rejects gif bytes — the
+        // .mp4 pattern must be registered before the catch-all (first match wins).
+        'https://static.klipy.com/*.mp4' => Http::response("\x00\x00\x00\x20".'ftypisom'.str_repeat("\x00", 4096), 200, ['Content-Type' => 'video/mp4']),
         'https://static.klipy.com/*' => Http::response(tinyGif(), 200, ['Content-Type' => 'image/gif']),
         'https://api.klipy.com/*' => Http::response(['result' => true, 'data' => []]),
     ]);
@@ -235,6 +238,44 @@ test('rejects a post gif when the composer declares a draft video it holds', fun
             'media_ids' => [$draftVideo->id],
         ]))
         ->assertStatus(422);
+});
+
+test('attaches a post gif to an empty segment while another segment already holds media', function () {
+    $user = User::factory()->withWorkspace()->create();
+    $post = Post::factory()->create(['workspace_id' => $user->current_workspace_id]);
+    // A saved image already lives on the post in a *different* thread segment.
+    // The composer declares only the target segment's media (none), so this
+    // GIF must attach — the mixing rules are per-segment, not per-post.
+    PostMedia::factory()->create([
+        'workspace_id' => $user->current_workspace_id,
+        'post_id' => $post->id,
+        'kind' => 'image',
+        'mime' => 'image/png',
+    ]);
+
+    $this->actingAs($user)
+        ->postJson("/posts/{$post->id}/gifs", attachPayload(['media_ids' => []]))
+        ->assertCreated();
+});
+
+test('attaches a post clip to an empty segment while another segment already holds media', function () {
+    $user = User::factory()->withWorkspace()->create();
+    $post = Post::factory()->create(['workspace_id' => $user->current_workspace_id]);
+    PostMedia::factory()->create([
+        'workspace_id' => $user->current_workspace_id,
+        'post_id' => $post->id,
+        'kind' => 'image',
+        'mime' => 'image/png',
+    ]);
+
+    $this->actingAs($user)
+        ->postJson("/posts/{$post->id}/gifs", attachPayload([
+            'catalog' => 'clip',
+            'variants' => [['url' => 'https://static.klipy.com/ok.mp4', 'mime' => 'video/mp4', 'width' => 320, 'height' => 240, 'bytes' => 40000]],
+            'duration_seconds' => 5,
+            'media_ids' => [],
+        ]))
+        ->assertCreated();
 });
 
 test('ignores post media ids from another workspace', function () {

--- a/tests/Feature/Posts/ImageEditApiTest.php
+++ b/tests/Feature/Posts/ImageEditApiTest.php
@@ -101,6 +101,41 @@ test('it 404s when updating media from another workspace', function () {
     ], ['Accept' => 'application/json'])->assertStatus(404);
 });
 
+test('it rejects editing an animated gif', function () {
+    Storage::fake('public');
+    [$user, $workspace, $post] = imageEditMember();
+    // Editing a GIF through the raster beautifier would flatten it to a static
+    // frame, silently destroying the animation — reject it server-side.
+    $gif = PostMedia::factory()->create([
+        'workspace_id' => $workspace->id,
+        'kind' => 'image',
+        'mime' => 'image/gif',
+    ]);
+
+    test()->put("/posts/{$post['id']}/image-edit/{$gif->id}", [
+        'composed' => UploadedFile::fake()->image('out.png', 800, 600),
+        'settings' => settingsPayload(),
+    ], ['Accept' => 'application/json'])->assertStatus(422);
+});
+
+test('it rejects editing a gif-browser webp (no edit_settings)', function () {
+    Storage::fake('public');
+    [$user, $workspace, $post] = imageEditMember();
+    // A GIF browsed from Klipy is stored as the larger WebP variant with no
+    // edit_settings — that's how it's told apart from a beautified WebP, which
+    // always carries edit_settings and stays editable.
+    $webp = PostMedia::factory()->create([
+        'workspace_id' => $workspace->id,
+        'mime' => 'image/webp',
+        'edit_settings' => null,
+    ]);
+
+    test()->put("/posts/{$post['id']}/image-edit/{$webp->id}", [
+        'composed' => UploadedFile::fake()->image('out.png', 800, 600),
+        'settings' => settingsPayload(),
+    ], ['Accept' => 'application/json'])->assertStatus(422);
+});
+
 test('it rejects a non-image composed file', function () {
     Storage::fake('public');
     [$user, $workspace, $post] = imageEditMember();

--- a/tests/Unit/PostMediaTest.php
+++ b/tests/Unit/PostMediaTest.php
@@ -48,6 +48,16 @@ test('a new media instance defaults to the image kind in memory', function () {
     expect((new PostMedia)->kind)->toBe('image');
 });
 
+test('isAttachOnlyImage distinguishes GIF-browser media from editable images', function () {
+    // GIFs and GIF-browser WebP (no edit_settings) are attach-only; a beautified
+    // WebP (has edit_settings) and plain rasters stay editable.
+    expect(PostMedia::factory()->make(['mime' => 'image/gif', 'edit_settings' => null])->isAttachOnlyImage())->toBeTrue()
+        ->and(PostMedia::factory()->make(['mime' => 'image/webp', 'edit_settings' => null])->isAttachOnlyImage())->toBeTrue()
+        ->and(PostMedia::factory()->make(['mime' => 'image/webp', 'edit_settings' => ['version' => 1]])->isAttachOnlyImage())->toBeFalse()
+        ->and(PostMedia::factory()->make(['mime' => 'image/jpeg', 'edit_settings' => null])->isAttachOnlyImage())->toBeFalse()
+        ->and(PostMedia::factory()->make(['mime' => 'image/png', 'edit_settings' => null])->isAttachOnlyImage())->toBeFalse();
+});
+
 test('deleting a media removes its composed and retained source files', function () {
     Storage::fake('public');
 


### PR DESCRIPTION
## Summary
- Fixed a bug where attaching a GIF or clip to one thread segment could be incorrectly blocked by media already present in a *different* segment of the same post.
- The composer now declares only the target segment's media ids (via `mediaForSegment`) instead of the entire post's media, so the backend mixing-rule guard (one video OR images, or a GIF alone) is correctly scoped per-segment rather than per-post.
- Added feature tests covering GIF and clip attachment to an empty segment while another segment already holds media.
