### PR TITLE
feat(posts): add Discord mention picker and fix handle validation

### DIFF
--- a/app/Http/Requests/Post/Concerns/DerivesMentionHandleRules.php
+++ b/app/Http/Requests/Post/Concerns/DerivesMentionHandleRules.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Post\Concerns;
+
+use App\Enums\Platform;
+
+trait DerivesMentionHandleRules
+{
+    /**
+     * Validation rules for every `mentions.*.handles.*` key.
+     *
+     * Derived from the Platform enum (plus the non-platform `linkedin_urn`)
+     * rather than hard-coded, because Laravel's `excludeUnvalidatedArrayKeys`
+     * strips any nested `handles.*` key that lacks an explicit rule from
+     * `validated()` — which silently dropped Discord/Meta mention markup before
+     * it reached DraftService (mirrors the fix in WorkspaceMentionController).
+     *
+     * @return array<string, array<int, string>>
+     */
+    protected function mentionHandleRules(): array
+    {
+        $rules = [];
+
+        foreach ([...Platform::cases(), 'linkedin_urn'] as $handleKey) {
+            $key = $handleKey instanceof Platform ? $handleKey->value : $handleKey;
+            $rules['mentions.*.handles.'.$key] = $key === 'linkedin_urn'
+                ? ['nullable', 'string', 'max:255']
+                : ['nullable', 'string'];
+        }
+
+        return $rules;
+    }
+}

