### PR TITLE
feat(accounts): add dedicated OAuth flow for LinkedIn Pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,10 +73,21 @@ SOCIALITE_ENABLED=false
 # X_REDIRECT_URI="${APP_URL}/accounts/callback/x"
 # X_BEARER_TOKEN=
 
-# LinkedIn — scopes: openid, profile, email, w_member_social
+# LinkedIn (personal profiles) — "Sign In with LinkedIn using OpenID Connect" +
+# "Share on LinkedIn" products. Scopes: openid, profile, email, w_member_social.
 # LINKEDIN_CLIENT_ID=
 # LINKEDIN_CLIENT_SECRET=
 # LINKEDIN_REDIRECT_URI="${APP_URL}/accounts/callback/linkedin"
+
+# LinkedIn Pages (Company/Organization) — a SEPARATE developer app approved for
+# the Community Management API. LinkedIn requires that the Community Management
+# product be the ONLY product on its app, so it cannot share the app above.
+# Register "${APP_URL}/accounts/callback/linkedin-pages" as an authorized
+# redirect URL. Scopes: r_organization_social, w_organization_social, rw_organization_admin.
+# Requires the instance "LinkedIn Pages" toggle (Community Management) to be on.
+# LINKEDIN_PAGES_CLIENT_ID=
+# LINKEDIN_PAGES_CLIENT_SECRET=
+# LINKEDIN_PAGES_REDIRECT_URI="${APP_URL}/accounts/callback/linkedin-pages"
 
 # Facebook + Instagram — one Meta app. Scopes: pages_show_list, pages_read_engagement,
 # pages_manage_posts, pages_read_user_content, pages_manage_engagement, read_insights,

--- a/app/Http/Controllers/ConnectedAccounts/ConnectedAccountController.php
+++ b/app/Http/Controllers/ConnectedAccounts/ConnectedAccountController.php
@@ -76,6 +76,11 @@ class ConnectedAccountController extends Controller
             'accounts' => $accounts,
             'capabilities' => Platform::capabilities(),
             'canManage' => $request->user()->can('create', ConnectedAccount::class),
+            // LinkedIn Pages is a distinct connect entry backed by a separate
+            // Community Management app; expose whether the operator has opted in
+            // and configured it so the connect menu can show it (or "Not set up").
+            'linkedinPagesEnabled' => app(InstanceSettings::class)->linkedinCommunityManagementEnabled(),
+            'linkedinPagesConfigured' => LinkedInPageOAuthController::pagesAppConfigured(),
         ]);
     }
 
@@ -138,6 +143,17 @@ class ConnectedAccountController extends Controller
             $this->connections->reconnect($account, $data, $request->user());
 
             return redirect()->route('accounts.index')->with('success', 'Account reconnected.');
