### PR TITLE
fix(publishing): validate X video aspect ratio before publish

### DIFF
--- a/app/Enums/Platform.php
+++ b/app/Enums/Platform.php
@@ -494,6 +494,21 @@ enum Platform: string
     }
 
     /**
+     * Allowed width:height ratio bounds for an uploaded video, or null when the
+     * platform does not constrain it. X rejects anything outside 1:3–3:1 with
+     * an "aspect ratio too large" error, so we catch it before publishing.
+     *
+     * @return array{min: float, max: float}|null
+     */
+    public function videoAspectRatioRange(): ?array
+    {
+        return match ($this) {
+            self::X => ['min' => 1 / 3, 'max' => 3.0],
+            default => null,
+        };
+    }
+
+    /**
      * Largest video byte cap across all platforms — the server-side upload ceiling.
      */
     public static function maxVideoBytesCeiling(): int
@@ -515,7 +530,7 @@ enum Platform: string
     }
 
     /**
-     * @return array{platform: string, maxLength: int, maxBytes: int|null, maxMedia: int, requiresMedia: bool, maxMediaBytes: int, allowedMime: list<string>, threadMax: int|null, maxImageDimensions: array{width: int, height: int}, allowedVideoMime: list<string>, maxVideoBytes: int, maxVideoDurationSeconds: int}
+     * @return array{platform: string, maxLength: int, maxBytes: int|null, maxMedia: int, requiresMedia: bool, maxMediaBytes: int, allowedMime: list<string>, threadMax: int|null, maxImageDimensions: array{width: int, height: int}, allowedVideoMime: list<string>, maxVideoBytes: int, maxVideoDurationSeconds: int, videoAspectRatioRange: array{min: float, max: float}|null}
      */
     public function limits(): array
     {
@@ -532,11 +547,12 @@ enum Platform: string
             'allowedVideoMime' => $this->allowedVideoMime(),
             'maxVideoBytes' => $this->maxVideoBytes(),
             'maxVideoDurationSeconds' => $this->maxVideoDurationSeconds(),
+            'videoAspectRatioRange' => $this->videoAspectRatioRange(),
         ];
     }
 
     /**
-     * @return list<array{platform: string, maxLength: int, maxBytes: int|null, maxMedia: int, requiresMedia: bool, maxMediaBytes: int, allowedMime: list<string>, threadMax: int|null, maxImageDimensions: array{width: int, height: int}, allowedVideoMime: list<string>, maxVideoBytes: int, maxVideoDurationSeconds: int}>
+     * @return list<array{platform: string, maxLength: int, maxBytes: int|null, maxMedia: int, requiresMedia: bool, maxMediaBytes: int, allowedMime: list<string>, threadMax: int|null, maxImageDimensions: array{width: int, height: int}, allowedVideoMime: list<string>, maxVideoBytes: int, maxVideoDurationSeconds: int, videoAspectRatioRange: array{min: float, max: float}|null}>
      */
     public static function allLimits(): array
     {

--- a/app/Services/Posts/PublishPrecheck.php
+++ b/app/Services/Posts/PublishPrecheck.php
@@ -83,6 +83,7 @@ class PublishPrecheck
             'mixed_video_and_images' => 'A post can contain one video or images, not both.',
             'video_too_long' => "The video is longer than {$label} allows.",
             'video_too_large' => "The video is larger than {$label} allows.",
+            'video_bad_aspect_ratio' => "The video's aspect ratio is outside {$label}'s allowed range (widest 3:1, tallest 1:3).",
             'gif_not_mixable' => "{$label} allows only one GIF and won't mix it with other media.",
             'unplaced_media' => "Some attached media isn't placed in this post — remove it or add it to a thread section.",
             default => "{$label} can't publish this post yet.",
@@ -181,6 +182,14 @@ class PublishPrecheck
 
             if ($video->size_bytes > $platform->maxVideoBytes()) {
                 $issues[] = 'video_too_large';
+            }
+
+            $range = $platform->videoAspectRatioRange();
+            if ($range !== null && $video->width > 0 && $video->height > 0) {
+                $ratio = $video->width / $video->height;
+                if ($ratio < $range['min'] || $ratio > $range['max']) {
+                    $issues[] = 'video_bad_aspect_ratio';
+                }
             }
         }
 

--- a/app/Services/Posts/PublishPrecheck.php
+++ b/app/Services/Posts/PublishPrecheck.php
@@ -174,22 +174,40 @@ class PublishPrecheck
             }
         }
 
