### PR TITLE
feat(compose): add required KLIPY attribution to GIF picker

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3139,16 +3139,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.3",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7"
+                "reference": "5703d83ba3da3b2e356a5fedc848ed6d8ffb6529"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/1902f60f984235023acbe03db6ad614a37b3c3e7",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/5703d83ba3da3b2e356a5fedc848ed6d8ffb6529",
+                "reference": "5703d83ba3da3b2e356a5fedc848ed6d8ffb6529",
                 "shasum": ""
             },
             "require": {
@@ -3185,7 +3185,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.10-dev"
                 }
             },
             "autoload": {
@@ -3242,7 +3242,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-12T15:29:16+00:00"
+            "time": "2026-08-03T13:42:31+00:00"
         },
         {
             "name": "league/config",

--- a/resources/js/components/compose/__tests__/gif-picker.test.tsx
+++ b/resources/js/components/compose/__tests__/gif-picker.test.tsx
@@ -275,6 +275,33 @@ describe('GifPicker', () => {
         ).toBeInTheDocument();
     });
 
+    it('carries the required Klipy attribution', () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(
+                async () =>
+                    new Response(
+                        JSON.stringify({ items: [], has_next: false }),
+                    ),
+            ),
+        );
+
+        render(<GifPicker onSelect={vi.fn()} />);
+
+        // Search-bar attribution: the placeholder must name KLIPY verbatim and
+        // stay fixed across catalogs.
+        expect(screen.getByRole('searchbox')).toHaveAttribute(
+            'placeholder',
+            'Search KLIPY',
+        );
+
+        // Content-area attribution: a "Powered by KLIPY" link back to source.
+        const attribution = screen.getByRole('link', {
+            name: 'Powered by KLIPY',
+        });
+        expect(attribution).toHaveAttribute('href', 'https://klipy.com');
+    });
+
     it('continues to the next page automatically when a settled page does not fill the viewport', async () => {
         vi.stubGlobal(
             'fetch',

--- a/resources/js/components/compose/gif-picker.tsx
+++ b/resources/js/components/compose/gif-picker.tsx
@@ -163,7 +163,10 @@ export function GifPicker({ onSelect }: Props) {
                     value={search.query}
                     onChange={(event) => search.setQuery(event.target.value)}
                     aria-label={`Search ${noun}`}
-                    placeholder={`Search ${noun}…`}
+                    // "Search KLIPY" is a required Klipy attribution — the
+                    // placeholder must name the content source verbatim, so it
+                    // stays fixed across catalogs rather than following `noun`.
+                    placeholder="Search KLIPY"
                     className="h-8 w-full appearance-none rounded-md bg-muted px-2.5 text-sm outline-none placeholder:text-muted-foreground"
                 />
             </div>
@@ -272,6 +275,17 @@ export function GifPicker({ onSelect }: Props) {
 
                 <div ref={sentinel} className="h-px" />
             </div>
+
+            {/* Required Klipy content-area attribution. Always visible below
+                the results, linking back to the source. */}
+            <a
+                href="https://klipy.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex shrink-0 items-center justify-end px-2.5 py-1.5 text-[10px] font-medium tracking-wide text-muted-foreground/70 transition-colors hover:text-muted-foreground"
+            >
+                Powered by KLIPY
+            </a>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- Fixed the GIF picker search placeholder to always read "Search KLIPY" instead of varying by catalog, satisfying KLIPY's required attribution text
- Added a "Powered by KLIPY" link (to klipy.com) below the results in the GIF picker content area
- Added test coverage verifying both attribution elements render correctly
