### PR TITLE
fix(calendar): allow adding posts to days that already have one

### DIFF
--- a/resources/js/components/posts/calendar/__tests__/calendar-drop.test.ts
+++ b/resources/js/components/posts/calendar/__tests__/calendar-drop.test.ts
@@ -2,18 +2,17 @@ import { describe, expect, it } from 'vitest';
 
 import {
     computeMonthDrop,
-    shouldOpenEmptyMonthDay,
+    shouldOpenMonthDay,
 } from '@/components/posts/calendar/month-grid';
 import { computeWeekDrop } from '@/components/posts/calendar/week-grid';
 
 describe('calendar day activation', () => {
-    it('does not open an empty month day in the past', () => {
-        expect(shouldOpenEmptyMonthDay(true, true)).toBe(false);
+    it('does not open a month day in the past', () => {
+        expect(shouldOpenMonthDay(true)).toBe(false);
     });
 
-    it('opens only empty future or current month days', () => {
-        expect(shouldOpenEmptyMonthDay(true, false)).toBe(true);
-        expect(shouldOpenEmptyMonthDay(false, false)).toBe(false);
+    it('opens future or current month days regardless of existing posts', () => {
+        expect(shouldOpenMonthDay(false)).toBe(true);
     });
 });
 

--- a/resources/js/components/posts/calendar/__tests__/month-grid-click.test.tsx
+++ b/resources/js/components/posts/calendar/__tests__/month-grid-click.test.tsx
@@ -19,9 +19,9 @@ vi.mock('@inertiajs/react', () => ({
 const anchor = dayjs.utc('2099-06-01');
 const dayWithPost = '2099-06-15';
 
-function post(): PostRowData {
+function post(id = 'post-1'): PostRowData {
     return {
-        id: 'post-1',
+        id,
         base_text: 'Existing post',
         status: 'scheduled',
         status_label: 'Scheduled',
@@ -37,12 +37,15 @@ function post(): PostRowData {
     };
 }
 
-function renderGrid(onEmptyDayClick: () => void) {
+function renderGrid(
+    onEmptyDayClick: () => void,
+    posts: PostRowData[] = [post()],
+) {
     return render(
         <DndContext>
             <MonthGrid
                 anchor={anchor}
-                posts={[post()]}
+                posts={posts}
                 onEmptyDayClick={onEmptyDayClick}
             />
         </DndContext>,
@@ -77,5 +80,22 @@ describe('MonthGrid — click a day that already has a post', () => {
 
         expect(onEmptyDayClick).not.toHaveBeenCalled();
         expect(routerVisit).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT create a post when activating the "+N more" button with the keyboard', () => {
+        const onEmptyDayClick = vi.fn();
+        // >3 posts renders the overflow "+N more" <button> inside the cell.
+        renderGrid(onEmptyDayClick, [
+            post('a'),
+            post('b'),
+            post('c'),
+            post('d'),
+        ]);
+
+        const moreButton = screen.getByText(/\+1 more/);
+        fireEvent.keyDown(moreButton, { key: 'Enter' });
+        fireEvent.keyDown(moreButton, { key: ' ' });
+
+        expect(onEmptyDayClick).not.toHaveBeenCalled();
     });
 });

--- a/resources/js/components/posts/calendar/__tests__/month-grid-click.test.tsx
+++ b/resources/js/components/posts/calendar/__tests__/month-grid-click.test.tsx
@@ -1,0 +1,81 @@
+import { DndContext } from '@dnd-kit/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MonthGrid } from '@/components/posts/calendar/month-grid';
+import type { PostRowData } from '@/components/posts/post-row';
+import { dayjs } from '@/lib/datetime/dayjs';
+import type { PlatformName } from '@/types/compose';
+
+const routerVisit = vi.fn();
+vi.mock('@inertiajs/react', () => ({
+    router: { visit: (...a: unknown[]) => routerVisit(...a) },
+    usePage: () => ({
+        props: { workspaces: { current: { timezone: 'UTC' } } },
+        url: '/calendar',
+    }),
+}));
+
+const anchor = dayjs.utc('2099-06-01');
+const dayWithPost = '2099-06-15';
+
+function post(): PostRowData {
+    return {
+        id: 'post-1',
+        base_text: 'Existing post',
+        status: 'scheduled',
+        status_label: 'Scheduled',
+        author: null,
+        target_count: 1,
+        updated_at: `${dayWithPost}T09:00:00Z`,
+        scheduled_at: `${dayWithPost}T14:30:00Z`,
+        published_at: null,
+        platforms: ['x'] as PlatformName[],
+        targets: [],
+        media_count: 0,
+        media_preview: null,
+    };
+}
+
+function renderGrid(onEmptyDayClick: () => void) {
+    return render(
+        <DndContext>
+            <MonthGrid
+                anchor={anchor}
+                posts={[post()]}
+                onEmptyDayClick={onEmptyDayClick}
+            />
+        </DndContext>,
+    );
+}
+
+describe('MonthGrid — click a day that already has a post', () => {
+    it('fires onEmptyDayClick when clicking the cell body of a future day with a post', () => {
+        const onEmptyDayClick = vi.fn();
+        renderGrid(onEmptyDayClick);
+
+        fireEvent.click(screen.getByLabelText(`Day ${dayWithPost}`));
+
+        expect(onEmptyDayClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onEmptyDayClick when clicking a non-button child (date number) of the cell', () => {
+        const onEmptyDayClick = vi.fn();
+        renderGrid(onEmptyDayClick);
+
+        // The date number span is a nested child; the click must bubble to the cell.
+        fireEvent.click(screen.getByText('15'));
+
+        expect(onEmptyDayClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT create a post when clicking the existing post chip (opens the post instead)', () => {
+        const onEmptyDayClick = vi.fn();
+        renderGrid(onEmptyDayClick);
+
+        fireEvent.click(screen.getByTitle('Existing post'));
+
+        expect(onEmptyDayClick).not.toHaveBeenCalled();
+        expect(routerVisit).toHaveBeenCalledTimes(1);
+    });
+});

--- a/resources/js/components/posts/calendar/__tests__/post-chip-propagation.test.tsx
+++ b/resources/js/components/posts/calendar/__tests__/post-chip-propagation.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PostChip } from '@/components/posts/calendar/post-chip';
+import type { PostRowData } from '@/components/posts/post-row';
+import type { PlatformName } from '@/types/compose';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { visit: vi.fn() },
+    usePage: () => ({
+        props: { workspaces: { current: { timezone: 'UTC' } } },
+    }),
+}));
+
+// Force the chip into the "mid-drag" state so we exercise the drag-end
+// synthetic-click branch of openPost.
+vi.mock('@dnd-kit/core', () => ({
+    useDraggable: () => ({
+        attributes: {},
+        listeners: {},
+        setNodeRef: () => {},
+        transform: null,
+        isDragging: true,
+    }),
+}));
+
+function post(): PostRowData {
+    return {
+        id: 'post-1',
+        base_text: 'Existing post',
+        status: 'scheduled',
+        status_label: 'Scheduled',
+        author: null,
+        target_count: 1,
+        updated_at: '2099-06-15T09:00:00Z',
+        scheduled_at: '2099-06-15T14:30:00Z',
+        published_at: null,
+        platforms: ['x'] as PlatformName[],
+        targets: [],
+        media_count: 0,
+        media_preview: null,
+    };
+}
+
+describe('PostChip — drag-end click never bubbles to the day cell', () => {
+    it('stops propagation even while dragging, so the parent create handler is not triggered', () => {
+        const parentClick = vi.fn();
+        render(
+            <div onClick={parentClick}>
+                <PostChip post={post()} draggable />
+            </div>,
+        );
+
+        fireEvent.click(screen.getByTitle('Existing post'));
+
+        expect(parentClick).not.toHaveBeenCalled();
+    });
+});

--- a/resources/js/components/posts/calendar/agenda-list.tsx
+++ b/resources/js/components/posts/calendar/agenda-list.tsx
@@ -117,14 +117,15 @@ export function AgendaList({ anchor, view, posts, onEmptyDayClick }: Props) {
                         </div>
 
                         <div className="min-w-0 flex-1 space-y-1 border-l border-border/60 py-0.5 pl-3">
-                            {dayPosts.length > 0 ? (
-                                dayPosts.map((post) => (
-                                    <AgendaItem key={post.id} post={post} />
-                                ))
-                            ) : isPast ? (
-                                <p className="px-1 py-2.5 text-[12.5px] text-muted-foreground/45">
-                                    No posts
-                                </p>
+                            {dayPosts.map((post) => (
+                                <AgendaItem key={post.id} post={post} />
+                            ))}
+                            {isPast ? (
+                                dayPosts.length === 0 && (
+                                    <p className="px-1 py-2.5 text-[12.5px] text-muted-foreground/45">
+                                        No posts
+                                    </p>
+                                )
                             ) : (
                                 <button
                                     type="button"

--- a/resources/js/components/posts/calendar/month-grid.tsx
+++ b/resources/js/components/posts/calendar/month-grid.tsx
@@ -32,11 +32,8 @@ export function computeMonthDrop(
         .format('YYYY-MM-DDTHH:mm:ss[Z]');
 }
 
-export function shouldOpenEmptyMonthDay(
-    empty: boolean,
-    isPast: boolean,
-): boolean {
-    return empty && !isPast;
+export function shouldOpenMonthDay(isPast: boolean): boolean {
+    return !isPast;
 }
 
 const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -119,12 +116,11 @@ function DayCell({
     });
     const visible = posts.slice(0, 3);
     const overflow = posts.length - visible.length;
-    const empty = posts.length === 0;
     const dimmed = !inMonth || isPast;
-    const canOpenEmptyDay = shouldOpenEmptyMonthDay(empty, isPast);
+    const canCreatePost = shouldOpenMonthDay(isPast);
 
     const handleActivate = () => {
-        if (canOpenEmptyDay) onEmptyClick();
+        if (canCreatePost) onEmptyClick();
     };
 
     return (
@@ -136,7 +132,7 @@ function DayCell({
             aria-label={`Day ${day.format('YYYY-MM-DD')}`}
             onClick={(e) => {
                 if (
-                    canOpenEmptyDay &&
+                    canCreatePost &&
                     !(e.target as HTMLElement).closest('button')
                 )
                     onEmptyClick();
@@ -152,7 +148,7 @@ function DayCell({
                 'focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none',
                 isPast && 'bg-muted/40',
                 isToday && 'bg-primary/5',
-                canOpenEmptyDay && 'cursor-pointer hover:bg-accent/40',
+                canCreatePost && 'cursor-pointer hover:bg-accent/40',
                 isOver && 'ring-2 ring-primary/60 ring-inset',
             )}
         >
@@ -168,7 +164,7 @@ function DayCell({
                     >
                         {day.date()}
                     </span>
-                    {canOpenEmptyDay && (
+                    {canCreatePost && (
                         <span
                             aria-hidden
                             className="text-[14px] leading-none text-muted-foreground opacity-0 transition-opacity group-hover/day:opacity-60"

--- a/resources/js/components/posts/calendar/month-grid.tsx
+++ b/resources/js/components/posts/calendar/month-grid.tsx
@@ -119,8 +119,12 @@ function DayCell({
     const dimmed = !inMonth || isPast;
     const canCreatePost = shouldOpenMonthDay(isPast);
 
-    const handleActivate = () => {
-        if (canCreatePost) onEmptyClick();
+    // Only the cell itself creates a post — clicks/keys on a nested control
+    // (a post chip, the "+N more" button) must not bubble into create.
+    const createFromCell = (e: { target: EventTarget | null }) => {
+        if (canCreatePost && !(e.target as HTMLElement).closest('button')) {
+            onEmptyClick();
+        }
     };
 
     return (
@@ -130,17 +134,12 @@ function DayCell({
             role="button"
             tabIndex={isPast ? -1 : 0}
             aria-label={`Day ${day.format('YYYY-MM-DD')}`}
-            onClick={(e) => {
-                if (
-                    canCreatePost &&
-                    !(e.target as HTMLElement).closest('button')
-                )
-                    onEmptyClick();
-            }}
+            onClick={createFromCell}
             onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
+                    if ((e.target as HTMLElement).closest('button')) return;
                     e.preventDefault();
-                    handleActivate();
+                    createFromCell(e);
                 }
             }}
             className={cn(

--- a/resources/js/components/posts/calendar/post-chip.tsx
+++ b/resources/js/components/posts/calendar/post-chip.tsx
@@ -70,11 +70,12 @@ export function PostChip({
         : {};
 
     function openPost(e: MouseEvent) {
-        // Ignore the synthetic click dnd fires at the end of a drag.
+        // A chip click must never bubble to the day cell's create-post handler,
+        // including the synthetic click dnd fires at the end of a drag.
+        e.stopPropagation();
         if (isDragging) {
             return;
         }
-        e.stopPropagation();
         router.visit(ComposerController.show(post.id).url);
     }
 


### PR DESCRIPTION
## Summary
- Month View day cells can now be clicked to schedule a new post even if the day already has scheduled posts, matching Week View behavior (closes #154)
- Clicking an existing post chip still opens that post instead of creating a new one
- Renamed `shouldOpenEmptyMonthDay` to `shouldOpenMonthDay`, dropping the "day is empty" requirement so any future/current-month day is clickable
- Agenda list view updated to always show the "Add post" affordance on non-past days, regardless of existing posts
- Added test coverage for clicking a day cell (and its child elements) that already has a post, verifying it doesn't interfere with clicking an existing post


---

Fixes #154