-        $videos = $media->filter(fn (PostMedia $item): bool => $item->isVideo());
-        foreach ($videos as $video) {
-            if ($video->duration_seconds !== null && $video->duration_seconds > $platform->maxVideoDurationSeconds()) {
-                $issues[] = 'video_too_long';
+        foreach ($media->filter(fn (PostMedia $item): bool => $item->isVideo()) as $video) {
+            foreach ($this->videoIssues($platform, $video) as $issue) {
+                $issues[] = $issue;
             }
+        }
 
-            if ($video->size_bytes > $platform->maxVideoBytes()) {
-                $issues[] = 'video_too_large';
-            }
+        return $issues;
+    }
 
-            $range = $platform->videoAspectRatioRange();
-            if ($range !== null && $video->width > 0 && $video->height > 0) {
-                $ratio = $video->width / $video->height;
-                if ($ratio < $range['min'] || $ratio > $range['max']) {
-                    $issues[] = 'video_bad_aspect_ratio';
-                }
+    /**
+     * Per-video limit rules — duration, byte size, and aspect ratio — for a
+     * single attached video. Aspect ratio is only bounded on some platforms (X
+     * rejects anything outside 1:3–3:1); incomplete client metadata (a missing
+     * width or height) is left to publish time rather than blocked here.
+     *
+     * @return list<string>
+     */
+    private function videoIssues(Platform $platform, PostMedia $video): array
+    {
+        $issues = [];
+
+        if ($video->duration_seconds !== null && $video->duration_seconds > $platform->maxVideoDurationSeconds()) {
+            $issues[] = 'video_too_long';
+        }
+
+        if ($video->size_bytes > $platform->maxVideoBytes()) {
+            $issues[] = 'video_too_large';
+        }
+
+        $range = $platform->videoAspectRatioRange();
+        if ($range !== null && $video->width > 0 && $video->height > 0) {
+            $ratio = $video->width / $video->height;
+            if ($ratio < $range['min'] || $ratio > $range['max']) {
+                $issues[] = 'video_bad_aspect_ratio';
             }
         }
 

--- a/app/Services/Publishing/Connectors/XConnector.php
+++ b/app/Services/Publishing/Connectors/XConnector.php
@@ -332,7 +332,14 @@ class XConnector implements PublishConnector, RepostConnector
             $stateName = (string) ($info['state'] ?? 'succeeded');
 
             if ($stateName === 'failed') {
-                return PublishResult::failure(ErrorKind::ServerError, "X failed to process the {$label}.");
+                // X puts the real reason (e.g. "The aspect ratio of the video you tried to upload
+                // was too large.") in processing_info.error — surface it instead of a generic string.
+                $reason = trim((string) ($info['error']['message'] ?? ''));
+
+                return PublishResult::failure(
+                    ErrorKind::ServerError,
+                    $reason !== '' ? "X rejected the {$label}: {$reason}" : "X failed to process the {$label}.",
+                );
             }
 
             if ($stateName !== 'succeeded') {

--- a/app/Services/Publishing/Connectors/XConnector.php
+++ b/app/Services/Publishing/Connectors/XConnector.php
@@ -336,8 +336,11 @@ class XConnector implements PublishConnector, RepostConnector
                 // was too large.") in processing_info.error — surface it instead of a generic string.
                 $reason = trim((string) ($info['error']['message'] ?? ''));
 
+                // A failed processing state is permanent (bad codec, aspect ratio, corrupt file) —
+                // re-uploading the same bytes fails identically. Use a terminal Validation kind so
+                // the publish job stops retrying instead of burning attempts on a doomed upload.
                 return PublishResult::failure(
-                    ErrorKind::ServerError,
+                    ErrorKind::Validation,
                     $reason !== '' ? "X rejected the {$label}: {$reason}" : "X failed to process the {$label}.",
                 );
             }

--- a/resources/js/components/compose/submit-bar.tsx
+++ b/resources/js/components/compose/submit-bar.tsx
@@ -77,6 +77,7 @@ function limitsFor(
             allowedVideoMime: [],
             maxVideoBytes: 0,
             maxVideoDurationSeconds: 0,
+            videoAspectRatioRange: null,
         }
     );
 }

--- a/resources/js/lib/compose/__tests__/precheck.test.ts
+++ b/resources/js/lib/compose/__tests__/precheck.test.ts
@@ -22,6 +22,7 @@ function limitsFor(
         allowedVideoMime: [],
         maxVideoBytes: 1,
         maxVideoDurationSeconds: 1,
+        videoAspectRatioRange: null,
         ...over,
     };
 }

