### PR TITLE
fix(posts): fix off-by-one today/past highlight in calendar views

### DIFF
--- a/resources/js/components/posts/calendar/agenda-list.tsx
+++ b/resources/js/components/posts/calendar/agenda-list.tsx
@@ -5,7 +5,7 @@ import { PlatformGlyphStack } from '@/components/common/platform-glyph-stack';
 import type { PostRowData, PostStatus } from '@/components/posts/post-row';
 import { Plus } from '@/components/ui/icons';
 import { useSchedulingTimezone } from '@/hooks/posts/use-scheduling-timezone';
-import { dayjs, toUserTz, weekRange } from '@/lib/datetime/dayjs';
+import { dayFlags, dayjs, toUserTz, weekRange } from '@/lib/datetime/dayjs';
 import type { Dayjs } from '@/lib/datetime/dayjs';
 import { cn } from '@/lib/utils';
 
@@ -72,7 +72,7 @@ type Props = {
  */
 export function AgendaList({ anchor, view, posts, onEmptyDayClick }: Props) {
     const tz = useSchedulingTimezone();
-    const today = dayjs().tz(tz).startOf('day');
+    const todayKey = dayjs().tz(tz).format('YYYY-MM-DD');
     const days = windowDays(anchor, view);
     const byDay = postsByDay(posts, tz);
 
@@ -87,8 +87,7 @@ export function AgendaList({ anchor, view, posts, onEmptyDayClick }: Props) {
                             b.scheduled_at ?? b.published_at ?? '',
                         ),
                     );
-                const isToday = day.isSame(today, 'day');
-                const isPast = day.isBefore(today, 'day');
+                const { isToday, isPast } = dayFlags(day, todayKey);
 
                 return (
                     <li key={key} className="flex gap-3 py-1">

--- a/resources/js/components/posts/calendar/month-grid.tsx
+++ b/resources/js/components/posts/calendar/month-grid.tsx
@@ -9,7 +9,7 @@ import {
     PopoverTrigger,
 } from '@/components/ui/popover';
 import { useSchedulingTimezone } from '@/hooks/posts/use-scheduling-timezone';
-import { dayjs, monthRange, toUserTz } from '@/lib/datetime/dayjs';
+import { dayFlags, dayjs, monthRange, toUserTz } from '@/lib/datetime/dayjs';
 import type { Dayjs } from '@/lib/datetime/dayjs';
 import { cn } from '@/lib/utils';
 
@@ -51,7 +51,7 @@ export function MonthGrid({
     onEmptyDayClick: (day: Dayjs) => void;
 }) {
     const tz = useSchedulingTimezone();
-    const today = dayjs().tz(tz).startOf('day');
+    const todayKey = dayjs().tz(tz).format('YYYY-MM-DD');
     const { days } = monthRange(anchor);
 
     const byDay = new Map<string, PostRowData[]>();
@@ -73,18 +73,23 @@ export function MonthGrid({
                 ))}
             </div>
             <div className="grid grid-cols-7 gap-px overflow-hidden rounded-lg border border-border bg-border">
-                {days.map((d) => (
-                    <DayCell
-                        key={d.format('YYYY-MM-DD')}
-                        day={d}
-                        tz={tz}
-                        inMonth={d.month() === anchor.month()}
-                        isToday={d.isSame(today, 'day')}
-                        isPast={d.isBefore(today, 'day')}
-                        posts={byDay.get(d.format('YYYY-MM-DD')) ?? []}
-                        onEmptyClick={() => onEmptyDayClick(d)}
-                    />
-                ))}
+                {days.map((d) => {
+                    const key = d.format('YYYY-MM-DD');
+                    const { isToday, isPast } = dayFlags(d, todayKey);
+
+                    return (
+                        <DayCell
+                            key={key}
+                            day={d}
+                            tz={tz}
+                            inMonth={d.month() === anchor.month()}
+                            isToday={isToday}
+                            isPast={isPast}
+                            posts={byDay.get(key) ?? []}
+                            onEmptyClick={() => onEmptyDayClick(d)}
+                        />
+                    );
+                })}
             </div>
         </div>
     );

--- a/resources/js/components/posts/post-row.tsx
+++ b/resources/js/components/posts/post-row.tsx
@@ -6,7 +6,8 @@ import { PlatformGlyph } from '@/components/common/platform-glyph';
 import type { ChipTarget } from '@/components/compose/target-status-chips';
 import { Badge } from '@/components/ui/badge';
 import { Film, Image } from '@/components/ui/icons';
-import { dayjs } from '@/lib/datetime/dayjs';
+import { useSchedulingTimezone } from '@/hooks/posts/use-scheduling-timezone';
+import { dayjs, toUserTz } from '@/lib/datetime/dayjs';
 import { postStatusMeta } from '@/lib/posts/status';
 import { cn } from '@/lib/utils';
 import type { PlatformName, PostStatus } from '@/types/compose';
@@ -31,9 +32,12 @@ export type PostRowData = {
     media_preview: { kind: 'image' | 'video'; url: string | null } | null;
 };
 
-function formatWhen(dateStr: string): { when: string; time: string } {
-    const d = dayjs(dateStr);
-    const startOfToday = dayjs().startOf('day');
+function formatWhen(
+    dateStr: string,
+    tz: string,
+): { when: string; time: string } {
+    const d = toUserTz(dateStr, tz);
+    const startOfToday = dayjs().tz(tz).startOf('day');
     let when: string;
     if (d.isSame(startOfToday, 'day')) {
         when = 'Today';
@@ -123,7 +127,8 @@ function rowTimestamp(post: PostRowData): string {
 }
 
 export function PostRow({ post }: { post: PostRowData }) {
-    const { when, time } = formatWhen(rowTimestamp(post));
+    const tz = useSchedulingTimezone();
+    const { when, time } = formatWhen(rowTimestamp(post), tz);
     // Default the optional list fields: an older/partial Inertia payload (e.g. a
     // page loaded before the index exposed per-target data) must not crash the row.
     const platforms = post.platforms ?? [];

--- a/resources/js/lib/datetime/__tests__/dayjs.test.ts
+++ b/resources/js/lib/datetime/__tests__/dayjs.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { monthRange, parseYm, weekRange, ymKey } from '@/lib/datetime/dayjs';
+import {
+    dayFlags,
+    monthRange,
+    parseYm,
+    weekRange,
+    ymKey,
+} from '@/lib/datetime/dayjs';
 
 describe('datetime helpers', () => {
     it('ymKey formats a YYYY-MM key', () => {
@@ -23,5 +29,38 @@ describe('datetime helpers', () => {
         const { days } = weekRange(parseYm('2026-06')!);
         expect(days).toHaveLength(7);
         expect(days[0].day()).toBe(0);
+    });
+
+    describe('dayFlags (issue #168 — today highlight is one day early)', () => {
+        // Cells come from the UTC anchor (the real code path via parseYm), while
+        // `todayKey` is the local calendar day in the scheduling tz. Comparing by
+        // date key must flag the correct day regardless of the anchor's offset.
+        const cells = monthRange(parseYm('2026-08')!).days;
+
+        it('flags exactly the local today, not the prior UTC day', () => {
+            const today = cells.filter(
+                (d) => dayFlags(d, '2026-08-21').isToday,
+            );
+            expect(today.map((d) => d.format('YYYY-MM-DD'))).toEqual([
+                '2026-08-21',
+            ]);
+        });
+
+        it('dims every day up to but not including today', () => {
+            const past = cells.filter((d) => dayFlags(d, '2026-08-21').isPast);
+            expect(past.at(-1)?.format('YYYY-MM-DD')).toBe('2026-08-20');
+            expect(dayFlags(cells[0], '2026-08-21').isPast).toBe(true);
+        });
+
+        it('marks future days as neither today nor past', () => {
+            const { isToday, isPast } = dayFlags(
+                monthRange(parseYm('2026-08')!).days.find(
+                    (d) => d.format('YYYY-MM-DD') === '2026-08-22',
+                )!,
+                '2026-08-21',
+            );
+            expect(isToday).toBe(false);
+            expect(isPast).toBe(false);
+        });
     });
 });

--- a/resources/js/lib/datetime/dayjs.ts
+++ b/resources/js/lib/datetime/dayjs.ts
@@ -55,6 +55,20 @@ export function ymKey(d: Dayjs): string {
     return d.format('YYYY-MM');
 }
 
+/**
+ * Today/past flags for a calendar cell, compared by calendar-date key rather
+ * than by instant, so the result is independent of whether `day` carries a UTC
+ * or zoned offset. `todayKey` is the current day in the scheduling tz, as
+ * `YYYY-MM-DD` (its string ordering is chronological, so `<` means "is past").
+ */
+export function dayFlags(
+    day: Dayjs,
+    todayKey: string,
+): { isToday: boolean; isPast: boolean } {
+    const key = day.format('YYYY-MM-DD');
+    return { isToday: key === todayKey, isPast: key < todayKey };
+}
+
 /** Parse a YYYY-MM string into a Dayjs at the 1st of that month (UTC). */
 export function parseYm(ym: string): Dayjs | null {
     const d = dayjs.utc(`${ym}-01`, 'YYYY-MM-DD', true);


### PR DESCRIPTION
## Summary
- Fixes the month calendar and mobile agenda showing the "today" highlight (and past-day dimming) one day early for workspace timezones with a positive UTC offset (e.g. `Europe/Madrid`, `Asia/Tokyo`) (fixes #168)
- Adds a shared `dayFlags` helper that compares calendar-date keys instead of instants, so `isToday`/`isPast` no longer depend on whether the day cell is in UTC or zoned mode
- Applies the same scheduling-timezone fix to `PostRow`'s "Today"/"Yesterday"/"Tomorrow" labels, which previously used the browser timezone instead of the workspace timezone
- Adds regression tests covering the UTC-anchor vs. tz-mode comparison across month boundaries


---

Fixes #168