### PR TITLE
fix(publishing): lock bluesky refresh, fix oauth assertion check

### DIFF
--- a/app/Services/Publishing/TokenManager.php
+++ b/app/Services/Publishing/TokenManager.php
@@ -14,6 +14,7 @@ use App\Services\Atproto\DPoP;
 use App\Services\ConnectedAccounts\Threads\ThreadsTokenExchanger;
 use App\Services\Usage\Concerns\TracksUsage;
 use App\Support\UsageOperation;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Cache;
@@ -46,7 +47,7 @@ class TokenManager
         $secret = $account->secret()->firstOrFail();
 
         if ($account->platform === Platform::Bluesky && $account->auth_method === 'app_password') {
-            return $this->blueskyCredentials($account, $secret);
+            return $this->blueskyCredentials($account);
         }
 
         if ($account->platform === Platform::Bluesky && $account->auth_method === 'oauth') {
@@ -210,15 +211,27 @@ class TokenManager
      *
      * @return array<string, mixed>
      */
-    private function blueskyCredentials(ConnectedAccount $account, ConnectedAccountSecret $secret): array
+    private function blueskyCredentials(ConnectedAccount $account): array
     {
-        return Cache::lock("connected-account-token-refresh:{$account->id}", 60)
-            ->block(10, function () use ($account): array {
-                $freshAccount = $account->newQueryWithoutScopes()->findOrFail($account->id);
-                $freshSecret = $freshAccount->secret()->firstOrFail();
+        try {
+            return Cache::lock("connected-account-token-refresh:{$account->id}", 60)
+                ->block(10, function () use ($account): array {
+                    $freshAccount = $account->newQueryWithoutScopes()->findOrFail($account->id);
+                    $freshSecret = $freshAccount->secret()->firstOrFail();
 
-                return $this->refreshBlueskyCredentials($freshAccount, $freshSecret);
-            });
+                    return $this->refreshBlueskyCredentials($freshAccount, $freshSecret);
+                });
+        } catch (LockTimeoutException) {
+            // Another worker already holds the lock and is refreshing this session. Rather
+            // than throw — which would fail the tries=1 publish job and risk flipping the
+            // account to needs-attention — degrade to the concurrently-persisted session,
+            // restoring the never-throw contract this path had before it was serialized.
+            // The holder saves the rotated tokens before releasing, so the re-read is at
+            // worst marginally stale and the publish proceeds with a valid session.
+            $freshSecret = $account->secret()->firstOrFail();
+
+            return ['session' => $freshSecret->session ?? [], 'app_password' => $freshSecret->app_password];
+        }
     }
 
     /**
@@ -267,7 +280,10 @@ class TokenManager
         }
 
         // refreshSession authenticates with the refreshJwt as the bearer token.
-        $response = $this->http->withToken($refreshJwt)->acceptJson()
+        // Bound the request so a hung PDS cannot outlast the refresh lock's lease
+        // (which would let a second worker refresh concurrently and race the
+        // single-use refreshJwt); mirrors the timeouts used across the connectors.
+        $response = $this->http->timeout(10)->connectTimeout(5)->withToken($refreshJwt)->acceptJson()
             ->post($pds.'/xrpc/com.atproto.server.refreshSession');
 
         $this->meter(UsageCategory::ExternalApi, UsageOperation::TOKEN_REFRESH, $account, $response);
@@ -287,7 +303,7 @@ class TokenManager
             return null;
         }
 
-        $response = $this->http->acceptJson()
+        $response = $this->http->timeout(10)->connectTimeout(5)->acceptJson()
             ->post($pds.'/xrpc/com.atproto.server.createSession', [
                 'identifier' => $identifier,
                 'password' => $appPassword,
@@ -337,7 +353,9 @@ class TokenManager
             : (string) config($configKey.'.client_id');
         $clientSecret = (string) config($configKey.'.client_secret');
 
-        $request = $this->http->asForm();
+        // Bound the token request so a hung endpoint cannot outlast the refresh
+        // lock's lease and let a second worker race the single-use refresh token.
+        $request = $this->http->asForm()->timeout(10)->connectTimeout(5);
 
         $body = [
             'grant_type' => 'refresh_token',
@@ -384,7 +402,7 @@ class TokenManager
                 if ($usesAssertion) {
                     $body['client_assertion'] = $this->dpop->clientAssertion($issuer, $this->dpop->signingKey(), $clientId);
                 }
-                $response = $this->http->asForm()
+                $response = $this->http->asForm()->timeout(10)->connectTimeout(5)
                     ->withHeader('DPoP', $this->dpop->proof('POST', $endpoint, $key, nonce: $nonce))
                     ->post((string) $endpoint, $body);
             }

--- a/app/Services/Publishing/TokenManager.php
+++ b/app/Services/Publishing/TokenManager.php
@@ -194,9 +194,37 @@ class TokenManager
      * also lapsed. Only when both fail do we surface the account as needing
      * attention and return the stale session (the publish then fails cleanly).
      *
+     * `refreshSession` rotates the single-use refreshJwt on every call, so
+     * concurrent callers — the publish, engagement, DM-poll, and repost jobs that
+     * all call fresh() — would otherwise race: the winner rotates the token, the
+     * loser POSTs the now-revoked one, 400s, falls back to createSession, and the
+     * churn hammers Bluesky's login rate limit until the account flips to
+     * needs-attention. ATProto's guidance is to serialize refreshes per session
+     * (see the XRPC spec and bluesky-social/atproto#3637); do so per account and
+     * re-read the rotated session under the lock. We refresh unconditionally rather
+     * than skipping while "still valid": the tokens are opaque per spec (their JWT
+     * fields "are not a stable part of the specification"), there is no
+     * server-provided expiry to gate on as the OAuth path has, and the spec expects
+     * a new access JWT to be fetched freely — refreshSession is cheap and, unlike
+     * createSession, not the rate-limited endpoint.
+     *
      * @return array<string, mixed>
      */
     private function blueskyCredentials(ConnectedAccount $account, ConnectedAccountSecret $secret): array
+    {
+        return Cache::lock("connected-account-token-refresh:{$account->id}", 60)
+            ->block(10, function () use ($account): array {
+                $freshAccount = $account->newQueryWithoutScopes()->findOrFail($account->id);
+                $freshSecret = $freshAccount->secret()->firstOrFail();
+
+                return $this->refreshBlueskyCredentials($freshAccount, $freshSecret);
+            });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function refreshBlueskyCredentials(ConnectedAccount $account, ConnectedAccountSecret $secret): array
     {
         $session = $secret->session ?? [];
         $pds = (string) ($session['pds'] ?? self::BLUESKY_DEFAULT_PDS);
@@ -328,10 +356,17 @@ class TokenManager
             if ($key === null || $endpoint === '') {
                 throw new TokenRefreshException("Token refresh failed for account {$account->id}.");
             }
-            // Confidential clients authenticate with a private_key_jwt assertion; the
-            // loopback dev client (the synthesized `http://localhost/?…` id) is public
-            // and must not send one.
-            $usesAssertion = $clientId === route('oauth.bluesky.metadata');
+            // Confidential clients authenticate every token request — including refresh
+            // (atproto OAuth spec: refresh must reuse the connect-time auth method) —
+            // with a private_key_jwt assertion; the loopback dev client (the synthesized
+            // `http://localhost/?…` id) is public and must not send one. Derive this from
+            // the stored client_id, NOT by re-deriving route('oauth.bluesky.metadata')
+            // here: refreshOAuth runs in queue workers, where route() takes its scheme/
+            // host from APP_URL and drifts from the web-request context that connected the
+            // account (e.g. behind a reverse proxy). A mismatch dropped the assertion, so
+            // the auth server rejected the refresh with invalid_client and the account was
+            // flipped to needs-attention.
+            $usesAssertion = ! str_starts_with($clientId, 'http://localhost');
             if ($usesAssertion) {
                 $body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
                 $body['client_assertion'] = $this->dpop->clientAssertion($issuer, $this->dpop->signingKey(), $clientId);

--- a/tests/Feature/Publishing/TokenManagerTest.php
+++ b/tests/Feature/Publishing/TokenManagerTest.php
@@ -280,9 +280,10 @@ test('bluesky app-password refresh serializes under the per-account lock', funct
 });
 
 test('fresh re-reads the rotated bluesky session under the lock before refreshing', function () {
-    // The refresh runs against the session read inside the lock, not a stale copy
-    // captured before the lock was acquired — so a token another worker already
-    // rotated is used as the basis for the next refresh.
+    // The refresh must run against the session read INSIDE the lock, not a stale copy
+    // captured before it was acquired. To prove the reload happens after acquisition,
+    // a concurrent worker rotates the refreshJwt from within the mocked block()
+    // callback — only a lock-scoped reload picks it up.
     $account = ConnectedAccount::factory()->bluesky()->create(['token_expires_at' => null]);
     ConnectedAccountSecret::factory()->create([
         'connected_account_id' => $account->id,
@@ -292,11 +293,6 @@ test('fresh re-reads the rotated bluesky session under the lock before refreshin
 
     $staleAccount = $account->fresh();
 
-    // Another worker rotated the refreshJwt after this caller loaded the account.
-    $account->secret->forceFill([
-        'session' => ['accessJwt' => 'worker-jwt', 'refreshJwt' => 'worker-rjwt', 'pds' => 'https://bsky.social'],
-    ])->save();
-
     Http::fake([
         'https://bsky.social/xrpc/com.atproto.server.refreshSession' => Http::response([
             'accessJwt' => 'fresh-jwt',
@@ -304,9 +300,25 @@ test('fresh re-reads the rotated bluesky session under the lock before refreshin
         ]),
     ]);
 
+    $lock = Mockery::mock(Lock::class);
+    $lock->shouldReceive('block')->once()
+        ->with(10, Mockery::type('Closure'))
+        ->andReturnUsing(function (int $seconds, Closure $callback) use ($account) {
+            // Another worker rotates the refreshJwt after the lock is acquired,
+            // before the callback reloads the credentials.
+            $account->secret->forceFill([
+                'session' => ['accessJwt' => 'worker-jwt', 'refreshJwt' => 'worker-rjwt', 'pds' => 'https://bsky.social'],
+            ])->save();
+
+            return $callback();
+        });
+    Cache::partialMock()->shouldReceive('lock')->once()
+        ->with("connected-account-token-refresh:{$account->id}", 60)
+        ->andReturn($lock);
+
     app(TokenManager::class)->fresh($staleAccount);
 
-    // refreshSession authenticated with the rotated token, not the stale one.
+    // refreshSession authenticated with the token rotated inside the lock, not the stale one.
     Http::assertSent(fn ($request) => $request->url() === 'https://bsky.social/xrpc/com.atproto.server.refreshSession'
         && $request->hasHeader('Authorization', 'Bearer worker-rjwt'));
 });

--- a/tests/Feature/Publishing/TokenManagerTest.php
+++ b/tests/Feature/Publishing/TokenManagerTest.php
@@ -6,6 +6,8 @@ use App\Exceptions\TokenRefreshException;
 use App\Models\ConnectedAccount;
 use App\Models\ConnectedAccountSecret;
 use App\Services\Publishing\TokenManager;
+use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
 test('fresh returns existing credentials when token is not near expiry', function () {
@@ -240,6 +242,73 @@ test('fresh refreshes the bluesky session before publishing and persists the new
     expect($account->secret->session['accessJwt'])->toBe('fresh-jwt')
         ->and($account->secret->session['refreshJwt'])->toBe('fresh-rjwt')
         ->and($account->last_refreshed_at)->not->toBeNull();
+});
+
+test('bluesky app-password refresh serializes under the per-account lock', function () {
+    // Regression: the app-password path used to refresh with no lock. Concurrent
+    // pollers (DM inbox, auto-repost) then consumed the same single-use refreshJwt,
+    // 400'd the loser, fell back to createSession, and hammered Bluesky's login
+    // rate limit until healthy accounts flipped to needs-attention. ATProto's
+    // guidance (XRPC spec, bluesky-social/atproto#3637) is to serialize refreshes
+    // per session, so the refresh must run inside the per-account lock.
+    $account = ConnectedAccount::factory()->bluesky()->create(['token_expires_at' => null]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'app_password' => 'app-pass',
+        'session' => ['accessJwt' => 'stale-jwt', 'refreshJwt' => 'rjwt', 'pds' => 'https://bsky.social'],
+    ]);
+
+    Http::fake([
+        'https://bsky.social/xrpc/com.atproto.server.refreshSession' => Http::response([
+            'accessJwt' => 'fresh-jwt',
+            'refreshJwt' => 'fresh-rjwt',
+        ]),
+    ]);
+
+    $lock = Mockery::mock(Lock::class);
+    $lock->shouldReceive('block')->once()
+        ->with(10, Mockery::type('Closure'))
+        ->andReturnUsing(fn (int $seconds, Closure $callback) => $callback());
+    Cache::partialMock()->shouldReceive('lock')->once()
+        ->with("connected-account-token-refresh:{$account->id}", 60)
+        ->andReturn($lock);
+
+    $creds = app(TokenManager::class)->fresh($account->fresh());
+
+    expect($creds['session']['accessJwt'])->toBe('fresh-jwt')
+        ->and($account->fresh()->status)->toBe(ConnectedAccountStatus::Active);
+});
+
+test('fresh re-reads the rotated bluesky session under the lock before refreshing', function () {
+    // The refresh runs against the session read inside the lock, not a stale copy
+    // captured before the lock was acquired — so a token another worker already
+    // rotated is used as the basis for the next refresh.
+    $account = ConnectedAccount::factory()->bluesky()->create(['token_expires_at' => null]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'app_password' => 'app-pass',
+        'session' => ['accessJwt' => 'stale-jwt', 'refreshJwt' => 'stale-rjwt', 'pds' => 'https://bsky.social'],
+    ]);
+
+    $staleAccount = $account->fresh();
+
+    // Another worker rotated the refreshJwt after this caller loaded the account.
+    $account->secret->forceFill([
+        'session' => ['accessJwt' => 'worker-jwt', 'refreshJwt' => 'worker-rjwt', 'pds' => 'https://bsky.social'],
+    ])->save();
+
+    Http::fake([
+        'https://bsky.social/xrpc/com.atproto.server.refreshSession' => Http::response([
+            'accessJwt' => 'fresh-jwt',
+            'refreshJwt' => 'fresh-rjwt',
+        ]),
+    ]);
+
+    app(TokenManager::class)->fresh($staleAccount);
+
+    // refreshSession authenticated with the rotated token, not the stale one.
+    Http::assertSent(fn ($request) => $request->url() === 'https://bsky.social/xrpc/com.atproto.server.refreshSession'
+        && $request->hasHeader('Authorization', 'Bearer worker-rjwt'));
 });
 
 test('fresh falls back to an app-password login when the refresh token has lapsed', function () {

--- a/tests/Unit/Publishing/TokenManagerTest.php
+++ b/tests/Unit/Publishing/TokenManagerTest.php
@@ -50,6 +50,57 @@ it('refreshes bluesky oauth tokens with dpop and returns a bluesky session paylo
         && $request['client_id'] === 'https://app.example/oauth/bluesky/client-metadata.json');
 });
 
+it('sends the private_key_jwt assertion on refresh even when route() drifts from the stored client_id', function () {
+    // Regression: refreshOAuth runs in queue workers, where route('oauth.bluesky.metadata')
+    // derives its scheme/host from APP_URL and drifts from the web-request context that
+    // connected the account (e.g. behind a reverse proxy). The old
+    // `usesAssertion = clientId === route(...)` check then went false, the confidential
+    // client dropped its private_key_jwt assertion, and Bluesky rejected the refresh with
+    // invalid_client, flipping the account to needs-attention. atproto requires refresh to
+    // authenticate with the same method used at connect.
+    $key = app(DPoP::class)->generateKey();
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::Bluesky->value,
+        'auth_method' => 'oauth',
+        'token_expires_at' => now()->subMinute(),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'access_token' => 'old-access',
+        'refresh_token' => 'old-refresh',
+        'session' => [
+            'pds' => 'https://pds.example',
+            'token_endpoint' => 'https://auth.example/oauth/token',
+            'issuer' => 'https://auth.example',
+            // Captured at connect behind a proxy (https + real host); differs from the
+            // worker's route('oauth.bluesky.metadata') (http://localhost in tests).
+            'client_id' => 'https://app.example/oauth/bluesky/client-metadata.json',
+            'dpop_private_jwk' => $key,
+            'dpop_nonce' => 'old-nonce',
+        ],
+    ]);
+
+    expect('https://app.example/oauth/bluesky/client-metadata.json')
+        ->not->toBe(route('oauth.bluesky.metadata'));
+
+    Http::fake([
+        'https://auth.example/oauth/token' => Http::response([
+            'access_token' => 'new-access',
+            'refresh_token' => 'new-refresh',
+            'expires_in' => 3600,
+        ], 200, ['DPoP-Nonce' => 'new-nonce']),
+    ]);
+
+    app(TokenManager::class)->fresh($account->fresh());
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://auth.example/oauth/token'
+        && $request['client_assertion_type'] === 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+        && isset($request['client_assertion'])
+        && $request['client_id'] === 'https://app.example/oauth/bluesky/client-metadata.json');
+
+    expect($account->fresh()->status)->toBe(ConnectedAccountStatus::Active);
+});
+
 it('uses a bluesky oauth token rotated by another worker instead of refreshing again', function () {
     $key = app(DPoP::class)->generateKey();
     $account = ConnectedAccount::factory()->create([

--- a/tests/Unit/Publishing/TokenManagerTest.php
+++ b/tests/Unit/Publishing/TokenManagerTest.php
@@ -6,7 +6,10 @@ use App\Models\ConnectedAccount;
 use App\Models\ConnectedAccountSecret;
 use App\Services\Atproto\DPoP;
 use App\Services\Publishing\TokenManager;
+use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
 it('refreshes bluesky oauth tokens with dpop and returns a bluesky session payload', function () {
@@ -58,6 +61,14 @@ it('sends the private_key_jwt assertion on refresh even when route() drifts from
     // client dropped its private_key_jwt assertion, and Bluesky rejected the refresh with
     // invalid_client, flipping the account to needs-attention. atproto requires refresh to
     // authenticate with the same method used at connect.
+    // Captured at connect behind a proxy (https + real host); must differ from the
+    // worker's route('oauth.bluesky.metadata') to exercise the drift. Guarantee the
+    // mismatch rather than depending on the test env's APP_URL.
+    $storedClientId = 'https://app.example/oauth/bluesky/client-metadata.json';
+    if ($storedClientId === route('oauth.bluesky.metadata')) {
+        $storedClientId .= '?connected_behind_proxy=1';
+    }
+
     $key = app(DPoP::class)->generateKey();
     $account = ConnectedAccount::factory()->create([
         'platform' => Platform::Bluesky->value,
@@ -72,16 +83,11 @@ it('sends the private_key_jwt assertion on refresh even when route() drifts from
             'pds' => 'https://pds.example',
             'token_endpoint' => 'https://auth.example/oauth/token',
             'issuer' => 'https://auth.example',
-            // Captured at connect behind a proxy (https + real host); differs from the
-            // worker's route('oauth.bluesky.metadata') (http://localhost in tests).
-            'client_id' => 'https://app.example/oauth/bluesky/client-metadata.json',
+            'client_id' => $storedClientId,
             'dpop_private_jwk' => $key,
             'dpop_nonce' => 'old-nonce',
         ],
     ]);
-
-    expect('https://app.example/oauth/bluesky/client-metadata.json')
-        ->not->toBe(route('oauth.bluesky.metadata'));
 
     Http::fake([
         'https://auth.example/oauth/token' => Http::response([
@@ -96,7 +102,7 @@ it('sends the private_key_jwt assertion on refresh even when route() drifts from
     Http::assertSent(fn (Request $request): bool => $request->url() === 'https://auth.example/oauth/token'
         && $request['client_assertion_type'] === 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
         && isset($request['client_assertion'])
-        && $request['client_id'] === 'https://app.example/oauth/bluesky/client-metadata.json');
+        && $request['client_id'] === $storedClientId);
 
     expect($account->fresh()->status)->toBe(ConnectedAccountStatus::Active);
 });
@@ -149,6 +155,67 @@ it('uses a bluesky oauth token rotated by another worker instead of refreshing a
     expect($credentials['access_token'])->toBe('fresh-from-worker')
         ->and($credentials['session']['accessJwt'])->toBe('fresh-from-worker')
         ->and($account->secret->refresh()->refresh_token)->toBe('rotated-by-worker');
+
+    Http::assertNothingSent();
+});
+
+it('refreshes a bluesky app-password session under the lock and returns the rotated session', function () {
+    $account = ConnectedAccount::factory()->bluesky()->create();
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'app_password' => 'app-pass',
+        'session' => [
+            'pds' => 'https://pds.example',
+            'accessJwt' => 'stale-access',
+            'refreshJwt' => 'stale-refresh',
+        ],
+    ]);
+
+    Http::fake([
+        'https://pds.example/xrpc/com.atproto.server.refreshSession' => Http::response([
+            'accessJwt' => 'new-access',
+            'refreshJwt' => 'new-refresh',
+        ]),
+    ]);
+
+    $credentials = app(TokenManager::class)->fresh($account);
+
+    expect($credentials['session']['accessJwt'])->toBe('new-access')
+        ->and($credentials['session']['refreshJwt'])->toBe('new-refresh')
+        ->and($credentials['app_password'])->toBe('app-pass')
+        ->and($account->secret->refresh()->session['accessJwt'])->toBe('new-access')
+        ->and($account->fresh()->status)->toBe(ConnectedAccountStatus::Active);
+
+    Http::assertSent(fn (Request $request): bool => $request->hasHeader('Authorization', 'Bearer stale-refresh')
+        && str_ends_with($request->url(), '/xrpc/com.atproto.server.refreshSession'));
+});
+
+it('falls back to the persisted bluesky session when the refresh lock times out', function () {
+    $account = ConnectedAccount::factory()->bluesky()->create();
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'app_password' => 'app-pass',
+        'session' => [
+            'pds' => 'https://pds.example',
+            'accessJwt' => 'persisted-access',
+            'refreshJwt' => 'persisted-refresh',
+        ],
+    ]);
+
+    // Simulate another worker holding the per-account lock: block() times out. The
+    // path must degrade to the persisted session rather than throw (which would fail
+    // the tries=1 publish job and risk flipping the account to needs-attention).
+    $lock = Mockery::mock(Lock::class);
+    $lock->shouldReceive('block')->once()->andThrow(new LockTimeoutException);
+    Cache::shouldReceive('lock')->once()->andReturn($lock);
+
+    Http::fake();
+
+    $credentials = app(TokenManager::class)->fresh($account);
+
+    expect($credentials['session']['accessJwt'])->toBe('persisted-access')
+        ->and($credentials['session']['refreshJwt'])->toBe('persisted-refresh')
+        ->and($credentials['app_password'])->toBe('app-pass');
 
     Http::assertNothingSent();
 });


### PR DESCRIPTION
## Summary
- Serialize Bluesky app-password token refresh under a per-account cache lock, and re-read the session inside the lock, so concurrent jobs (publish, engagement, DM-poll, repost) no longer race on the single-use `refreshJwt`. Previously the losing job would 400, fall back to a full login, and repeated churn could trip Bluesky's rate limit and flip healthy accounts to needs-attention.
- Fix the Bluesky OAuth `client_assertion` check to derive from the stored `client_id` instead of comparing against `route('oauth.bluesky.metadata')`, which can drift from the connect-time host in queue workers (e.g. behind a reverse proxy). The mismatch was causing confidential clients to drop their `private_key_jwt` assertion, resulting in `invalid_client` refresh failures and accounts incorrectly flipped to needs-attention.