--- a/resources/js/lib/compose/__tests__/video.test.ts
+++ b/resources/js/lib/compose/__tests__/video.test.ts
@@ -25,6 +25,7 @@ function limits(
         allowedVideoMime: ['video/mp4'],
         maxVideoBytes: 100_000_000,
         maxVideoDurationSeconds: 180,
+        videoAspectRatioRange: null,
         ...over,
     };
 }
@@ -72,6 +73,30 @@ describe('validateVideo', () => {
             limits({ platform: 'bluesky', maxVideoBytes: 100_000_000 }),
         ]);
         expect(result.ok).toBe(false);
+    });
+
+    it('rejects a video wider than a platform aspect-ratio bound', () => {
+        const result = validateVideo({ ...meta, width: 4000, height: 1000 }, [
+            limits({
+                platform: 'x',
+                videoAspectRatioRange: { min: 1 / 3, max: 3 },
+            }),
+        ]);
+        expect(result).toEqual({
+            ok: false,
+            reason: expect.stringContaining('shape'),
+        });
+    });
+
+    it('accepts an in-range video and ignores platforms with no ratio bound', () => {
+        const result = validateVideo({ ...meta, width: 1920, height: 1080 }, [
+            limits({
+                platform: 'x',
+                videoAspectRatioRange: { min: 1 / 3, max: 3 },
+            }),
+            limits({ platform: 'bluesky' }),
+        ]);
+        expect(result.ok).toBe(true);
     });
 });
 

--- a/resources/js/lib/compose/__tests__/video.test.ts
+++ b/resources/js/lib/compose/__tests__/video.test.ts
@@ -88,13 +88,31 @@ describe('validateVideo', () => {
         });
     });
 
