### PR TITLE
feat(mcp): allow custom redirect URI schemes for OAuth clients

### DIFF
--- a/config/mcp.php
+++ b/config/mcp.php
@@ -1,0 +1,54 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Redirect Domains
+    |--------------------------------------------------------------------------
+    |
+    | These domains are the domains that OAuth clients are permitted to use
+    | for redirect URIs. Each domain should be specified with its scheme
+    | and host. Domains not in this list will raise validation errors.
+    |
+    | An "*" may be used to allow all domains.
+    |
+    */
+
+    'redirect_domains' => [
+        '*',
+        // 'https://example.com',
+        // 'http://localhost',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allowed Custom Schemes
+    |--------------------------------------------------------------------------
+    |
+    | Native desktop OAuth clients like Cursor and VS Code use private-use URI
+    | schemes (RFC 8252) for redirect callbacks instead of standard schemes
+    | like HTTPS. Here, you may list which custom schemes you will allow.
+    |
+    */
+
+    'custom_schemes' => [
+        // 'claude',
+        'cursor',
+        // 'vscode',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authorization Server
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the OAuth authorization server issuer identifier
+    | per RFC 8414. This value appears in your protected resource and auth
+    | server metadata endpoints. When null, this defaults to `url('/')`.
+    |
+    */
+
+    'authorization_server' => null,
+
+];

--- a/tests/Feature/Mcp/OAuthDynamicClientRegistrationTest.php
+++ b/tests/Feature/Mcp/OAuthDynamicClientRegistrationTest.php
@@ -1,0 +1,10 @@
+<?php
+
+test('cursor can dynamically register its desktop oauth callback', function (): void {
+    $this->postJson('/oauth/register', [
+        'client_name' => 'Cursor',
+        'redirect_uris' => ['cursor://anysphere.cursor-deeplink/oauth'],
+    ])
+        ->assertCreated()
+        ->assertJsonPath('redirect_uris.0', 'cursor://anysphere.cursor-deeplink/oauth');
+});


### PR DESCRIPTION
## Summary
- Add `config/mcp.php` to configure allowed OAuth redirect domains, custom URI schemes, and the authorization server issuer
- Support RFC 8252 private-use URI schemes (e.g. `cursor://`) so native desktop OAuth clients like Cursor and VS Code can register redirect callbacks that aren't standard `https`/`http` URLs
- Enable the `cursor` scheme by default, with commented-out examples for `claude` and `vscode`
- Add a feature test verifying Cursor can dynamically register with a `cursor://` redirect URI