--- a/app/Http/Requests/Post/Concerns/DerivesMentionHandleRules.php
+++ b/app/Http/Requests/Post/Concerns/DerivesMentionHandleRules.php
@@ -23,12 +23,11 @@ trait DerivesMentionHandleRules
     {
         $rules = [];
 
-        foreach ([...Platform::cases(), 'linkedin_urn'] as $handleKey) {
-            $key = $handleKey instanceof Platform ? $handleKey->value : $handleKey;
-            $rules['mentions.*.handles.'.$key] = $key === 'linkedin_urn'
-                ? ['nullable', 'string', 'max:255']
-                : ['nullable', 'string'];
+        foreach (Platform::cases() as $platform) {
+            $rules['mentions.*.handles.'.$platform->value] = ['nullable', 'string'];
         }
+
+        $rules['mentions.*.handles.linkedin_urn'] = ['nullable', 'string', 'max:255'];
 
         return $rules;
     }

--- a/app/Http/Requests/Post/StorePostRequest.php
+++ b/app/Http/Requests/Post/StorePostRequest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Post;
 
+use App\Http\Requests\Post\Concerns\DerivesMentionHandleRules;
 use App\Models\Post;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
 class StorePostRequest extends FormRequest
 {
+    use DerivesMentionHandleRules;
+
     public function authorize(): bool
     {
         return $this->user()->can('create', Post::class);
@@ -28,10 +31,7 @@ class StorePostRequest extends FormRequest
             'mentions.*.id' => ['required', 'string'],
             'mentions.*.label' => ['required', 'string'],
             'mentions.*.handles' => ['array'],
-            'mentions.*.handles.x' => ['nullable', 'string'],
-            'mentions.*.handles.bluesky' => ['nullable', 'string'],
-            'mentions.*.handles.linkedin' => ['nullable', 'string'],
-            'mentions.*.handles.linkedin_urn' => ['nullable', 'string', 'max:255'],
+            ...$this->mentionHandleRules(),
             'destination' => ['required', 'array'],
             'destination.kind' => ['required', Rule::in(['all', 'none', 'set', 'account', 'accounts'])],
             'destination.id' => ['nullable', 'string', 'required_if:destination.kind,set,account'],

--- a/app/Http/Requests/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/Post/UpdatePostRequest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\Http\Requests\Post;
 
 use App\Enums\PostFormat;
+use App\Http\Requests\Post\Concerns\DerivesMentionHandleRules;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
 class UpdatePostRequest extends FormRequest
 {
+    use DerivesMentionHandleRules;
+
     public function authorize(): bool
     {
         return $this->user()->can('update', $this->route('post'));
@@ -28,10 +31,7 @@ class UpdatePostRequest extends FormRequest
             'mentions.*.id' => ['required', 'string'],
             'mentions.*.label' => ['required', 'string'],
             'mentions.*.handles' => ['array'],
-            'mentions.*.handles.x' => ['nullable', 'string'],
-            'mentions.*.handles.bluesky' => ['nullable', 'string'],
-            'mentions.*.handles.linkedin' => ['nullable', 'string'],
-            'mentions.*.handles.linkedin_urn' => ['nullable', 'string', 'max:255'],
+            ...$this->mentionHandleRules(),
             'destination' => ['required', 'array'],
             'destination.kind' => ['required', Rule::in(['all', 'none', 'set', 'account', 'accounts'])],
             'destination.id' => ['nullable', 'string', 'required_if:destination.kind,set,account'],

--- a/resources/js/components/compose/__tests__/mention-picker.test.tsx
+++ b/resources/js/components/compose/__tests__/mention-picker.test.tsx
@@ -239,3 +239,37 @@ describe('linkedin mention field', () => {
         expect(source).not.toContain('LinkedIn company URL or org URN');
     });
 });
+
+describe('discord mention field', () => {
+    const source = readFileSync(
+        resolve(
+            process.cwd(),
+            'resources/js/components/compose/mention-picker.tsx',
+        ),
+        'utf8',
+    );
+
+    it('renders a dedicated Discord field routed from the platform map', () => {
+        expect(source).toContain('function DiscordMentionField');
+        expect(source).toContain("platform === 'discord'");
+        expect(source).toContain('key={`discord-${activeMention.id}`}');
+    });
+
+    it('exposes a plain-text ⇄ mention toggle plus a User/Role/Channel picker', () => {
+        expect(source).toContain('DISCORD_KIND_OPTIONS');
+        expect(source).toContain("{ value: 'user', label: 'User' }");
+        expect(source).toContain("{ value: 'role', label: 'Role' }");
+        expect(source).toContain("{ value: 'channel', label: 'Channel' }");
+    });
+
+    it('composes the chosen kind + id into native Discord markup', () => {
+        expect(source).toContain('discordMentionMarkup(nextKind, nextId)');
+        expect(source).toContain('parseDiscordMention(stored)');
+    });
+
+    it('keeps the id field numeric and previews the posted markup', () => {
+        expect(source).toContain("inputMode={idMode ? 'numeric' : undefined}");
+        expect(source).toContain('Posts as');
+        expect(source).toContain('Copy ID');
+    });
+});

--- a/resources/js/components/compose/mention-picker.tsx
+++ b/resources/js/components/compose/mention-picker.tsx
@@ -767,9 +767,13 @@ function DiscordMentionField({
 
     function setMode(next: boolean) {
         setIdMode(next);
-        if (next) {
+        // Only overwrite the stored handle when there is an id to write —
+        // otherwise toggling into mention mode with an empty field would erase
+        // the plain-text handle (permanently, if the component then remounts on
+        // a mention rename). Typing an id later composes the markup.
+        if (next && idValue !== '') {
             writeMarkup(kind, idValue);
-        } else {
+        } else if (!next) {
             writeText(textValue);
         }
     }

--- a/resources/js/components/compose/mention-picker.tsx
+++ b/resources/js/components/compose/mention-picker.tsx
@@ -25,10 +25,12 @@ import {
     InputGroupInput,
 } from '@/components/ui/input-group';
 import {
+    discordMentionMarkup,
     extractLinkedInOrgRef,
     hasEmptyActiveHandle,
     mentionInputValue,
     normalizeMentionName,
+    parseDiscordMention,
     platformSupportsMention,
     savedMentionToPlaceholder,
     setPlatformMentionMode,
@@ -36,6 +38,7 @@ import {
     updateMentionLinkedInUrn,
     updateMentionName,
     usesPlatformMention,
+    type DiscordMentionKind,
 } from '@/lib/compose/mentions';
 import { cn } from '@/lib/utils';
 import type {
@@ -405,22 +408,36 @@ function MentionHandleEditor({
                  * Keyed on the mention id so each field's local mode state resets
                  * when a different mention is edited.
                  */}
-                {activePlatforms.map((platform) =>
-                    platform === 'linkedin' ? (
-                        <LinkedInMentionField
-                            key={`linkedin-${activeMention.id}`}
-                            activeMention={activeMention}
-                            onUpdateMention={onUpdateMention}
-                        />
-                    ) : (
+                {activePlatforms.map((platform) => {
+                    if (platform === 'linkedin') {
+                        return (
+                            <LinkedInMentionField
+                                key={`linkedin-${activeMention.id}`}
+                                activeMention={activeMention}
+                                onUpdateMention={onUpdateMention}
+                            />
+                        );
+                    }
+
+                    if (platform === 'discord') {
+                        return (
+                            <DiscordMentionField
+                                key={`discord-${activeMention.id}`}
+                                activeMention={activeMention}
+                                onUpdateMention={onUpdateMention}
+                            />
+                        );
+                    }
+
+                    return (
                         <PlatformMentionField
                             key={`${platform}-${activeMention.id}`}
                             activeMention={activeMention}
                             platform={platform}
                             onUpdateMention={onUpdateMention}
                         />
-                    ),
-                )}
+                    );
+                })}
             </div>
             {onSave && (
                 <div className="flex flex-col gap-1.5">
@@ -680,6 +697,167 @@ function LinkedInMentionField({
                         <span className="text-[11px] text-muted-foreground/80">
                             Match the company&rsquo;s exact name above, or
                             LinkedIn won&rsquo;t link it.
+                        </span>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+type DiscordMentionFieldProps = {
+    activeMention: MentionPlaceholder;
+    onUpdateMention: (
+        previous: MentionPlaceholder,
+        next: MentionPlaceholder,
+    ) => void;
+};
+
+const DISCORD_KIND_OPTIONS: { value: DiscordMentionKind; label: string }[] = [
+    { value: 'user', label: 'User' },
+    { value: 'role', label: 'Role' },
+    { value: 'channel', label: 'Channel' },
+];
+
+/**
+ * The Discord row: a plain-text ⇄ mention toggle, and in mention mode a
+ * User/Role/Channel picker plus a snowflake-id field. The chosen kind + id are
+ * composed into Discord's native markup (`<@id>`, `<@&id>`, `<#id>`) and stored
+ * in `handles.discord`, which the webhook posts verbatim so Discord renders the
+ * mention. Local state (mode, kind, and the separate id/text values) resets per
+ * mention because the parent keys this element on the mention id.
+ */
+function DiscordMentionField({
+    activeMention,
+    onUpdateMention,
+}: DiscordMentionFieldProps) {
+    const stored = activeMention.handles.discord ?? '';
+    const parsed = parseDiscordMention(stored);
+    const [idMode, setIdMode] = useState(Boolean(parsed));
+    const [kind, setKind] = useState<DiscordMentionKind>(
+        parsed?.kind ?? 'user',
+    );
+    const [idValue, setIdValue] = useState(parsed?.id ?? '');
+    // In id mode the stored value is markup, so seed the plain-text field from
+    // the label instead of the markup that would otherwise leak into it.
+    const [textValue, setTextValue] = useState(
+        mentionInputValue(
+            parsed ? activeMention.label : stored || activeMention.label,
+        ),
+    );
+
+    function writeMarkup(nextKind: DiscordMentionKind, nextId: string) {
+        onUpdateMention(
+            activeMention,
+            updateMentionHandle(
+                activeMention,
+                'discord',
+                discordMentionMarkup(nextKind, nextId),
+                false,
+            ),
+        );
+    }
+
+    function writeText(value: string) {
+        onUpdateMention(
+            activeMention,
+            updateMentionHandle(activeMention, 'discord', value, false),
+        );
+    }
+
+    function setMode(next: boolean) {
+        setIdMode(next);
+        if (next) {
+            writeMarkup(kind, idValue);
+        } else {
+            writeText(textValue);
+        }
+    }
+
+    function changeKind(next: DiscordMentionKind) {
+        setKind(next);
+        writeMarkup(next, idValue);
+    }
+
+    function changeId(raw: string) {
+        // Discord ids are numeric snowflakes; drop anything else as it is typed.
+        const digits = raw.replace(/\D+/g, '');
+        setIdValue(digits);
+        writeMarkup(kind, digits);
+    }
+
+    function changeText(value: string) {
+        setTextValue(value);
+        writeText(value);
+    }
+
+    const markup = discordMentionMarkup(kind, idValue);
+    const idPlaceholder =
+        kind === 'role'
+            ? 'Role ID'
+            : kind === 'channel'
+              ? 'Channel ID'
+              : 'User ID';
+
+    return (
+        <div className="flex flex-col gap-1 text-xs">
+            <div className="flex items-center gap-2">
+                <PlatformGlyph
+                    platform="discord"
+                    size={15}
+                    className="shrink-0 text-muted-foreground"
+                />
+                <InputGroup className="h-8 min-w-0 flex-1 rounded-lg">
+                    <InputGroupInput
+                        value={idMode ? idValue : textValue}
+                        inputMode={idMode ? 'numeric' : undefined}
+                        placeholder={
+                            idMode ? idPlaceholder : 'Name shown on Discord'
+                        }
+                        aria-label={`discord ${
+                            idMode ? `${kind} id` : 'display text'
+                        } for ${activeMention.label}`}
+                        className="text-xs"
+                        onChange={(event) =>
+                            idMode
+                                ? changeId(event.target.value)
+                                : changeText(event.target.value)
+                        }
+                    />
+                </InputGroup>
+                <MentionModeToggle
+                    ariaLabel={`How to show ${activeMention.label} on Discord`}
+                    value={idMode ? 'id' : 'text'}
+                    options={[
+                        { value: 'text', label: 'Plain text' },
+                        { value: 'id', label: 'Mention' },
+                    ]}
+                    onChange={(next) => setMode(next === 'id')}
+                />
+            </div>
+            {idMode && (
+                <div className="flex flex-col gap-1.5 pl-6">
+                    <MentionModeToggle
+                        ariaLabel={`Discord mention type for ${activeMention.label}`}
+                        value={kind}
+                        options={DISCORD_KIND_OPTIONS}
+                        onChange={(next) =>
+                            changeKind(next as DiscordMentionKind)
+                        }
+                    />
+                    {idValue ? (
+                        <span className="flex items-center gap-1.5 rounded-md bg-muted/60 px-2 py-1">
+                            <span className="shrink-0 text-foreground">
+                                Posts as
+                            </span>
+                            <code className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground">
+                                {markup}
+                            </code>
+                        </span>
+                    ) : (
+                        <span className="text-[11px] text-muted-foreground">
+                            Turn on Developer Mode in Discord, then right-click
+                            the {kind} &rarr; Copy ID.
                         </span>
                     )}
                 </div>

--- a/resources/js/components/compose/platform-preview-panel.tsx
+++ b/resources/js/components/compose/platform-preview-panel.tsx
@@ -161,6 +161,7 @@ function PlatformPreviewPost({
                         text={item.text}
                         platform={preview.platform}
                         linkExclusions={item.linkExclusions}
+                        discordLabels={preview.discordLabels}
                         emptyFallback={`Start writing to preview your ${label} post.`}
                     />
                 </p>

--- a/resources/js/components/compose/preview/__tests__/fixtures.ts
+++ b/resources/js/components/compose/preview/__tests__/fixtures.ts
@@ -47,6 +47,7 @@ export function makePreview(
         limit: 2200,
         autoSplit: false,
         format,
+        discordLabels: {},
         items: [
             {
                 id: `${platform}-preview-1`,

--- a/resources/js/components/posts/published-post-view.tsx
+++ b/resources/js/components/posts/published-post-view.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/icons';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { discordMentionLabels } from '@/lib/compose/mentions';
 import { dayjs } from '@/lib/datetime/dayjs';
 import { formatCompact, formatFull } from '@/lib/format';
 import { LinkedText } from '@/lib/linked-text';
@@ -229,6 +230,7 @@ function PublishedCard({
     stat,
     showMetrics,
     loading,
+    discordLabels,
 }: {
     target: TargetView;
     media: MediaView[];
@@ -236,6 +238,7 @@ function PublishedCard({
     stat: PostStatTarget | undefined;
     showMetrics: boolean;
     loading: boolean;
+    discordLabels: Record<string, string>;
 }) {
     const name =
         target.display_name ?? target.handle ?? platformLabel(target.platform);
@@ -321,6 +324,7 @@ function PublishedCard({
                                     <LinkedText
                                         text={section}
                                         platform={target.platform}
+                                        discordLabels={discordLabels}
                                     />
                                 </p>
                                 {index === 0 && cardMedia.length > 0 && (
@@ -576,6 +580,7 @@ function PublishedBody({
                     stat={statsById.get(selectedTarget.id)}
                     showMetrics={showMetrics}
                     loading={loading}
+                    discordLabels={discordMentionLabels(post.mentions ?? [])}
                 />
             )}
 

--- a/resources/js/lib/compose/__tests__/mentions.test.ts
+++ b/resources/js/lib/compose/__tests__/mentions.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import {
     createMention,
+    discordMentionLabels,
+    discordMentionMarkup,
     extractLinkedInOrgRef,
     hasEmptyActiveHandle,
     mentionInputValue,
     mentionToken,
     normalizeLinkedInUrn,
+    parseDiscordMention,
     platformSupportsMention,
     replaceMentionLabel,
     replaceMentionTokens,
@@ -529,6 +532,98 @@ describe('extractLinkedInOrgRef', () => {
 
         expect(next.handles.linkedin).toBe('Acme Corp');
         expect(next.handles.linkedin_urn).toBe('urn:li:organization:123');
+    });
+});
+
+describe('discord mentions', () => {
+    it('composes native markup per kind', () => {
+        expect(discordMentionMarkup('user', '123')).toBe('<@123>');
+        expect(discordMentionMarkup('role', '456')).toBe('<@&456>');
+        expect(discordMentionMarkup('channel', '789')).toBe('<#789>');
+        expect(discordMentionMarkup('user', '  123  ')).toBe('<@123>');
+    });
+
+    it('returns empty markup for a blank id so the label is used', () => {
+        expect(discordMentionMarkup('user', '')).toBe('');
+        expect(discordMentionMarkup('role', '   ')).toBe('');
+    });
+
+    it('parses stored markup back into a kind and id', () => {
+        expect(parseDiscordMention('<@123>')).toEqual({
+            kind: 'user',
+            id: '123',
+        });
+        expect(parseDiscordMention('<@&456>')).toEqual({
+            kind: 'role',
+            id: '456',
+        });
+        expect(parseDiscordMention('<#789>')).toEqual({
+            kind: 'channel',
+            id: '789',
+        });
+        // Legacy nickname form collapses to a plain user mention.
+        expect(parseDiscordMention('<@!123>')).toEqual({
+            kind: 'user',
+            id: '123',
+        });
+    });
+
+    it('treats plain display text as not an id mention', () => {
+        expect(parseDiscordMention('Guest')).toBeNull();
+        expect(parseDiscordMention('')).toBeNull();
+        expect(parseDiscordMention(undefined)).toBeNull();
+        expect(parseDiscordMention('<@abc>')).toBeNull();
+    });
+
+    it('round-trips composed markup through parse', () => {
+        const markup = discordMentionMarkup('role', '42');
+        expect(parseDiscordMention(markup)).toEqual({ kind: 'role', id: '42' });
+    });
+
+    it('emits the stored Discord markup verbatim at publish time', () => {
+        const mention: MentionPlaceholder = {
+            id: 'guest',
+            label: '@guest',
+            handles: { discord: '<@&123>' },
+        };
+
+        expect(
+            replaceMentionTokens(
+                'Ping {{mention:guest}}',
+                [mention],
+                'discord',
+            ),
+        ).toBe('Ping <@&123>');
+    });
+
+    it('falls back to the label when no Discord handle is set', () => {
+        const mention: MentionPlaceholder = {
+            id: 'guest',
+            label: '@guest',
+            handles: { x: '@guest_x' },
+        };
+
+        expect(
+            replaceMentionTokens(
+                'Ping {{mention:guest}}',
+                [mention],
+                'discord',
+            ),
+        ).toBe('Ping @guest');
+    });
+
+    it('builds a snowflake-id → label map for rendering resolved markup', () => {
+        const mentions: MentionPlaceholder[] = [
+            { id: 'a', label: '@adiology', handles: { discord: '<@1>' } },
+            { id: 'm', label: '@mods', handles: { discord: '<@&2>' } },
+            // Non-Discord and plain-text handles contribute nothing to the map.
+            { id: 'x', label: '@xonly', handles: { x: '@xonly' } },
+        ];
+
+        expect(discordMentionLabels(mentions)).toEqual({
+            '1': '@adiology',
+            '2': '@mods',
+        });
     });
 });
 

--- a/resources/js/lib/compose/mentions.ts
+++ b/resources/js/lib/compose/mentions.ts
@@ -173,6 +173,81 @@ export function normalizeLinkedInUrn(reference: string): string | null {
     return null;
 }
 
+/** The kinds of Discord entity a mention can reference. */
+export type DiscordMentionKind = 'user' | 'role' | 'channel';
+
+/**
+ * Compose Discord's native mention markup for a snowflake id: `<@id>` for a
+ * user, `<@&id>` for a role, `<#id>` for a channel. Stored verbatim in
+ * `handles.discord` and posted to the webhook as-is, so Discord renders (and,
+ * per the server's mention settings, pings) the referenced entity. Returns ''
+ * for a blank id so the mention falls back to the label.
+ */
+export function discordMentionMarkup(
+    kind: DiscordMentionKind,
+    id: string,
+): string {
+    const trimmed = id.trim();
+    if (trimmed === '') {
+        return '';
+    }
+
+    switch (kind) {
+        case 'role':
+            return `<@&${trimmed}>`;
+        case 'channel':
+            return `<#${trimmed}>`;
+        default:
+            return `<@${trimmed}>`;
+    }
+}
+
+const DISCORD_MENTION_TOKEN = /^<(@&|@!?|#)(\d+)>$/;
+
+/**
+ * Parse a stored `handles.discord` value back into its kind + snowflake id, or
+ * null when it is plain display text (i.e. never configured as an id mention).
+ * The legacy `<@!id>` nickname form is normalized to a plain user mention.
+ */
+export function parseDiscordMention(
+    value: string | undefined,
+): { kind: DiscordMentionKind; id: string } | null {
+    const match = (value ?? '').trim().match(DISCORD_MENTION_TOKEN);
+    if (!match) {
+        return null;
+    }
+
+    const [, prefix, id] = match;
+    if (prefix === '@&') {
+        return { kind: 'role', id };
+    }
+    if (prefix === '#') {
+        return { kind: 'channel', id };
+    }
+
+    return { kind: 'user', id };
+}
+
+/**
+ * Reverse-map a mention set to `snowflake id → display label`, so resolved
+ * Discord markup (`<@id>` etc.) in published/preview text can be rendered as the
+ * friendly mention name instead of the raw id.
+ */
+export function discordMentionLabels(
+    mentions: readonly Pick<MentionPlaceholder, 'label' | 'handles'>[],
+): Record<string, string> {
+    const labels: Record<string, string> = {};
+
+    for (const mention of mentions) {
+        const parsed = parseDiscordMention(mention.handles.discord);
+        if (parsed) {
+            labels[parsed.id] = mention.label;
+        }
+    }
+
+    return labels;
+}
+
 const LINKEDIN_URN_TOKEN = /urn:li:organization:\d+/;
 const LINKEDIN_COMPANY_TOKEN = /\S*linkedin\.com\/company\/([^\s/?#]+)\S*/i;
 

--- a/resources/js/lib/compose/platform-preview.ts
+++ b/resources/js/lib/compose/platform-preview.ts
@@ -1,4 +1,5 @@
 import {
+    discordMentionLabels,
     mentionInputValue,
     replaceMentionTokens,
 } from '@/lib/compose/mentions';
@@ -36,6 +37,8 @@ export type PlatformPreview = {
      */
     format: PostFormat;
     items: PlatformPreviewItem[];
+    /** Discord snowflake id → display label, for rendering `<@id>` as a pill. */
+    discordLabels: Record<string, string>;
 };
 
 type BuildPlatformPreviewInput = {
@@ -200,6 +203,7 @@ export function buildPlatformPreview({
         limit,
         autoSplit,
         format,
+        discordLabels: discordMentionLabels(mentions),
         items: built.map((section, index) => ({
             id: `${account.platform}-preview-${index + 1}`,
             // Show the spacing the platform will actually render; the character

--- a/resources/js/lib/linked-text.test.ts
+++ b/resources/js/lib/linked-text.test.ts
@@ -159,6 +159,29 @@ describe('linkedTextParts', () => {
         ]);
     });
 
+    it('renders a LinkedIn company annotation as a named link, not raw markup', () => {
+        expect(
+            linkedTextParts(
+                'Thanks @[Coolify](urn:li:organization:12345) team',
+                'linkedin',
+            ),
+        ).toEqual([
+            { type: 'text', text: 'Thanks ' },
+            {
+                type: 'link',
+                text: 'Coolify',
+                href: 'https://www.linkedin.com/company/12345',
+            },
+            { type: 'text', text: ' team' },
+        ]);
+    });
+
+    it('leaves a plain LinkedIn display name untouched (no annotation)', () => {
+        expect(linkedTextParts('Thanks Coolify team', 'linkedin')).toEqual([
+            { type: 'text', text: 'Thanks Coolify team' },
+        ]);
+    });
+
     it('renders preview links with visible link styling', () => {
         const markup = renderToStaticMarkup(
             createElement(LinkedText, { text: 'Read shoutrrr.com' }),
@@ -167,5 +190,49 @@ describe('linkedTextParts', () => {
         expect(markup).toContain('href="https://shoutrrr.com"');
         expect(markup).toContain('underline');
         expect(markup).toContain('text-primary');
+    });
+
+    it('resolves Discord user/role/channel markup to labeled mention pills', () => {
+        const labels = { '1': '@adiology', '2': '@mods', '3': '@general' };
+
+        expect(
+            linkedTextParts('hi <@1> and <@&2> in <#3>', 'discord', [], labels),
+        ).toEqual([
+            { type: 'text', text: 'hi ' },
+            { type: 'mention', text: '@adiology' },
+            { type: 'text', text: ' and ' },
+            { type: 'mention', text: '@mods' },
+            { type: 'text', text: ' in ' },
+            { type: 'mention', text: '#general' },
+        ]);
+    });
+
+    it('treats the legacy <@!id> nickname form as a user mention', () => {
+        expect(
+            linkedTextParts('yo <@!1>', 'discord', [], { '1': '@adiology' }),
+        ).toEqual([
+            { type: 'text', text: 'yo ' },
+            { type: 'mention', text: '@adiology' },
+        ]);
+    });
+
+    it('leaves an unknown Discord id as raw text rather than a fake handle', () => {
+        expect(linkedTextParts('ping <@999>', 'discord', [], {})).toEqual([
+            { type: 'text', text: 'ping <@999>' },
+        ]);
+    });
+
+    it('renders a Discord mention as a non-link styled pill', () => {
+        const markup = renderToStaticMarkup(
+            createElement(LinkedText, {
+                text: 'hi <@1>',
+                platform: 'discord',
+                discordLabels: { '1': '@adiology' },
+            }),
+        );
+
+        expect(markup).toContain('@adiology');
+        expect(markup).not.toContain('<@1>');
+        expect(markup).not.toContain('<a ');
     });
 });

--- a/resources/js/lib/linked-text.tsx
+++ b/resources/js/lib/linked-text.tsx
@@ -4,13 +4,15 @@ import type { PlatformName } from '@/types/compose';
 
 export type LinkedTextPart =
     | { type: 'text'; text: string }
-    | { type: 'link'; text: string; href: string };
+    | { type: 'link'; text: string; href: string }
+    | { type: 'mention'; text: string };
 
 type LinkCandidate = {
     start: number;
     end: number;
     text: string;
-    href: string;
+    /** A linkable target. Omitted for non-link spans (e.g. Discord mentions). */
+    href?: string;
 };
 
 const URL_PATTERN =
@@ -31,6 +33,17 @@ const INSTAGRAM_MENTION_PATTERN = /(?<![A-Za-z0-9._@])@([A-Za-z0-9._]{1,30})/g;
 // letters/numbers/underscores. The lookbehind skips `#` inside a word (e.g.
 // `C#`) or an HTML entity (`&#39;`), matching how the apps detect tags.
 const HASHTAG_PATTERN = /(?<![A-Za-z0-9_&])#([A-Za-z0-9_]+)/g;
+
+// Discord's native mention markup: `<@id>`/`<@!id>` (user), `<@&id>` (role),
+// `<#id>` (channel). The published/preview text stores the raw markup because
+// that is what Discord receives; we render it as a friendly pill.
+const DISCORD_MENTION_PATTERN = /<(@&|@!?|#)(\d+)>/g;
+
+// LinkedIn's inline company annotation `@[Name](urn:li:organization:ID)` — the
+// form baked into a published section. Render the name as a link to the company
+// page (numeric org ids resolve at linkedin.com/company/<id>).
+const LINKEDIN_ANNOTATION_PATTERN =
+    /@\[([^\]]+)\]\(urn:li:organization:(\d+)\)/g;
 
 function urlCandidates(
     text: string,
@@ -57,7 +70,45 @@ function urlCandidates(
 function mentionCandidates(
     text: string,
     platform?: PlatformName,
+    discordLabels: Record<string, string> = {},
 ): LinkCandidate[] {
+    // Discord mentions resolve `<@id>`/`<@&id>`/`<#id>` back to the friendly
+    // name via the post's mention map. An id with no known label is left as raw
+    // text rather than shown as a fake handle.
+    if (platform === 'discord') {
+        return [...text.matchAll(DISCORD_MENTION_PATTERN)].flatMap((match) => {
+            const prefix = match[1] ?? '';
+            const label = discordLabels[match[2] ?? ''];
+            if (label === undefined) {
+                return [];
+            }
+            const start = match.index ?? 0;
+
+            return [
+                {
+                    start,
+                    end: start + (match[0]?.length ?? 0),
+                    text:
+                        (prefix === '#' ? '#' : '@') +
+                        label.replace(/^[@#]/, ''),
+                },
+            ];
+        });
+    }
+
+    if (platform === 'linkedin') {
+        return [...text.matchAll(LINKEDIN_ANNOTATION_PATTERN)].map((match) => {
+            const start = match.index ?? 0;
+
+            return {
+                start,
+                end: start + (match[0]?.length ?? 0),
+                text: match[1] ?? '',
+                href: `https://www.linkedin.com/company/${match[2]}`,
+            };
+        });
+    }
+
     if (platform === 'x') {
         return [...text.matchAll(X_MENTION_PATTERN)].map((match) => {
             const handle = match[0] ?? '';
@@ -149,11 +200,12 @@ export function linkedTextParts(
     text: string,
     platform?: PlatformName,
     linkExclusions: readonly string[] = [],
+    discordLabels: Record<string, string> = {},
 ): LinkedTextPart[] {
     const parts: LinkedTextPart[] = [];
     const candidates = [
         ...urlCandidates(text, linkExclusions),
-        ...mentionCandidates(text, platform),
+        ...mentionCandidates(text, platform, discordLabels),
         ...hashtagCandidates(text, platform),
     ]
         .filter((candidate) => candidate.text !== '')
@@ -172,11 +224,11 @@ export function linkedTextParts(
             });
         }
 
-        parts.push({
-            type: 'link',
-            text: candidate.text,
-            href: candidate.href,
-        });
+        parts.push(
+            candidate.href !== undefined
+                ? { type: 'link', text: candidate.text, href: candidate.href }
+                : { type: 'mention', text: candidate.text },
+        );
 
         cursor = candidate.end;
     }
@@ -192,12 +244,19 @@ export function LinkedText({
     text,
     platform,
     linkExclusions = [],
+    discordLabels = {},
     emptyFallback = null,
     linkClassName = 'font-medium text-primary underline underline-offset-2 hover:text-primary/80',
+    mentionClassName = 'rounded bg-[#5865F2]/15 px-1 font-medium text-[#5865F2]',
 }: {
     text: string;
     platform?: PlatformName;
     linkExclusions?: readonly string[];
+    /**
+     * Maps a Discord snowflake id to the mention's display label so `<@id>`
+     * markup renders as a friendly pill instead of the raw id.
+     */
+    discordLabels?: Record<string, string>;
     emptyFallback?: ReactNode;
     /**
      * Overrides the styling of every linked span. Defaults to the app's
@@ -205,15 +264,25 @@ export function LinkedText({
      * un-underlined blue so captions read like the real feeds.
      */
     linkClassName?: string;
+    /** Styling for non-link mention pills (Discord). Defaults to a blurple pill. */
+    mentionClassName?: string;
 }) {
     if (text === '') {
         return emptyFallback;
     }
 
-    return linkedTextParts(text, platform, linkExclusions).map(
+    return linkedTextParts(text, platform, linkExclusions, discordLabels).map(
         (part, index) => {
             if (part.type === 'text') {
                 return part.text;
+            }
+
+            if (part.type === 'mention') {
+                return (
+                    <span key={`mention-${index}`} className={mentionClassName}>
+                        {part.text}
+                    </span>
+                );
             }
 
             return (

--- a/tests/Feature/Posts/ComposeApiTest.php
+++ b/tests/Feature/Posts/ComposeApiTest.php
@@ -139,6 +139,39 @@ test('POST /posts rejects an over-long linkedin_urn handle', function () {
     ])->assertInvalid(['mentions.0.handles.linkedin_urn']);
 });
 
+test('PUT /posts/{post} keeps a Discord mention handle through request validation', function () {
+    // Regression: `validated()` strips any mentions.*.handles.* key without an
+    // explicit rule (excludeUnvalidatedArrayKeys), which dropped the Discord
+    // markup so it posted as the plain label instead of a native mention.
+    [$user, $workspace] = actingMember(0);
+    $discord = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'platform' => Platform::Discord->value,
+    ]);
+
+    $created = test()->postJson('/posts', [
+        'destination' => ['kind' => 'all'],
+        'segments' => ['Ping @adiology'],
+        'mentions' => [],
+    ])->json('post');
+
+    $response = test()->putJson("/posts/{$created['id']}", [
+        'segments' => ['Ping @adiology'],
+        'destination' => ['kind' => 'accounts', 'ids' => [$discord->id]],
+        'targets' => [['connected_account_id' => $discord->id, 'auto_split' => true]],
+        'mentions' => [[
+            'id' => 'adiology',
+            'label' => '@adiology',
+            'handles' => ['discord' => '<@136549806079344640>'],
+        ]],
+        'expected_updated_at' => $created['updated_at'],
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('post.mentions.0.handles.discord', '<@136549806079344640>')
+        ->assertJsonPath('post.targets.0.sections', ['Ping <@136549806079344640>']);
+});
+
 test('PUT /posts/{post} accepts the real buildPutBody payload with no base_text', function () {
     [$user, $workspace, $accounts] = actingMember(1);
     $created = test()->postJson('/posts', [

--- a/tests/Feature/Posts/DraftServiceUpdateTest.php
+++ b/tests/Feature/Posts/DraftServiceUpdateTest.php
@@ -359,6 +359,52 @@ test('updateDraft routes an org reference typed into the LinkedIn name field to 
         ->toBe(['Hi @[Coolify](urn:li:organization:12345)']);
 });
 
+test('updateDraft emits Discord id mention markup verbatim per kind', function () {
+    [$user, $workspace] = draftSetup(0);
+    $discord = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'platform' => Platform::Discord->value,
+    ]);
+
+    $post = app(DraftService::class)->createDraft($workspace->id, $user, ['kind' => 'all'], ['Ping @team and @lead in @general']);
+
+    $updated = app(DraftService::class)->updateDraft($post, DraftData::fromArray([
+        'base_text' => 'Ping @team and @lead in @general',
+        'mentions' => [
+            ['id' => 'team', 'label' => '@team', 'handles' => ['discord' => '<@&123>']],
+            ['id' => 'lead', 'label' => '@lead', 'handles' => ['discord' => '<@456>']],
+            ['id' => 'general', 'label' => '@general', 'handles' => ['discord' => '<#789>']],
+        ],
+        'destination' => ['kind' => 'accounts', 'ids' => [$discord->id]],
+        'targets' => [['connected_account_id' => $discord->id, 'auto_split' => true]],
+        'expected_updated_at' => $post->updated_at->toIso8601String(),
+    ]));
+
+    expect($updated->targets->firstWhere('connected_account_id', $discord->id)->sections)
+        ->toBe(['Ping <@&123> and <@456> in <#789>']);
+});
+
+test('updateDraft falls back to the label when a Discord mention has no handle', function () {
+    [$user, $workspace] = draftSetup(0);
+    $discord = ConnectedAccount::factory()->create([
+        'workspace_id' => $workspace->id,
+        'platform' => Platform::Discord->value,
+    ]);
+
+    $post = app(DraftService::class)->createDraft($workspace->id, $user, ['kind' => 'all'], ['Ping @guest']);
+
+    $updated = app(DraftService::class)->updateDraft($post, DraftData::fromArray([
+        'base_text' => 'Ping @guest',
+        'mentions' => [['id' => 'guest', 'label' => '@guest', 'handles' => ['x' => '@guest_x']]],
+        'destination' => ['kind' => 'accounts', 'ids' => [$discord->id]],
+        'targets' => [['connected_account_id' => $discord->id, 'auto_split' => true]],
+        'expected_updated_at' => $post->updated_at->toIso8601String(),
+    ]));
+
+    expect($updated->targets->firstWhere('connected_account_id', $discord->id)->sections)
+        ->toBe(['Ping @guest']);
+});
+
 test('updateDraft sets the auto_repost override when the payload carries it', function () {
     [$user, $workspace, $accounts] = draftSetup(1);
     $post = app(DraftService::class)->createDraft($workspace->id, $user, ['kind' => 'all'], ['hi'], [], true);


### PR DESCRIPTION
## Summary
- Added a dedicated Discord mention field to the mention picker with a plain-text ⇄ mention toggle and a User/Role/Channel picker, composing input into Discord's native markup (`<@id>`, `<@&id>`, `<#id>`)
- Fixed a validation bug where `mentions.*.handles.*` keys without an explicit rule (e.g. Discord) were silently stripped from `validated()` by Laravel's `excludeUnvalidatedArrayKeys`, causing mention markup to be dropped before reaching `DraftService`; handle rules are now derived from the `Platform` enum via a shared `DerivesMentionHandleRules` trait on both `StorePostRequest` and `UpdatePostRequest`
- Added Discord mention resolution to previews and published posts: `<@id>`/`<@&id>`/`<#id>` markup now renders as a friendly labeled pill instead of raw ids
- Added LinkedIn company annotation rendering (`@[Name](urn:li:organization:ID)`) as a linked name in preview/published text
- Added test coverage across the mention picker UI, the `mentions.ts` library helpers, `linked-text` rendering, and Laravel feature tests for request validation and draft updates

## Breaking Changes
None.
