### PR TITLE
fix(api): generate passport keys in-process for octane compatibility

### DIFF
--- a/app/Services/Api/ApiKeyManager.php
+++ b/app/Services/Api/ApiKeyManager.php
@@ -115,6 +115,12 @@ class ApiKeyManager
      * Passport only registers its console commands when runningInConsole(), so
      * under FrankenPHP/Octane the web worker has no `passport:keys` command and
      * `Artisan::call('passport:keys')` throws CommandNotFoundException.
+     *
+     * A partial write would leave a truncated key file on disk that passes the
+     * file_exists() guard above, so the corrupt pair would never be regenerated
+     * and Passport would reject every future token. To avoid that, verify both
+     * writes and delete any partial output before failing loudly. Writes are
+     * already serialized by the surrounding Cache::lock, so no LOCK_EX is needed.
      */
     private function generateEncryptionKeys(): void
     {
@@ -123,8 +129,18 @@ class ApiKeyManager
 
         $key = RSA::createKey(4096);
 
-        file_put_contents($publicKeyPath, (string) $key->getPublicKey());
-        file_put_contents($privateKeyPath, (string) $key);
+        $publicKey = (string) $key->getPublicKey();
+        $privateKey = (string) $key;
+
+        $publicBytes = file_put_contents($publicKeyPath, $publicKey);
+        $privateBytes = file_put_contents($privateKeyPath, $privateKey);
+
+        if ($publicBytes !== strlen($publicKey) || $privateBytes !== strlen($privateKey)) {
+            @unlink($publicKeyPath);
+            @unlink($privateKeyPath);
+
+            throw new RuntimeException('Failed to write Passport encryption keys ('.$privateKeyPath.').');
+        }
 
         if (! windows_os()) {
             chmod($publicKeyPath, 0660);

--- a/app/Services/Api/ApiKeyManager.php
+++ b/app/Services/Api/ApiKeyManager.php
@@ -8,13 +8,13 @@ use App\Models\ApiKey;
 use App\Models\User;
 use App\Models\Workspace;
 use Carbon\CarbonInterface;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use InvalidArgumentException;
 use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
 use Laravel\Passport\Token;
+use phpseclib3\Crypt\RSA;
 use RuntimeException;
 
 class ApiKeyManager
@@ -104,8 +104,32 @@ class ApiKeyManager
                 return;
             }
 
-            Artisan::call('passport:keys', ['--no-interaction' => true]);
+            $this->generateEncryptionKeys();
         });