-    it('accepts an in-range video and ignores platforms with no ratio bound', () => {
+    it('accepts an in-range video against a platform that bounds the ratio', () => {
         const result = validateVideo({ ...meta, width: 1920, height: 1080 }, [
             limits({
                 platform: 'x',
                 videoAspectRatioRange: { min: 1 / 3, max: 3 },
             }),
-            limits({ platform: 'bluesky' }),
+        ]);
+        expect(result.ok).toBe(true);
+    });
+
+    it('does not apply a ratio bound to a platform that has none', () => {
+        // 4000x1000 (4:1) is outside X's range, but Bluesky sets no bound.
+        const result = validateVideo({ ...meta, width: 4000, height: 1000 }, [
+            limits({ platform: 'bluesky', videoAspectRatioRange: null }),
+        ]);
+        expect(result.ok).toBe(true);
+    });
+
+    it('does not reject when metadata is missing a dimension', () => {
+        // Incomplete metadata (width 0) must defer to publish time, matching the server.
+        const result = validateVideo({ ...meta, width: 0, height: 1080 }, [
+            limits({
+                platform: 'x',
+                videoAspectRatioRange: { min: 1 / 3, max: 3 },
+            }),
         ]);
         expect(result.ok).toBe(true);
     });

--- a/resources/js/lib/compose/video.ts
+++ b/resources/js/lib/compose/video.ts
@@ -98,7 +98,7 @@ export function validateVideo(
 
     // Aspect-ratio bounds are per-platform (only X constrains them today). X rejects
     // anything outside 1:3–3:1 at upload, so block it here against the tightest range.
-    if (meta.height > 0) {
+    if (meta.width > 0 && meta.height > 0) {
         const ratio = meta.width / meta.height;
         for (const limit of limits) {
             const range = limit.videoAspectRatioRange;

--- a/resources/js/lib/compose/video.ts
+++ b/resources/js/lib/compose/video.ts
@@ -1,3 +1,4 @@
+import { platformLabel } from '@/lib/platforms';
 import type { PlatformLimits, PlatformName } from '@/types/compose';
 
 export type VideoMeta = {
@@ -93,6 +94,21 @@ export function validateVideo(
             ok: false,
             reason: `Video is too long; the limit is ${maxDuration}s for the selected platforms.`,
         };
+    }
+
+    // Aspect-ratio bounds are per-platform (only X constrains them today). X rejects
+    // anything outside 1:3–3:1 at upload, so block it here against the tightest range.
+    if (meta.height > 0) {
+        const ratio = meta.width / meta.height;
+        for (const limit of limits) {
+            const range = limit.videoAspectRatioRange;
+            if (range && (ratio < range.min || ratio > range.max)) {
+                return {
+                    ok: false,
+                    reason: `This video's shape isn't supported by ${platformLabel(limit.platform)} (must be between 3:1 wide and 1:3 tall).`,
+                };
+            }
+        }
     }
 
     return { ok: true };

--- a/resources/js/lib/video-editor/__tests__/convert-plan.test.ts
+++ b/resources/js/lib/video-editor/__tests__/convert-plan.test.ts
@@ -27,6 +27,7 @@ function limits(
             allowedVideoMime: ['video/mp4'],
             maxVideoBytes: 536_870_912,
             maxVideoDurationSeconds: 140,
+            videoAspectRatioRange: { min: 1 / 3, max: 3 },
             ...overrides,
         },
     ];

--- a/resources/js/types/compose.ts
+++ b/resources/js/types/compose.ts
@@ -79,6 +79,8 @@ export type PlatformLimits = {
     allowedVideoMime: string[];
     maxVideoBytes: number;
     maxVideoDurationSeconds: number;
+    /** Allowed width:height ratio bounds for a video, or null when unconstrained. */
+    videoAspectRatioRange: { min: number; max: number } | null;
 };
 
 export type MediaView = {

--- a/tests/Feature/Publishing/PublishPrecheckTest.php
+++ b/tests/Feature/Publishing/PublishPrecheckTest.php
@@ -290,6 +290,48 @@ test('blockingTargets flags a video larger than the platform allows', function (
         ->and($blocked[0]['issues'])->toContain('video_too_large');
 });
 
+test('blockingTargets flags an X video whose aspect ratio is too wide', function () {
+    $post = Post::factory()->create();
+    PostMedia::factory()->for($post)->video()->create(['width' => 4000, 'height' => 1000]);
+    PostTarget::factory()->for($post)->create([
+        'platform' => Platform::X->value,
+        'sections' => ['hello'],
+    ]);
+
+    $blocked = app(PublishPrecheck::class)->blockingTargets($post->fresh(['targets.account', 'media']));
+
+    expect($blocked)->toHaveCount(1)
+        ->and($blocked[0]['issues'])->toContain('video_bad_aspect_ratio');
+});
+
+test('blockingTargets passes an X video within the allowed aspect ratio', function () {
+    $post = Post::factory()->create();
+    PostMedia::factory()->for($post)->video()->create(['width' => 1920, 'height' => 1080]);
+    PostTarget::factory()->for($post)->create([
+        'platform' => Platform::X->value,
+        'sections' => ['hello'],
+    ]);
+
+    $blocked = app(PublishPrecheck::class)->blockingTargets($post->fresh(['targets.account', 'media']));
+
+    expect($blocked)->toBe([]);
+});
+
+test('blockingTargets ignores aspect ratio on platforms that do not constrain it', function () {
+    $post = Post::factory()->create();
+    PostMedia::factory()->for($post)->video()->create(['width' => 4000, 'height' => 1000]);
+    $account = ConnectedAccount::factory()->create(['platform' => Platform::Bluesky]);
+    PostTarget::factory()->for($post)->create([
+        'connected_account_id' => $account->id,
+        'platform' => Platform::Bluesky->value,
+        'sections' => ['hello'],
+    ]);
+
+    $blocked = app(PublishPrecheck::class)->blockingTargets($post->fresh(['targets.account', 'media']));
+
+    expect($blocked)->toBe([]);
+});
+
 test('blockingTargets flags a GIF mixed with another image on X', function () {
     $post = Post::factory()->create();
     PostMedia::factory()->for($post)->create(['mime' => 'image/gif']);

--- a/tests/Feature/Publishing/XConnectorTest.php
+++ b/tests/Feature/Publishing/XConnectorTest.php
@@ -271,7 +271,7 @@ test('x surfaces the real reason when video processing fails', function () {
     $result = app(XConnector::class)->publish(xContext(['watch this'], [$media]));
 
     expect($result->isSuccessful())->toBeFalse()
-        ->and($result->errorKind)->toBe(ErrorKind::ServerError)
+        ->and($result->errorKind)->toBe(ErrorKind::Validation)
         ->and($result->errorMessage)->toContain('aspect ratio of the video');
 });
 

--- a/tests/Feature/Publishing/XConnectorTest.php
+++ b/tests/Feature/Publishing/XConnectorTest.php
@@ -247,6 +247,34 @@ test('x uploads gifs through the async tweet_gif flow', function () {
         && ($request['media']['media_ids'] ?? null) === ['gif123']);
 });
 
+test('x surfaces the real reason when video processing fails', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('media/result.mp4', 'video-bytes');
+
+    $media = PostMedia::factory()->video()->create([
+        'disk' => 'public',
+        'path' => 'media/result.mp4',
+        'mime' => 'video/mp4',
+        'size_bytes' => strlen('video-bytes'),
+    ]);
+
+    Http::fake([
+        'https://api.x.com/2/media/upload/initialize' => Http::response(['data' => ['id' => 'vid123']], 200),
+        'https://api.x.com/2/media/upload/vid123/append' => Http::response([], 200),
+        'https://api.x.com/2/media/upload/vid123/finalize' => Http::response([], 200),
+        'https://api.x.com/2/media/upload*' => Http::response(['data' => ['processing_info' => [
+            'state' => 'failed',
+            'error' => ['message' => 'The aspect ratio of the video you tried to upload was too large.'],
+        ]]], 200),
+    ]);
+
+    $result = app(XConnector::class)->publish(xContext(['watch this'], [$media]));
+
+    expect($result->isSuccessful())->toBeFalse()
+        ->and($result->errorKind)->toBe(ErrorKind::ServerError)
+        ->and($result->errorMessage)->toContain('aspect ratio of the video');
+});
+
 test('x rejects mixing a gif with other media before calling the api', function () {
     Storage::fake('public');
     Storage::disk('public')->put('media/animation.gif', 'gif-bytes');

--- a/tests/Feature/Publishing/XVideoConnectorTest.php
+++ b/tests/Feature/Publishing/XVideoConnectorTest.php
@@ -97,7 +97,7 @@ test('transient 503 on status poll returns MediaProcessing (not ServerError)', f
         ->and($result->errorKind)->toBe(ErrorKind::MediaProcessing);
 });
 
-test('STATUS=failed returns a terminal ServerError', function (): void {
+test('STATUS=failed returns a terminal Validation error', function (): void {
     $account = ConnectedAccount::factory()->state(['platform' => 'x'])->create();
     $media = PostMedia::factory()->video()->create(['disk' => 'public', 'path' => 'media/ws/v.mp4']);
     Storage::disk('public')->put('media/ws/v.mp4', str_repeat('x', 2048));
@@ -114,5 +114,5 @@ test('STATUS=failed returns a terminal ServerError', function (): void {
     $result = app(XConnector::class)->publish($ctx);
 
     expect($result->isSuccessful())->toBeFalse()
-        ->and($result->errorKind)->toBe(ErrorKind::ServerError);
+        ->and($result->errorKind)->toBe(ErrorKind::Validation);
 });

--- a/tests/Unit/PlatformVideoLimitsTest.php
+++ b/tests/Unit/PlatformVideoLimitsTest.php
@@ -19,7 +19,14 @@ test('video byte ceiling is the largest per-platform cap', function (): void {
 
 test('limits payload exposes video fields', function (): void {
     expect(Platform::X->limits())
-        ->toHaveKeys(['allowedVideoMime', 'maxVideoBytes', 'maxVideoDurationSeconds']);
+        ->toHaveKeys(['allowedVideoMime', 'maxVideoBytes', 'maxVideoDurationSeconds', 'videoAspectRatioRange']);
+});
+
+test('only X constrains the video aspect ratio', function (): void {
+    expect(Platform::X->videoAspectRatioRange())->toBe(['min' => 1 / 3, 'max' => 3.0])
+        ->and(Platform::LinkedIn->videoAspectRatioRange())->toBeNull()
+        ->and(Platform::Bluesky->videoAspectRatioRange())->toBeNull()
+        ->and(Platform::Instagram->videoAspectRatioRange())->toBeNull();
 });
 
 test('meta platform video limits are set', function (): void {


### PR DESCRIPTION
## Summary
- Add a per-platform video aspect ratio limit; X requires a width:height ratio between 1:3 and 3:1, other platforms are unconstrained
- Enforce the check both server-side (publish precheck) and client-side (compose video validation) so out-of-range videos are blocked before upload
- Surface X's actual processing error message (e.g. "aspect ratio too large") instead of a generic failure when media processing fails
- fixes #162


---

Fixes #162