+        }
+
+        // LinkedIn Pages reconnect against the dedicated Community Management app,
+        // not the personal `linkedin-openid` flow — its token was minted there.
+        if ($account->platform === Platform::LinkedIn && $account->isLinkedInOrganization()) {
+            if (! LinkedInPageOAuthController::pagesAppConfigured()) {
+                return redirect()->route('accounts.index')
+                    ->with('error', 'LinkedIn Pages is not configured for reconnection.');
+            }
+
+            return redirect()->route('accounts.linkedin-pages.redirect');
         }
 
         if (! $account->platform->supportsAppPassword()) {

--- a/app/Http/Controllers/ConnectedAccounts/ConnectedAccountController.php
+++ b/app/Http/Controllers/ConnectedAccounts/ConnectedAccountController.php
@@ -147,8 +147,14 @@ class ConnectedAccountController extends Controller
 
         // LinkedIn Pages reconnect against the dedicated Community Management app,
         // not the personal `linkedin-openid` flow — its token was minted there.
+        // The Pages redirect route 404s unless BOTH the toggle is on and the app
+        // is configured, so mirror that here and flash a friendly reason instead
+        // of bouncing the user into a bare 404.
         if ($account->platform === Platform::LinkedIn && $account->isLinkedInOrganization()) {
-            if (! LinkedInPageOAuthController::pagesAppConfigured()) {
+            if (
+                ! app(InstanceSettings::class)->linkedinCommunityManagementEnabled()
+                || ! LinkedInPageOAuthController::pagesAppConfigured()
+            ) {
                 return redirect()->route('accounts.index')
                     ->with('error', 'LinkedIn Pages is not configured for reconnection.');
             }

--- a/app/Http/Controllers/ConnectedAccounts/LinkedInPageConnectionController.php
+++ b/app/Http/Controllers/ConnectedAccounts/LinkedInPageConnectionController.php
@@ -16,10 +16,11 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 
 /**
- * Persists the LinkedIn accounts (personal profile + administered Pages) the
- * user picked after OAuth. All selected accounts share the same member token —
- * LinkedIn mints no per-Page token; the member token acts on Pages it
- * administers.
+ * Persists the LinkedIn Pages (Organizations) the user picked after the
+ * Community Management OAuth flow (LinkedInPageOAuthController). LinkedIn mints
+ * no per-Page token; the member token from the dedicated Pages app acts on every
+ * Page the member administers. Personal profiles never come through here — they
+ * connect directly via the separate `linkedin-openid` app.
  */
 class LinkedInPageConnectionController extends Controller
 {
@@ -42,8 +43,8 @@ class LinkedInPageConnectionController extends Controller
 
         $validated = $request->validate([
             'selected' => ['required', 'array', 'min:1'],
-            'selected.*.type' => ['required', 'string', Rule::in(['person', 'organization'])],
-            'selected.*.id' => ['required_if:selected.*.type,organization', 'nullable', 'string', Rule::in(array_keys($organizations))],
+            'selected.*.type' => ['required', 'string', Rule::in(['organization'])],
+            'selected.*.id' => ['required', 'string', Rule::in(array_keys($organizations))],
         ]);
 
         $token = (string) ($stash['accessToken'] ?? '');
@@ -57,39 +58,23 @@ class LinkedInPageConnectionController extends Controller
 
         $user = $request->user();
 
-        // Persist every selected account in one transaction so a mid-loop failure
+        // Persist every selected Page in one transaction so a mid-loop failure
         // can't leave the workspace with a partial set of connected accounts.
-        DB::transaction(function () use ($validated, $organizations, $stash, $token, $refresh, $expiresAt, $granted, $user): void {
+        DB::transaction(function () use ($validated, $organizations, $token, $refresh, $expiresAt, $granted, $user): void {
             foreach ($validated['selected'] as $selection) {
-                if ($selection['type'] === 'person') {
-                    $person = $stash['person'];
-                    $data = new ConnectedAccountData(
-                        platform: Platform::LinkedIn,
-                        remoteAccountId: (string) $person['remoteAccountId'],
-                        handle: (string) $person['handle'],
-                        displayName: $person['displayName'] ?? null,
-                        avatarUrl: $person['avatarUrl'] ?? null,
-                        authMethod: 'oauth',
-                        accessToken: $token,
-                        refreshToken: $refresh,
-                        capabilities: ['linkedin_account_type' => 'person', 'linkedin_engagement' => in_array('r_member_social_feed', $granted, true)],
-                        tokenExpiresAt: $expiresAt,
-                    );
-                } else {
-                    $organization = $organizations[$selection['id']];
-                    $data = new ConnectedAccountData(
-                        platform: Platform::LinkedIn,
-                        remoteAccountId: (string) $organization['id'],
-                        handle: (string) $organization['vanityName'],
-                        displayName: (string) $organization['name'],
-                        avatarUrl: null,
-                        authMethod: 'oauth',
-                        accessToken: $token,
-                        refreshToken: $refresh,
-                        capabilities: ['linkedin_account_type' => 'organization', 'linkedin_engagement' => in_array('r_organization_social', $granted, true)],
-                        tokenExpiresAt: $expiresAt,
-                    );
-                }
+                $organization = $organizations[$selection['id']];
+                $data = new ConnectedAccountData(
+                    platform: Platform::LinkedIn,
+                    remoteAccountId: (string) $organization['id'],
+                    handle: (string) $organization['vanityName'],
+                    displayName: (string) $organization['name'],
+                    avatarUrl: null,
+                    authMethod: 'oauth',
+                    accessToken: $token,
+                    refreshToken: $refresh,
+                    capabilities: ['linkedin_account_type' => 'organization', 'linkedin_engagement' => in_array('r_organization_social', $granted, true)],
+                    tokenExpiresAt: $expiresAt,
+                );
 
                 $this->connections->store($data, $user);
             }

--- a/app/Http/Controllers/ConnectedAccounts/LinkedInPageOAuthController.php
+++ b/app/Http/Controllers/ConnectedAccounts/LinkedInPageOAuthController.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\ConnectedAccounts;
+
+use App\Http\Controllers\Controller;
+use App\Models\ConnectedAccount;
+use App\Services\ConnectedAccounts\LinkedIn\LinkedInOrganizationDiscovery;
+use App\Support\InstanceSettings;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\Client\Factory as HttpFactory;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response as InertiaResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
+
+/**
+ * Connects LinkedIn Pages (Organizations) through a SEPARATE developer app
+ * approved for the Community Management API. LinkedIn requires that product to
+ * be the only one on its app, so Pages cannot share the personal `linkedin-openid`
+ * app that `OAuthConnectionController` drives — hence a dedicated OAuth flow with
+ * its own credentials (`services.linkedin-pages`) and organization-only scopes.
+ *
+ * The Community Management app has no OpenID/Sign-In product, so its token can't
+ * read a member profile via /userinfo. That's fine: the flow only needs the
+ * member token to enumerate administered Pages and then post as the organization.
+ * The exchange is therefore done manually (like MetaConnectionController /
+ * ThreadsTokenExchanger) rather than through Socialite's linkedin-openid driver.
+ */
+class LinkedInPageOAuthController extends Controller
+{
+    private const string SESSION_KEY = 'accounts.linkedin.connect';
+
+    private const string AUTHORIZE_URL = 'https://www.linkedin.com/oauth/v2/authorization';
+
+    private const string TOKEN_URL = 'https://www.linkedin.com/oauth/v2/accessToken';
+
+    /**
+     * Organization scopes only — reading/writing Page posts and enumerating the
+     * member's administered Pages (organizationAcls). No `openid`: the Community
+     * Management app has no Sign-In product to grant it.
+     *
+     * @var list<string>
+     */
+    private const array SCOPES = ['r_organization_social', 'w_organization_social', 'rw_organization_admin'];
+
+    public function __construct(
+        private readonly HttpFactory $http,
+        private readonly LinkedInOrganizationDiscovery $organizations,
+        private readonly InstanceSettings $settings,
+    ) {}
+
+    /**
+     * Whether the dedicated Community Management app credentials are configured.
+     */
+    public static function pagesAppConfigured(): bool
+    {
+        return filled(config('services.linkedin-pages.client_id'))
+            && filled(config('services.linkedin-pages.client_secret'));
+    }
+
+    public function redirect(Request $request): SymfonyRedirectResponse
+    {
+        $this->abortUnlessAvailable($request);
+
+        // Stateless, like MetaConnectionController: the `auth` middleware plus the
+        // explicit POST on the picker are the CSRF gates. `state` is echoed for
+        // OAuth hygiene but not verified, since session state is unreliable behind
+        // TLS-terminating proxies/tunnels.
+        $query = http_build_query([
+            'response_type' => 'code',
+            'client_id' => (string) config('services.linkedin-pages.client_id'),
+            'redirect_uri' => route('accounts.linkedin-pages.callback'),
+            'state' => Str::random(40),
+            'scope' => implode(' ', self::SCOPES),
+        ]);
+
+        return redirect()->away(self::AUTHORIZE_URL.'?'.$query);
+    }
+
+    public function callback(Request $request): RedirectResponse|InertiaResponse
+    {
+        $this->abortUnlessAvailable($request);
+
+        if ($request->filled('error')) {
+            Log::warning('LinkedIn Pages OAuth provider returned an error.', [
+                'error' => $request->query('error'),
+                'error_description' => $request->query('error_description'),
+            ]);
+
+            return $this->failed($request->query('error') === 'user_cancelled_authorize'
+                ? 'You declined to connect your LinkedIn Page.'
+                : "LinkedIn couldn't complete the connection. Please try again.");
+        }
+
+        if (! $request->filled('code')) {
+            return $this->failed("We couldn't connect your LinkedIn Page. Please try again.");
+        }
+
+        $token = $this->exchangeCodeForToken((string) $request->query('code'));
+
+        if ($token === null) {
+            return $this->failed("We couldn't connect your LinkedIn Page. Please try again.");
+        }
+
+        $organizations = $this->organizations->administeredOrganizations($token['accessToken']);
+
+        if ($organizations === []) {
+            return $this->failed(
+                "We couldn't find any LinkedIn Pages you administer. Only Pages where you're an "
+                .'admin can be connected — check your role on the Page, then try again.',
+            );
+        }
+
+        $stashedOrganizations = [];
+        foreach ($organizations as $organization) {
+            $stashedOrganizations[$organization->id] = [
+                'id' => $organization->id,
+                'urn' => $organization->urn,
+                'name' => $organization->name,
+                'vanityName' => $organization->vanityName,
+            ];
+        }
+
+        $request->session()->put(self::SESSION_KEY, [
+            'organizations' => $stashedOrganizations,
+            'accessToken' => $token['accessToken'],
+            'refreshToken' => $token['refreshToken'],
+            'tokenExpiresAt' => $token['expiresAt']?->toIso8601String(),
+            'approvedScopes' => $token['scopes'],
+        ]);
+
+        return Inertia::render('accounts/connect-linkedin', [
+            'organizations' => array_values($stashedOrganizations),
+        ]);
+    }
+
+    /**
+     * Exchange the authorization code for a member token using the Community
+     * Management app's credentials. Returns null on any failure (logged).
+     *
+     * @return array{accessToken: string, refreshToken: ?string, expiresAt: ?CarbonImmutable, scopes: list<string>}|null
+     */
+    private function exchangeCodeForToken(string $code): ?array
+    {
+        $response = $this->http->asForm()->post(self::TOKEN_URL, [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => route('accounts.linkedin-pages.callback'),
+            'client_id' => (string) config('services.linkedin-pages.client_id'),
+            'client_secret' => (string) config('services.linkedin-pages.client_secret'),
+        ]);
+
+        if ($response->failed()) {
+            Log::warning('LinkedIn Pages token exchange failed.', [
+                'status' => $response->status(),
+                'error' => $response->json('error'),
+                'error_description' => $response->json('error_description'),
+            ]);
+
+            return null;
+        }
+
+        $accessToken = (string) $response->json('access_token');
+
+        if ($accessToken === '') {
+            return null;
+        }
+
+        $expiresIn = (int) $response->json('expires_in');
+        $refreshToken = $response->json('refresh_token');
+
+        return [
+            'accessToken' => $accessToken,
+            'refreshToken' => is_string($refreshToken) && $refreshToken !== '' ? $refreshToken : null,
+            'expiresAt' => $expiresIn > 0 ? Date::now()->addSeconds($expiresIn)->toImmutable() : null,
+            'scopes' => $this->parseScopes($response->json('scope')),
+        ];
+    }
+
+    /**
+     * LinkedIn returns granted scopes as a comma- or space-separated string.
+     *
+     * @return list<string>
+     */
+    private function parseScopes(mixed $scope): array
+    {
+        if (! is_string($scope) || $scope === '') {
+            return [];
+        }
+
+        return array_values(array_filter(preg_split('/[\s,]+/', $scope) ?: []));
+    }
+
+    /**
+     * The Pages flow is only reachable when the operator has both turned on the
+     * Community Management ("LinkedIn Pages") toggle and configured the dedicated
+     * app. Anything else 404s — there's no personal-account fallback here.
+     */
+    private function abortUnlessAvailable(Request $request): void
+    {
+        $request->user()->can('create', ConnectedAccount::class) ?: abort(403);
+
+        if (! $this->settings->linkedinCommunityManagementEnabled() || ! self::pagesAppConfigured()) {
+            abort(404);
+        }
+    }
+
+    private function failed(string $message): RedirectResponse
+    {
+        return redirect()->route('accounts.index')->with('error', $message);
+    }
+}

--- a/app/Http/Controllers/ConnectedAccounts/OAuthConnectionController.php
+++ b/app/Http/Controllers/ConnectedAccounts/OAuthConnectionController.php
@@ -9,15 +9,12 @@ use App\Enums\Platform;
 use App\Http\Controllers\Controller;
 use App\Models\ConnectedAccount;
 use App\Services\ConnectedAccounts\AccountConnectionService;
-use App\Services\ConnectedAccounts\LinkedIn\LinkedInOrganizationDiscovery;
 use App\Services\ConnectedAccounts\Threads\ThreadsTokenExchanger;
 use App\Services\ConnectedAccounts\XAccountCapabilities;
 use App\Support\InstanceSettings;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use Inertia\Inertia;
-use Inertia\Response as InertiaResponse;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\AbstractProvider;
 use Laravel\Socialite\Two\InvalidStateException;
@@ -32,7 +29,6 @@ class OAuthConnectionController extends Controller
         private readonly XAccountCapabilities $xCapabilities,
         private readonly ThreadsTokenExchanger $threadsExchanger,
         private readonly InstanceSettings $settings,
-        private readonly LinkedInOrganizationDiscovery $linkedInOrganizations,
     ) {}
 
     public function redirect(Request $request, string $platform): Response
@@ -44,7 +40,7 @@ class OAuthConnectionController extends Controller
         return $this->driver($resolved)->setScopes($this->scopesFor($resolved))->redirect();
     }
 
-    public function callback(Request $request, string $platform): RedirectResponse|InertiaResponse
+    public function callback(Request $request, string $platform): RedirectResponse
     {
         $resolved = $this->resolveOAuthPlatform($platform);
 
@@ -109,19 +105,6 @@ class OAuthConnectionController extends Controller
             $data = $data->withCapabilities([...($data->capabilities ?? []), 'dm_enabled' => $dmGranted]);
         }
 
-        $linkedInGrantedScopes = [];
-
-        if ($resolved === Platform::LinkedIn) {
-            // Record whether LinkedIn actually granted the restricted Community
-            // Management read scope, so the engagement inbox only polls accounts
-            // that can read replies (others 403). `approvedScopes` comes from the
-            // token response's `scope` field.
-            $linkedInGrantedScopes = array_values((array) $oauthUser->approvedScopes);
-            $data = $data->withCapabilities([
-                'linkedin_engagement' => in_array('r_member_social_feed', $linkedInGrantedScopes, true),
-            ]);
-        }
-
         if ($resolved === Platform::Threads) {
             // The short-lived Threads token is useless for publishing, so a failed
             // long-lived exchange is a failed connection — redirect with a friendly
@@ -140,66 +123,10 @@ class OAuthConnectionController extends Controller
             $data = $data->withLongLivedToken($long['token'], $long['expiresAt']);
         }
 
-        if ($resolved === Platform::LinkedIn && $this->settings->linkedinCommunityManagementEnabled()) {
-            $picker = $this->renderLinkedInPagePicker($request, $data, $linkedInGrantedScopes);
-
-            if ($picker !== null) {
-                return $picker;
-            }
-        }
-
         $this->connections->store($data, $request->user());
 
         return redirect()->route('accounts.index')
             ->with('success', $this->successMessage($resolved));
-    }
-
-    /**
-     * When the operator has opted into Community Management, offer the member's
-     * administered Pages alongside their personal profile. Returns the picker
-     * response, or null when the member administers no Pages (then the caller
-     * falls through to the normal single personal-account store).
-     *
-     * @param  list<string>  $grantedScopes
-     */
-    private function renderLinkedInPagePicker(Request $request, ConnectedAccountData $data, array $grantedScopes): ?InertiaResponse
-    {
-        $organizations = $this->linkedInOrganizations->administeredOrganizations((string) $data->accessToken);
-
-        if ($organizations === []) {
-            return null;
-        }
-
-        $stashedOrganizations = [];
-        foreach ($organizations as $organization) {
-            $stashedOrganizations[$organization->id] = [
-                'id' => $organization->id,
-                'urn' => $organization->urn,
-                'name' => $organization->name,
-                'vanityName' => $organization->vanityName,
-            ];
-        }
-
-        $person = [
-            'remoteAccountId' => $data->remoteAccountId,
-            'handle' => $data->handle,
-            'displayName' => $data->displayName,
-            'avatarUrl' => $data->avatarUrl,
-        ];
-
-        $request->session()->put('accounts.linkedin.connect', [
-            'person' => $person,
-            'organizations' => $stashedOrganizations,
-            'accessToken' => $data->accessToken,
-            'refreshToken' => $data->refreshToken,
-            'tokenExpiresAt' => $data->tokenExpiresAt?->toIso8601String(),
-            'approvedScopes' => $grantedScopes,
-        ]);
-
-        return Inertia::render('accounts/connect-linkedin', [
-            'person' => $person,
-            'organizations' => array_values($stashedOrganizations),
-        ]);
     }
 
     private function failed(string $message): RedirectResponse
@@ -244,27 +171,15 @@ class OAuthConnectionController extends Controller
     }
 
     /**
-     * OAuth scopes to request for a platform. LinkedIn's engagement inbox needs
-     * the restricted Community Management feed scopes; they are only appended
-     * when the operator has declared the app is approved for them, because
-     * requesting a scope an app lacks makes LinkedIn reject the whole authorize.
+     * OAuth scopes to request for a platform. LinkedIn Pages/organizations run
+     * through the dedicated Community Management app (LinkedInPageOAuthController),
+     * so the personal LinkedIn app here only ever requests its base member scopes.
      *
      * @return list<string>
      */
     private function scopesFor(Platform $platform): array
     {
         $scopes = $platform->scopes();
-
-        if ($platform === Platform::LinkedIn && $this->settings->linkedinCommunityManagementEnabled()) {
-            $scopes = [
-                ...$scopes,
-                'r_member_social_feed',
-                'w_member_social_feed',
-                'r_organization_social',
-                'w_organization_social',
-                'rw_organization_admin',
-            ];
-        }
 
         if ($platform->supportsDirectMessages() && $this->settings->directMessagesEnabled()) {
             $scopes = [...$scopes, ...$this->directMessageScopeDeltas($platform)];

--- a/app/Services/Publishing/TokenManager.php
+++ b/app/Services/Publishing/TokenManager.php
@@ -303,7 +303,11 @@ class TokenManager
             $endpoint = 'https://www.linkedin.com/oauth/v2/accessToken';
         }
 
-        $configKey = $account->platform->configKey();
+        // LinkedIn Pages/organizations are minted by — and so must be refreshed
+        // against — the dedicated Community Management app, not the personal one.
+        $configKey = $account->isLinkedInOrganization()
+            ? 'services.linkedin-pages'
+            : $account->platform->configKey();
         $clientId = $account->platform === Platform::Bluesky
             ? (string) ($secret->session['client_id'] ?? route('oauth.bluesky.metadata'))
             : (string) config($configKey.'.client_id');

--- a/config/services.php
+++ b/config/services.php
@@ -57,6 +57,16 @@ return [
         'api_version' => env('LINKEDIN_API_VERSION', LinkedInConnector::DEFAULT_VERSION),
     ],
 
+    // LinkedIn Pages/Organizations run through a SEPARATE developer app approved
+    // for the Community Management API — LinkedIn requires that product to be the
+    // only one on the app, so it cannot share the personal `linkedin-openid` app.
+    'linkedin-pages' => [
+        'client_id' => env('LINKEDIN_PAGES_CLIENT_ID'),
+        'client_secret' => env('LINKEDIN_PAGES_CLIENT_SECRET'),
+        'redirect' => env('LINKEDIN_PAGES_REDIRECT_URI'),
+        'api_version' => env('LINKEDIN_API_VERSION', LinkedInConnector::DEFAULT_VERSION),
+    ],
+
     'facebook' => [
         'client_id' => env('FACEBOOK_CLIENT_ID'),
         'client_secret' => env('FACEBOOK_CLIENT_SECRET'),

--- a/resources/js/components/accounts/connect-buttons.tsx
+++ b/resources/js/components/accounts/connect-buttons.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import BlueskyConnectionController from '@/actions/App/Http/Controllers/ConnectedAccounts/BlueskyConnectionController';
 import BlueskyOAuthController from '@/actions/App/Http/Controllers/ConnectedAccounts/BlueskyOAuthController';
 import DiscordConnectionController from '@/actions/App/Http/Controllers/ConnectedAccounts/DiscordConnectionController';
+import LinkedInPageOAuthController from '@/actions/App/Http/Controllers/ConnectedAccounts/LinkedInPageOAuthController';
 import MetaConnectionController from '@/actions/App/Http/Controllers/ConnectedAccounts/MetaConnectionController';
 import OAuthConnectionController from '@/actions/App/Http/Controllers/ConnectedAccounts/OAuthConnectionController';
 import InputError from '@/components/common/input-error';
@@ -522,8 +523,12 @@ function connectHref(capability: Capability): string {
  */
 export function ConnectButtons({
     capabilities,
+    linkedinPagesEnabled = false,
+    linkedinPagesConfigured = false,
 }: {
     capabilities: Capability[];
+    linkedinPagesEnabled?: boolean;
+    linkedinPagesConfigured?: boolean;
 }) {
     const [blueskyOpen, setBlueskyOpen] = useState(false);
     const [discordOpen, setDiscordOpen] = useState(false);
@@ -618,6 +623,34 @@ export function ConnectButtons({
                             </DropdownMenuItem>
                         );
                     })}
+                    {/* LinkedIn Pages connect through a separate Community
+                        Management app, so they're a distinct entry — shown only
+                        once the operator opts in, and dimmed until that app's
+                        credentials are configured. */}
+                    {linkedinPagesEnabled &&
+                        (linkedinPagesConfigured ? (
+                            <DropdownMenuItem
+                                className="gap-2.5"
+                                render={
+                                    <a
+                                        href={LinkedInPageOAuthController.redirect.url()}
+                                    />
+                                }
+                            >
+                                {platformIcon('linkedin')}
+                                LinkedIn Page
+                            </DropdownMenuItem>
+                        ) : (
+                            <DropdownMenuItem disabled className="gap-2.5">
+                                {platformIcon('linkedin')}
+                                <span className="flex-1 truncate">
+                                    LinkedIn Page
+                                </span>
+                                <span className="text-xs whitespace-nowrap text-muted-foreground">
+                                    Not set up
+                                </span>
+                            </DropdownMenuItem>
+                        ))}
                 </DropdownMenuContent>
             </DropdownMenu>
             <BlueskyConnectDialog

--- a/resources/js/pages/accounts/connect-linkedin.tsx
+++ b/resources/js/pages/accounts/connect-linkedin.tsx
@@ -8,13 +8,6 @@ import { PlatformGlyph } from '@/components/common/platform-glyph';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 
-type LinkedInPerson = {
-    remoteAccountId: string;
-    handle: string;
-    displayName: string | null;
-    avatarUrl: string | null;
-};
-
 type LinkedInOrganization = {
     id: string;
     urn: string;
@@ -22,21 +15,17 @@ type LinkedInOrganization = {
     vanityName: string;
 };
 
-type Selection = { type: 'person' } | { type: 'organization'; id: string };
+type Selection = { type: 'organization'; id: string };
 
-type Props = { person: LinkedInPerson; organizations: LinkedInOrganization[] };
+type Props = { organizations: LinkedInOrganization[] };
 
-export default function ConnectLinkedIn({ person, organizations }: Props) {
-    const [personChecked, setPersonChecked] = useState(true);
+export default function ConnectLinkedIn({ organizations }: Props) {
     const [checkedOrgs, setCheckedOrgs] = useState<Record<string, boolean>>({});
     const [processing, setProcessing] = useState(false);
 
-    const selection: Selection[] = [
-        ...(personChecked ? [{ type: 'person' as const }] : []),
-        ...organizations
-            .filter((org) => checkedOrgs[org.id])
-            .map((org) => ({ type: 'organization' as const, id: org.id })),
-    ];
+    const selection: Selection[] = organizations
+        .filter((org) => checkedOrgs[org.id])
+        .map((org) => ({ type: 'organization' as const, id: org.id }));
 
     const submit = () => {
         router.post(
@@ -53,28 +42,10 @@ export default function ConnectLinkedIn({ person, organizations }: Props) {
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 pt-6 pb-16 sm:px-6">
             <Head title="Connect LinkedIn" />
             <Heading
-                title="Choose what to connect"
-                description="Connect your personal LinkedIn profile and any Pages you administer to this workspace."
+                title="Choose which Pages to connect"
+                description="Connect any LinkedIn Pages you administer to this workspace."
             />
             <div className="flex flex-col gap-4">
-                <label className="flex items-center gap-3 rounded-xl border p-4">
-                    <Checkbox
-                        checked={personChecked}
-                        onCheckedChange={(c) => setPersonChecked(c === true)}
-                    />
-                    <PlatformGlyph
-                        platform="linkedin"
-                        size={16}
-                        className="size-4"
-                    />
-                    <span className="font-medium">
-                        {person.displayName ?? person.handle}
-                    </span>
-                    <span className="text-sm text-muted-foreground">
-                        Personal profile
-                    </span>
-                </label>
-
                 {organizations.map((org) => (
                     <label
                         key={org.id}

--- a/resources/js/pages/accounts/index.tsx
+++ b/resources/js/pages/accounts/index.tsx
@@ -46,12 +46,16 @@ type Props = {
     accounts: Account[];
     capabilities: Capability[];
     canManage: boolean;
+    linkedinPagesEnabled: boolean;
+    linkedinPagesConfigured: boolean;
 };
 
 export default function ConnectedAccounts({
     accounts,
     capabilities,
     canManage,
+    linkedinPagesEnabled,
+    linkedinPagesConfigured,
 }: Props) {
     const disabledPlatforms = new Set(
         capabilities.filter((c) => !c.enabled).map((c) => c.platform),
@@ -159,7 +163,13 @@ export default function ConnectedAccounts({
                     title="Connected accounts"
                     description="Workspace-owned social accounts shared by every member."
                 />
-                {canManage && <ConnectButtons capabilities={capabilities} />}
+                {canManage && (
+                    <ConnectButtons
+                        capabilities={capabilities}
+                        linkedinPagesEnabled={linkedinPagesEnabled}
+                        linkedinPagesConfigured={linkedinPagesConfigured}
+                    />
+                )}
             </div>
 
             {connectError && (
@@ -193,7 +203,13 @@ export default function ConnectedAccounts({
                     </EmptyHeader>
                     {canManage && (
                         <div className="mt-4 flex justify-center">
-                            <ConnectButtons capabilities={capabilities} />
+                            <ConnectButtons
+                                capabilities={capabilities}
+                                linkedinPagesEnabled={linkedinPagesEnabled}
+                                linkedinPagesConfigured={
+                                    linkedinPagesConfigured
+                                }
+                            />
                         </div>
                     )}
                 </Empty>

--- a/resources/js/pages/accounts/index.tsx
+++ b/resources/js/pages/accounts/index.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import BlueskyOAuthController from '@/actions/App/Http/Controllers/ConnectedAccounts/BlueskyOAuthController';
 import ConnectedAccountController from '@/actions/App/Http/Controllers/ConnectedAccounts/ConnectedAccountController';
+import LinkedInPageOAuthController from '@/actions/App/Http/Controllers/ConnectedAccounts/LinkedInPageOAuthController';
 import OAuthConnectionController from '@/actions/App/Http/Controllers/ConnectedAccounts/OAuthConnectionController';
 import { AccountCard } from '@/components/accounts/account-card';
 import { ConnectButtons } from '@/components/accounts/connect-buttons';
@@ -28,6 +29,12 @@ export const ACCOUNT_GRID_CLASS = 'grid grid-cols-1 gap-4 lg:grid-cols-2';
  * authorization server instead of falling back to the bsky.social default.
  */
 export function reconnectOAuthUrl(account: Account): string {
+    // LinkedIn Pages reconnect through the dedicated Community Management app,
+    // not the personal LinkedIn OAuth flow that its member token can't reach.
+    if (account.is_linkedin_page) {
+        return LinkedInPageOAuthController.redirect.url();
+    }
+
     if (account.platform !== 'bluesky') {
         return OAuthConnectionController.redirect.url({
             platform: account.platform,

--- a/routes/accounts.php
+++ b/routes/accounts.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\ConnectedAccounts\BlueskyOAuthController;
 use App\Http\Controllers\ConnectedAccounts\ConnectedAccountController;
 use App\Http\Controllers\ConnectedAccounts\DiscordConnectionController;
 use App\Http\Controllers\ConnectedAccounts\LinkedInPageConnectionController;
+use App\Http\Controllers\ConnectedAccounts\LinkedInPageOAuthController;
 use App\Http\Controllers\ConnectedAccounts\MetaConnectionController;
 use App\Http\Controllers\ConnectedAccounts\OAuthConnectionController;
 use App\Http\Controllers\OAuth\BlueskyClientMetadataController;
@@ -63,8 +64,17 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
         ->middleware('throttle:10,1')
         ->name('accounts.meta.store');
 
-    // Same registration-order requirement as the Meta routes above: this must
-    // come before the generic `{platform}` wildcard route.
+    // Same registration-order requirement as the Meta routes above: these must
+    // come before the generic `{platform}` wildcard route (Platform::tryFrom
+    // ('linkedin-pages') is null, so the wildcard would 404 first).
+    Route::get('accounts/connect/linkedin-pages', [LinkedInPageOAuthController::class, 'redirect'])
+        ->middleware('throttle:10,1')
+        ->name('accounts.linkedin-pages.redirect');
+
+    Route::get('accounts/callback/linkedin-pages', [LinkedInPageOAuthController::class, 'callback'])
+        ->middleware('throttle:10,1')
+        ->name('accounts.linkedin-pages.callback');
+
     Route::post('accounts/connect/linkedin/pages', [LinkedInPageConnectionController::class, 'store'])
         ->middleware('throttle:10,1')
         ->name('accounts.linkedin.store');

--- a/tests/Feature/ConnectedAccounts/AccountsPageTest.php
+++ b/tests/Feature/ConnectedAccounts/AccountsPageTest.php
@@ -62,7 +62,6 @@ test('the accounts page lists accounts and exposes capabilities and canManage to
 test('the accounts page exposes the linkedin pages availability flags', function () {
     $owner = viewerInWorkspace(WorkspaceRole::Owner);
 
-    // Off + unconfigured by default.
     test()->actingAs($owner)->get('/accounts')
         ->assertInertia(fn (Assert $page) => $page
             ->where('linkedinPagesEnabled', false)

--- a/tests/Feature/ConnectedAccounts/AccountsPageTest.php
+++ b/tests/Feature/ConnectedAccounts/AccountsPageTest.php
@@ -8,6 +8,7 @@ use App\Models\ConnectedAccountSecret;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Models\WorkspaceMembership;
+use App\Support\InstanceSettings;
 use Illuminate\Support\Facades\Http;
 use Inertia\Testing\AssertableInertia as Assert;
 
@@ -55,6 +56,27 @@ test('the accounts page lists accounts and exposes capabilities and canManage to
             ->where('accounts.0.max_video_duration_seconds', 14_400)
             ->where('accounts.0.is_default', false)
             ->missing('accounts.0.secret'),
+        );
+});
+
+test('the accounts page exposes the linkedin pages availability flags', function () {
+    $owner = viewerInWorkspace(WorkspaceRole::Owner);
+
+    // Off + unconfigured by default.
+    test()->actingAs($owner)->get('/accounts')
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('linkedinPagesEnabled', false)
+            ->where('linkedinPagesConfigured', false),
+        );
+
+    app(InstanceSettings::class)->update(['linkedin_community_management_enabled' => true]);
+    config()->set('services.linkedin-pages.client_id', 'pages-cid');
+    config()->set('services.linkedin-pages.client_secret', 'pages-secret');
+
+    test()->actingAs($owner)->get('/accounts')
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('linkedinPagesEnabled', true)
+            ->where('linkedinPagesConfigured', true),
         );
 });
 

--- a/tests/Feature/ConnectedAccounts/ConnectLinkedInPagesTest.php
+++ b/tests/Feature/ConnectedAccounts/ConnectLinkedInPagesTest.php
@@ -4,11 +4,6 @@ use App\Models\ConnectedAccount;
 use App\Support\InstanceSettings;
 use Illuminate\Support\Facades\Http;
 
-// Reuses ownerActingIn() from tests/Pest.php (shared across the
-// connected-accounts Feature suite). LinkedIn Pages run through a SEPARATE
-// Community Management developer app (`services.linkedin-pages`), gated on the
-// instance "LinkedIn Pages" (Community Management) toggle.
-
 beforeEach(function () {
     config()->set('services.linkedin-pages.client_id', 'pages-cid');
     config()->set('services.linkedin-pages.client_secret', 'pages-secret');
@@ -62,8 +57,6 @@ test('pages callback renders the org picker after the CM token exchange', functi
     ]);
 
     test()->get('/accounts/callback/linkedin-pages?code=abc&state=xyz')
-        // The `accounts/connect-linkedin` picker page's existence check is skipped
-        // (mirrors ConnectMetaTest): assert only the props it's handed.
         ->assertInertia(fn ($page) => $page
             ->component('accounts/connect-linkedin', false)
             ->has('organizations', 1)

--- a/tests/Feature/ConnectedAccounts/ConnectLinkedInPagesTest.php
+++ b/tests/Feature/ConnectedAccounts/ConnectLinkedInPagesTest.php
@@ -4,30 +4,54 @@ use App\Models\ConnectedAccount;
 use App\Support\InstanceSettings;
 use Illuminate\Support\Facades\Http;
 
-// Reuses ownerActingIn() + fakeOAuthUser() from tests/Pest.php (shared across
-// the connected-accounts Feature suite).
+// Reuses ownerActingIn() from tests/Pest.php (shared across the
+// connected-accounts Feature suite). LinkedIn Pages run through a SEPARATE
+// Community Management developer app (`services.linkedin-pages`), gated on the
+// instance "LinkedIn Pages" (Community Management) toggle.
 
 beforeEach(function () {
-    // The generic OAuth connect/callback routes abort 404 unless the platform
-    // is configured (Platform::isConfigured()). CI copies .env from
-    // .env.example, which ships LinkedIn creds commented out, so set them here
-    // to keep these callback tests independent of the host environment.
-    config()->set('services.linkedin-openid.client_id', 'cid');
-    config()->set('services.linkedin-openid.client_secret', 'secret');
+    config()->set('services.linkedin-pages.client_id', 'pages-cid');
+    config()->set('services.linkedin-pages.client_secret', 'pages-secret');
+    app(InstanceSettings::class)->update(['linkedin_community_management_enabled' => true]);
 });
 
-test('linkedin callback renders the page picker when organizations are administered', function () {
+test('pages redirect sends the user to LinkedIn with the org scopes and pages app id', function () {
     ownerActingIn();
-    app(InstanceSettings::class)->update(['linkedin_community_management_enabled' => true]);
 
-    fakeOAuthUser('linkedin-openid', [
-        'id' => 'PERSON1',
-        'name' => 'Jane Member',
-        'nickname' => 'jane',
-        'approvedScopes' => ['r_member_social_feed', 'w_organization_social', 'rw_organization_admin'],
-    ]);
+    $location = test()->get(route('accounts.linkedin-pages.redirect'))
+        ->headers->get('Location');
+
+    expect($location)->toStartWith('https://www.linkedin.com/oauth/v2/authorization')
+        ->and($location)->toContain('client_id=pages-cid')
+        ->and(urldecode((string) $location))->toContain('r_organization_social')
+        ->and(urldecode((string) $location))->toContain('w_organization_social')
+        ->and(urldecode((string) $location))->toContain('rw_organization_admin');
+});
+
+test('pages redirect 404s when the community management toggle is off', function () {
+    ownerActingIn();
+    app(InstanceSettings::class)->update(['linkedin_community_management_enabled' => false]);
+
+    test()->get(route('accounts.linkedin-pages.redirect'))->assertNotFound();
+});
+
+test('pages redirect 404s when the dedicated pages app is not configured', function () {
+    ownerActingIn();
+    config()->set('services.linkedin-pages.client_id', null);
+
+    test()->get(route('accounts.linkedin-pages.redirect'))->assertNotFound();
+});
+
+test('pages callback renders the org picker after the CM token exchange', function () {
+    ownerActingIn();
 
     Http::fake([
+        'https://www.linkedin.com/oauth/v2/accessToken' => Http::response([
+            'access_token' => 'org-tok',
+            'expires_in' => 5184000,
+            'refresh_token' => 'org-ref',
+            'scope' => 'r_organization_social w_organization_social rw_organization_admin',
+        ]),
         'https://api.linkedin.com/rest/organizationAcls*' => Http::response([
             'elements' => [['organizationTarget' => 'urn:li:organization:2414183']],
         ]),
@@ -37,90 +61,119 @@ test('linkedin callback renders the page picker when organizations are administe
         ]),
     ]);
 
-    test()->get('/accounts/callback/linkedin?code=abc&state=xyz')
-        // The `accounts/connect-linkedin` picker page is a later task; skip
-        // Inertia's page-file existence check (mirrors ConnectMetaTest).
+    test()->get('/accounts/callback/linkedin-pages?code=abc&state=xyz')
+        // The `accounts/connect-linkedin` picker page's existence check is skipped
+        // (mirrors ConnectMetaTest): assert only the props it's handed.
         ->assertInertia(fn ($page) => $page
             ->component('accounts/connect-linkedin', false)
-            ->where('person.remoteAccountId', 'PERSON1')
             ->has('organizations', 1)
             ->where('organizations.0.name', 'Acme Inc'));
 
-    expect(ConnectedAccount::count())->toBe(0); // nothing persisted until the user picks
+    expect(ConnectedAccount::count())->toBe(0)          // nothing persisted until the user picks
+        ->and(session('accounts.linkedin.connect.accessToken'))->toBe('org-tok');
 });
 
-test('linkedin callback stays single-step when the toggle is off', function () {
+test('pages callback redirects with an error when the member administers no pages', function () {
     ownerActingIn();
 
-    fakeOAuthUser('linkedin-openid', ['id' => 'PERSON1', 'name' => 'Jane', 'nickname' => 'jane', 'approvedScopes' => []]);
+    Http::fake([
+        'https://www.linkedin.com/oauth/v2/accessToken' => Http::response([
+            'access_token' => 'org-tok',
+            'expires_in' => 5184000,
+            'scope' => 'r_organization_social',
+        ]),
+        'https://api.linkedin.com/rest/organizationAcls*' => Http::response(['elements' => []]),
+    ]);
 
-    test()->get('/accounts/callback/linkedin?code=abc&state=xyz')->assertRedirect(route('accounts.index'));
+    test()->get('/accounts/callback/linkedin-pages?code=abc')
+        ->assertRedirect(route('accounts.index'))
+        ->assertSessionHas('error');
 
-    expect(ConnectedAccount::where('platform', 'linkedin')->count())->toBe(1);
+    expect(ConnectedAccount::count())->toBe(0);
 });
 
-test('store persists the personal profile and selected pages', function () {
+test('pages callback redirects with an error when the token exchange fails', function () {
     ownerActingIn();
-    app(InstanceSettings::class)->update(['linkedin_community_management_enabled' => true]);
+
+    Http::fake([
+        'https://www.linkedin.com/oauth/v2/accessToken' => Http::response(['error' => 'invalid_grant'], 400),
+    ]);
+
+    test()->get('/accounts/callback/linkedin-pages?code=abc')
+        ->assertRedirect(route('accounts.index'))
+        ->assertSessionHas('error');
+
+    expect(ConnectedAccount::count())->toBe(0);
+});
+
+test('store persists the selected pages as organization accounts', function () {
+    ownerActingIn();
 
     session(['accounts.linkedin.connect' => [
-        'person' => ['remoteAccountId' => 'PERSON1', 'handle' => 'jane', 'displayName' => 'Jane', 'avatarUrl' => null],
         'organizations' => ['2414183' => ['id' => '2414183', 'urn' => 'urn:li:organization:2414183', 'name' => 'Acme Inc', 'vanityName' => 'acme']],
-        'accessToken' => 'tok',
-        'refreshToken' => 'ref',
+        'accessToken' => 'org-tok',
+        'refreshToken' => 'org-ref',
         'tokenExpiresAt' => null,
-        'approvedScopes' => ['r_member_social_feed', 'r_organization_social'],
+        'approvedScopes' => ['r_organization_social'],
     ]]);
 
     test()->post(route('accounts.linkedin.store'), [
-        'selected' => [['type' => 'person'], ['type' => 'organization', 'id' => '2414183']],
+        'selected' => [['type' => 'organization', 'id' => '2414183']],
     ])->assertRedirect(route('accounts.index'));
 
-    $person = ConnectedAccount::where('remote_account_id', 'PERSON1')->firstOrFail();
     $page = ConnectedAccount::where('remote_account_id', '2414183')->firstOrFail();
 
-    expect($person->isLinkedInOrganization())->toBeFalse()
-        ->and($page->isLinkedInOrganization())->toBeTrue()
+    expect($page->isLinkedInOrganization())->toBeTrue()
         ->and($page->display_name)->toBe('Acme Inc')
-        ->and($person->capabilities['linkedin_engagement'])->toBeTrue()
+        ->and($page->handle)->toBe('acme')
         ->and($page->capabilities['linkedin_engagement'])->toBeTrue();
 });
 
 test('store gates page engagement capability off when the org scope was not granted', function () {
     ownerActingIn();
-    app(InstanceSettings::class)->update(['linkedin_community_management_enabled' => true]);
 
     session(['accounts.linkedin.connect' => [
-        'person' => ['remoteAccountId' => 'PERSON1', 'handle' => 'jane', 'displayName' => 'Jane', 'avatarUrl' => null],
         'organizations' => ['2414183' => ['id' => '2414183', 'urn' => 'urn:li:organization:2414183', 'name' => 'Acme Inc', 'vanityName' => 'acme']],
-        'accessToken' => 'tok',
-        'refreshToken' => 'ref',
+        'accessToken' => 'org-tok',
+        'refreshToken' => 'org-ref',
         'tokenExpiresAt' => null,
-        'approvedScopes' => ['r_member_social_feed'],
+        'approvedScopes' => [],
     ]]);
 
     test()->post(route('accounts.linkedin.store'), [
-        'selected' => [['type' => 'person'], ['type' => 'organization', 'id' => '2414183']],
+        'selected' => [['type' => 'organization', 'id' => '2414183']],
     ])->assertRedirect(route('accounts.index'));
 
-    $person = ConnectedAccount::where('remote_account_id', 'PERSON1')->firstOrFail();
-    $page = ConnectedAccount::where('remote_account_id', '2414183')->firstOrFail();
+    expect(ConnectedAccount::where('remote_account_id', '2414183')->firstOrFail()->capabilities['linkedin_engagement'])->toBeFalse();
+});
 
-    expect($person->capabilities['linkedin_engagement'])->toBeTrue()
-        ->and($page->capabilities['linkedin_engagement'])->toBeFalse();
+test('store rejects a personal selection — pages flow is organization-only', function () {
+    ownerActingIn();
+
+    session(['accounts.linkedin.connect' => [
+        'organizations' => ['2414183' => ['id' => '2414183', 'urn' => 'urn:li:organization:2414183', 'name' => 'Acme Inc', 'vanityName' => 'acme']],
+        'accessToken' => 'org-tok',
+        'refreshToken' => 'org-ref',
+        'tokenExpiresAt' => null,
+        'approvedScopes' => ['r_organization_social'],
+    ]]);
+
+    test()->post(route('accounts.linkedin.store'), [
+        'selected' => [['type' => 'person']],
+    ])->assertSessionHasErrors('selected.0.type');
+
+    expect(ConnectedAccount::where('platform', 'linkedin')->count())->toBe(0);
 });
 
 test('store rejects an organization selection missing an id and persists nothing', function () {
     ownerActingIn();
-    app(InstanceSettings::class)->update(['linkedin_community_management_enabled' => true]);
 
     session(['accounts.linkedin.connect' => [
-        'person' => ['remoteAccountId' => 'PERSON1', 'handle' => 'jane', 'displayName' => 'Jane', 'avatarUrl' => null],
         'organizations' => ['2414183' => ['id' => '2414183', 'urn' => 'urn:li:organization:2414183', 'name' => 'Acme Inc', 'vanityName' => 'acme']],
-        'accessToken' => 'tok',
-        'refreshToken' => 'ref',
+        'accessToken' => 'org-tok',
+        'refreshToken' => 'org-ref',
         'tokenExpiresAt' => null,
-        'approvedScopes' => ['r_member_social_feed', 'r_organization_social'],
+        'approvedScopes' => ['r_organization_social'],
     ]]);
 
     test()->post(route('accounts.linkedin.store'), [
@@ -130,17 +183,15 @@ test('store rejects an organization selection missing an id and persists nothing
     expect(ConnectedAccount::where('platform', 'linkedin')->count())->toBe(0);
 });
 
-test('store rejects an organization selection with an id outside the stashed whitelist and persists nothing', function () {
+test('store rejects an organization id outside the stashed whitelist and persists nothing', function () {
     ownerActingIn();
-    app(InstanceSettings::class)->update(['linkedin_community_management_enabled' => true]);
 
     session(['accounts.linkedin.connect' => [
-        'person' => ['remoteAccountId' => 'PERSON1', 'handle' => 'jane', 'displayName' => 'Jane', 'avatarUrl' => null],
         'organizations' => ['2414183' => ['id' => '2414183', 'urn' => 'urn:li:organization:2414183', 'name' => 'Acme Inc', 'vanityName' => 'acme']],
-        'accessToken' => 'tok',
-        'refreshToken' => 'ref',
+        'accessToken' => 'org-tok',
+        'refreshToken' => 'org-ref',
         'tokenExpiresAt' => null,
-        'approvedScopes' => ['r_member_social_feed', 'r_organization_social'],
+        'approvedScopes' => ['r_organization_social'],
     ]]);
 
     test()->post(route('accounts.linkedin.store'), [

--- a/tests/Feature/ConnectedAccounts/ConnectOAuthTest.php
+++ b/tests/Feature/ConnectedAccounts/ConnectOAuthTest.php
@@ -177,7 +177,7 @@ test('callback maps a linkedin-openid user', function () {
         ->and($account->token_expires_at)->not->toBeNull();
 });
 
-test('linkedin connect requests the community management feed scopes only when enabled', function () {
+test('personal linkedin connect never requests organization or member-feed scopes', function () {
     config()->set('services.linkedin-openid.client_id', 'cid');
     config()->set('services.linkedin-openid.client_secret', 'secret');
     config()->set('services.linkedin-openid.redirect', 'https://app.test/accounts/callback/linkedin');
@@ -194,80 +194,39 @@ test('linkedin connect requests the community management feed scopes only when e
     $provider->shouldReceive('redirect')->andReturn(redirect('https://provider.test/oauth'));
     Socialite::shouldReceive('driver')->with('linkedin-openid')->andReturn($provider);
 
-    // Off by default: never request the restricted scope (it would break authorize).
-    test()->get('/accounts/connect/linkedin')->assertRedirect('https://provider.test/oauth');
-    expect($captured)->not->toContain('r_member_social_feed');
-
+    // Pages/organizations run through the dedicated Community Management app, so
+    // the personal app only ever asks for its base member scopes — even when the
+    // Community Management ("LinkedIn Pages") toggle is on. Requesting the closed
+    // org/member-feed scopes here would break the authorize outright.
     app(InstanceSettings::class)->update(['linkedin_community_management_enabled' => true]);
 
     test()->get('/accounts/connect/linkedin')->assertRedirect('https://provider.test/oauth');
-    expect($captured)->toContain('r_member_social_feed')
-        ->and($captured)->toContain('w_member_social_feed');
+
+    expect($captured)->toEqual(['openid', 'profile', 'email', 'w_member_social'])
+        ->and($captured)->not->toContain('r_member_social_feed')
+        ->and($captured)->not->toContain('w_organization_social')
+        ->and($captured)->not->toContain('rw_organization_admin');
 });
 
-test('linkedin connect requests the organization scopes only when community management is enabled', function () {
-    config()->set('services.linkedin-openid.client_id', 'cid');
-    config()->set('services.linkedin-openid.client_secret', 'secret');
-    config()->set('services.linkedin-openid.redirect', 'https://app.test/accounts/callback/linkedin');
-    ownerActingIn();
-
-    $captured = [];
-    $provider = Mockery::mock(AbstractProvider::class);
-    $provider->shouldReceive('setScopes')->andReturnUsing(function (array $scopes) use ($provider, &$captured) {
-        $captured = $scopes;
-
-        return $provider;
-    });
-    $provider->shouldReceive('redirectUrl')->andReturnSelf();
-    $provider->shouldReceive('redirect')->andReturn(redirect('https://provider.test/oauth'));
-    Socialite::shouldReceive('driver')->with('linkedin-openid')->andReturn($provider);
-
-    test()->get('/accounts/connect/linkedin')->assertRedirect('https://provider.test/oauth');
-    expect($captured)->not->toContain('w_organization_social');
-
-    app(InstanceSettings::class)->update(['linkedin_community_management_enabled' => true]);
-
-    test()->get('/accounts/connect/linkedin')->assertRedirect('https://provider.test/oauth');
-    expect($captured)->toContain('r_organization_social')
-        ->and($captured)->toContain('w_organization_social')
-        ->and($captured)->toContain('rw_organization_admin');
-});
-
-test('linkedin connect records the engagement capability from the granted scopes', function () {
+test('personal linkedin connect does not grant the engagement capability', function () {
+    // Member reply-reading needs the closed Community Management member-feed
+    // scope, which the personal app can't hold — so personal profiles never get
+    // engagement. Only Pages (connected via the CM app) can fetch engagement.
     config()->set('services.linkedin-openid.client_id', 'cid');
     config()->set('services.linkedin-openid.client_secret', 'secret');
     config()->set('services.linkedin-openid.redirect', 'https://app.test/accounts/callback/linkedin');
     ownerActingIn();
     fakeOAuthUser('linkedin-openid', [
-        'id' => 'sub-cap',
+        'id' => 'sub-person',
         'name' => 'Ada Lovelace',
-        'expiresIn' => 5184000,
-        'approvedScopes' => ['openid', 'profile', 'email', 'w_member_social', 'r_member_social_feed'],
-    ]);
-
-    test()->get('/accounts/callback/linkedin')->assertRedirect(route('accounts.index'));
-
-    $account = ConnectedAccount::withoutGlobalScopes()->firstWhere('remote_account_id', 'sub-cap');
-    expect($account->capabilities['linkedin_engagement'])->toBeTrue()
-        ->and($account->canFetchEngagement())->toBeTrue();
-});
-
-test('linkedin connect marks engagement unavailable when the feed scope is not granted', function () {
-    config()->set('services.linkedin-openid.client_id', 'cid');
-    config()->set('services.linkedin-openid.client_secret', 'secret');
-    config()->set('services.linkedin-openid.redirect', 'https://app.test/accounts/callback/linkedin');
-    ownerActingIn();
-    fakeOAuthUser('linkedin-openid', [
-        'id' => 'sub-nocap',
-        'name' => 'Alan Turing',
         'expiresIn' => 5184000,
         'approvedScopes' => ['openid', 'profile', 'email', 'w_member_social'],
     ]);
 
     test()->get('/accounts/callback/linkedin')->assertRedirect(route('accounts.index'));
 
-    $account = ConnectedAccount::withoutGlobalScopes()->firstWhere('remote_account_id', 'sub-nocap');
-    expect($account->capabilities['linkedin_engagement'])->toBeFalse()
+    $account = ConnectedAccount::withoutGlobalScopes()->firstWhere('remote_account_id', 'sub-person');
+    expect($account->isLinkedInOrganization())->toBeFalse()
         ->and($account->canFetchEngagement())->toBeFalse();
 });
 

--- a/tests/Feature/ConnectedAccounts/ReconnectDisconnectTest.php
+++ b/tests/Feature/ConnectedAccounts/ReconnectDisconnectTest.php
@@ -165,6 +165,61 @@ test('reconnecting a facebook account restarts the shared meta login flow, not t
         ->assertRedirect(route('accounts.meta.redirect'));
 });
 
+test('reconnecting a linkedin page restarts the community management flow, not the personal route', function () {
+    [$user, $workspace] = ownerWithWorkspace();
+    config()->set('services.linkedin-openid.client_id', 'cid');
+    config()->set('services.linkedin-openid.client_secret', 'secret');
+    config()->set('services.linkedin-pages.client_id', 'pages-cid');
+    config()->set('services.linkedin-pages.client_secret', 'pages-secret');
+
+    $account = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'platform' => Platform::LinkedIn->value,
+        'connected_by_user_id' => $user->id,
+        'capabilities' => ['linkedin_account_type' => 'organization'],
+    ]);
+    ConnectedAccountSecret::factory()->create(['connected_account_id' => $account->id]);
+
+    test()->post("/accounts/{$account->id}/reconnect")
+        ->assertRedirect(route('accounts.linkedin-pages.redirect'));
+});
+
+test('reconnecting a linkedin page errors when the community management app is not configured', function () {
+    [$user, $workspace] = ownerWithWorkspace();
+    config()->set('services.linkedin-openid.client_id', 'cid');
+    config()->set('services.linkedin-openid.client_secret', 'secret');
+    config()->set('services.linkedin-pages.client_id', null);
+    config()->set('services.linkedin-pages.client_secret', null);
+
+    $account = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'platform' => Platform::LinkedIn->value,
+        'connected_by_user_id' => $user->id,
+        'capabilities' => ['linkedin_account_type' => 'organization'],
+    ]);
+    ConnectedAccountSecret::factory()->create(['connected_account_id' => $account->id]);
+
+    test()->post("/accounts/{$account->id}/reconnect")
+        ->assertRedirect(route('accounts.index'))
+        ->assertSessionHas('error');
+});
+
+test('reconnecting a personal linkedin account uses the generic per-platform route', function () {
+    [$user, $workspace] = ownerWithWorkspace();
+    config()->set('services.linkedin-openid.client_id', 'cid');
+    config()->set('services.linkedin-openid.client_secret', 'secret');
+
+    $account = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'platform' => Platform::LinkedIn->value,
+        'connected_by_user_id' => $user->id,
+    ]);
+    ConnectedAccountSecret::factory()->create(['connected_account_id' => $account->id]);
+
+    test()->post("/accounts/{$account->id}/reconnect")
+        ->assertRedirect(route('accounts.connect', ['platform' => 'linkedin']));
+});
+
 test('disconnect removes both the account and its secret row', function () {
     [$user, $workspace] = ownerWithWorkspace();
     $account = ConnectedAccount::factory()->create([

--- a/tests/Feature/ConnectedAccounts/ReconnectDisconnectTest.php
+++ b/tests/Feature/ConnectedAccounts/ReconnectDisconnectTest.php
@@ -8,6 +8,7 @@ use App\Models\ConnectedAccountSecret;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Models\WorkspaceMembership;
+use App\Support\InstanceSettings;
 use Illuminate\Support\Facades\Http;
 
 function ownerWithWorkspace(): array
@@ -171,6 +172,7 @@ test('reconnecting a linkedin page restarts the community management flow, not t
     config()->set('services.linkedin-openid.client_secret', 'secret');
     config()->set('services.linkedin-pages.client_id', 'pages-cid');
     config()->set('services.linkedin-pages.client_secret', 'pages-secret');
+    app(InstanceSettings::class)->update(['linkedin_community_management_enabled' => true]);
 
     $account = ConnectedAccount::factory()->create([
         'workspace_id' => $workspace->id,
@@ -190,6 +192,28 @@ test('reconnecting a linkedin page errors when the community management app is n
     config()->set('services.linkedin-openid.client_secret', 'secret');
     config()->set('services.linkedin-pages.client_id', null);
     config()->set('services.linkedin-pages.client_secret', null);
+    app(InstanceSettings::class)->update(['linkedin_community_management_enabled' => true]);
+
+    $account = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'platform' => Platform::LinkedIn->value,
+        'connected_by_user_id' => $user->id,
+        'capabilities' => ['linkedin_account_type' => 'organization'],
+    ]);
+    ConnectedAccountSecret::factory()->create(['connected_account_id' => $account->id]);
+
+    test()->post("/accounts/{$account->id}/reconnect")
+        ->assertRedirect(route('accounts.index'))
+        ->assertSessionHas('error');
+});
+
+test('reconnecting a linkedin page errors when the community management toggle is off even if configured', function () {
+    // The Pages redirect route 404s when the toggle is off; the reconnect branch
+    // must flash a friendly reason rather than bounce the user into that 404.
+    [$user, $workspace] = ownerWithWorkspace();
+    config()->set('services.linkedin-pages.client_id', 'pages-cid');
+    config()->set('services.linkedin-pages.client_secret', 'pages-secret');
+    app(InstanceSettings::class)->update(['linkedin_community_management_enabled' => false]);
 
     $account = ConnectedAccount::factory()->create([
         'workspace_id' => $workspace->id,

--- a/tests/Feature/Publishing/TokenManagerTest.php
+++ b/tests/Feature/Publishing/TokenManagerTest.php
@@ -210,6 +210,38 @@ test('linkedin token refresh sends credentials in the body', function () {
         && ! $request->hasHeader('Authorization'));
 });
 
+test('linkedin page token refresh uses the dedicated community management app credentials', function () {
+    // Org accounts are minted by the separate pages app, so their refresh must
+    // send THAT app's credentials — the personal `linkedin-openid` client would
+    // be rejected by LinkedIn as a mismatched client for the refresh token.
+    config()->set('services.linkedin-openid.client_id', 'personal-id');
+    config()->set('services.linkedin-openid.client_secret', 'personal-secret');
+    config()->set('services.linkedin-pages.client_id', 'pages-id');
+    config()->set('services.linkedin-pages.client_secret', 'pages-secret');
+
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::LinkedIn->value,
+        'token_expires_at' => now()->subMinute(),
+        'capabilities' => ['linkedin_account_type' => 'organization'],
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'refresh_token' => 'refresh-old',
+    ]);
+
+    Http::fake([
+        'https://www.linkedin.com/oauth/v2/accessToken' => Http::response([
+            'access_token' => 'new-access',
+            'expires_in' => 3600,
+        ]),
+    ]);
+
+    app(TokenManager::class)->fresh($account->fresh());
+
+    Http::assertSent(fn ($request) => $request['client_id'] === 'pages-id'
+        && $request['client_secret'] === 'pages-secret');
+});
+
 test('fresh refreshes the bluesky session before publishing and persists the new tokens', function () {
     $account = ConnectedAccount::factory()->bluesky()->create(['token_expires_at' => null]);
     ConnectedAccountSecret::factory()->create([


### PR DESCRIPTION
## Summary
- Adds a separate LinkedIn Pages connect flow (`LinkedInPageOAuthController`) backed by its own Community Management developer app (`services.linkedin-pages` / `LINKEDIN_PAGES_*` env vars), since LinkedIn requires that product to be the only one on an app — fixes #150, where "Select account" for LinkedIn Pages silently redirected back with no page picker.
- The Connect menu now shows a distinct "LinkedIn Page" entry, gated behind the instance's "LinkedIn Pages" (Community Management) toggle and dimmed with "Not set up" if the dedicated app isn't configured.
- After authorizing, users are shown a picker to select which administered Page(s) to connect (personal-profile selection removed from this flow — personal profiles connect via the existing `linkedin-openid` app).
- Reconnecting a LinkedIn Page account now restarts the Community Management flow instead of the personal OAuth route, and token refresh for Page accounts uses the dedicated app's credentials.
- Simplifies `OAuthConnectionController` by removing the now-unused organization-scope/page-picker logic from the personal LinkedIn flow.

## Breaking Changes
- Operators using LinkedIn Pages must configure new `LINKEDIN_PAGES_CLIENT_ID` / `LINKEDIN_PAGES_CLIENT_SECRET` / `LINKEDIN_PAGES_REDIRECT_URI` env vars (a separate LinkedIn developer app approved for the Community Management API) and register the new `${APP_URL}/accounts/callback/linkedin-pages` redirect URL. Existing personal LinkedIn connections are unaffected.


---

Fixes #150