+    }
+
+    /**
+     * Write a fresh Passport RSA keypair to disk in-process. This mirrors
+     * Passport's `passport:keys` console command exactly (4096-bit key, same
+     * paths and file permissions) without going through the Artisan layer:
+     * Passport only registers its console commands when runningInConsole(), so
+     * under FrankenPHP/Octane the web worker has no `passport:keys` command and
+     * `Artisan::call('passport:keys')` throws CommandNotFoundException.
+     */
+    private function generateEncryptionKeys(): void
+    {
+        $publicKeyPath = Passport::keyPath('oauth-public.key');
+        $privateKeyPath = Passport::keyPath('oauth-private.key');
+
+        $key = RSA::createKey(4096);
+
+        file_put_contents($publicKeyPath, (string) $key->getPublicKey());
+        file_put_contents($privateKeyPath, (string) $key);
+
+        if (! windows_os()) {
+            chmod($publicKeyPath, 0660);
+            chmod($privateKeyPath, 0600);
+        }
     }
 
     /**

--- a/tests/Feature/Api/ApiKeyManagerTest.php
+++ b/tests/Feature/Api/ApiKeyManagerTest.php
@@ -118,6 +118,30 @@ test('issue generates the encryption keypair when none exists and auto-generatio
     }
 });
 
+test('issue generates keys without invoking the passport console command (octane-safe)', function () {
+    // Under FrankenPHP/Octane the web worker is not runningInConsole(), so Passport never
+    // registers its `passport:keys` command there and Artisan::call() would throw. Key
+    // generation must therefore happen in-process, never through the console layer. See #167.
+    $emptyDir = storage_path('framework/testing/passport-keys-'.uniqid());
+    File::ensureDirectoryExists($emptyDir);
+    Passport::loadKeysFrom($emptyDir);
+    config(['passport.auto_generate_keys' => true, 'passport.private_key' => null, 'passport.public_key' => null]);
+
+    try {
+        Artisan::spy();
+
+        [$apiKey] = $this->manager->issue($this->workspace, $this->user, 'octane', 'read', null);
+
+        Artisan::shouldNotHaveReceived('call');
+        expect(file_exists($emptyDir.'/oauth-private.key'))->toBeTrue();
+        expect(file_exists($emptyDir.'/oauth-public.key'))->toBeTrue();
+        expect(Token::find($apiKey->access_token_id))->not->toBeNull();
+    } finally {
+        Passport::loadKeysFrom(storage_path());
+        File::deleteDirectory($emptyDir);
+    }
+});
+
 test('issue does not generate keys and fails loudly when auto-generation is disabled', function () {
     $emptyDir = storage_path('framework/testing/passport-keys-'.uniqid());
     File::ensureDirectoryExists($emptyDir);

--- a/tests/Feature/Api/ApiKeyManagerTest.php
+++ b/tests/Feature/Api/ApiKeyManagerTest.php
@@ -119,23 +119,27 @@ test('issue generates the encryption keypair when none exists and auto-generatio
 });
 
 test('issue generates keys without invoking the passport console command (octane-safe)', function () {
-    // Under FrankenPHP/Octane the web worker is not runningInConsole(), so Passport never
-    // registers its `passport:keys` command there and Artisan::call() would throw. Key
-    // generation must therefore happen in-process, never through the console layer. See #167.
+    // Passport only registers `passport:keys` when runningInConsole(), so under Octane the
+    // web worker must generate the keypair in-process, never via Artisan::call(). See #167.
     $emptyDir = storage_path('framework/testing/passport-keys-'.uniqid());
     File::ensureDirectoryExists($emptyDir);
     Passport::loadKeysFrom($emptyDir);
     config(['passport.auto_generate_keys' => true, 'passport.private_key' => null, 'passport.public_key' => null]);
+    $this->workspace->members()->create(['user_id' => $this->user->id, 'role' => 'admin']);
 
     try {
         Artisan::spy();
 
-        [$apiKey] = $this->manager->issue($this->workspace, $this->user, 'octane', 'read', null);
+        [$apiKey, $plain] = $this->manager->issue($this->workspace, $this->user, 'octane', 'read', null);
 
         Artisan::shouldNotHaveReceived('call');
         expect(file_exists($emptyDir.'/oauth-private.key'))->toBeTrue();
         expect(file_exists($emptyDir.'/oauth-public.key'))->toBeTrue();
         expect(Token::find($apiKey->access_token_id))->not->toBeNull();
+
+        // The generated public key must verify a JWT signed by the generated private key:
+        // authenticate the freshly issued token through the real resource-server guard.
+        $this->withToken($plain)->getJson('/api/v1/connected-accounts')->assertOk();
     } finally {
         Passport::loadKeysFrom(storage_path());
         File::deleteDirectory($emptyDir);


### PR DESCRIPTION
## Summary
- Fixes HTTP 500 when creating the first API key on FrankenPHP/Octane deployments, caused by `Artisan::call('passport:keys')` failing with `CommandNotFoundException` since Passport's console commands aren't registered in the web worker context (fixes #167)
- `ApiKeyManager::ensureEncryptionKeysExist()` now generates the Passport RSA keypair directly in-process (mirroring `passport:keys`), instead of going through Artisan
- Adds a regression test asserting key generation succeeds without invoking the Artisan console layer


---

Fixes #167