### PR TITLE
fix(publishing): treat transient token-refresh errors as retryable

### DIFF
--- a/app/Console/Commands/RefreshExpiringTokens.php
+++ b/app/Console/Commands/RefreshExpiringTokens.php
@@ -7,11 +7,13 @@ namespace App\Console\Commands;
 use App\Enums\ConnectedAccountStatus;
 use App\Enums\Platform;
 use App\Exceptions\TokenRefreshException;
+use App\Exceptions\TransientTokenRefreshException;
 use App\Models\ConnectedAccount;
 use App\Services\Publishing\TokenManager;
 use App\Support\InstanceSettings;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Log;
 
 class RefreshExpiringTokens extends Command
 {
@@ -43,6 +45,13 @@ class RefreshExpiringTokens extends Command
                     // Force the refresh: these accounts are inside the health-check window
                     // but typically still outside the just-in-time skew band.
                     $tokens->fresh($account, force: true);
+                } catch (TransientTokenRefreshException $e) {
+                    // Provider hiccup (429/5xx/timeout). The account is left Active and the
+                    // next sweep retries, so this is expected noise — log it, don't report.
+                    Log::info('Token sweep: transient refresh failure, will retry next run', [
+                        'account_id' => $account->id,
+                        'reason' => $e->getMessage(),
+                    ]);
                 } catch (TokenRefreshException $e) {
                     // TokenManager already flipped the account to needs-attention;
                     // report the swallowed sweep failure so it stays observable.

--- a/app/Exceptions/TransientTokenRefreshException.php
+++ b/app/Exceptions/TransientTokenRefreshException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+/**
+ * A token refresh that failed for a transient reason (provider 429/5xx or a
+ * connection timeout). The account is left Active and untouched so the next
+ * refresh attempt retries; callers should back off rather than flip the
+ * account to needs-attention or report the failure as an error.
+ */
+class TransientTokenRefreshException extends TokenRefreshException {}

--- a/app/Jobs/PublishPostTarget.php
+++ b/app/Jobs/PublishPostTarget.php
@@ -12,6 +12,7 @@ use App\Enums\ErrorKind;
 use App\Enums\Platform;
 use App\Enums\PostTargetStatus;
 use App\Exceptions\TokenRefreshException;
+use App\Exceptions\TransientTokenRefreshException;
 use App\Models\PostMediaPlacement;
 use App\Models\PostTarget;
 use App\Models\PostTargetAttempt;
@@ -167,6 +168,11 @@ class PublishPostTarget implements ShouldQueue
                     $credentials = $tokens->fresh($account, force: true);
                     $result = $connector->publish($this->context($target, $credentials));
                 }
+            } catch (TransientTokenRefreshException $e) {
+                // A transient token-endpoint failure (429/5xx/timeout) is not a bad
+                // credential — treat it as a retryable server error so the publish backs
+                // off and retries instead of flipping the account to needs-attention.
+                $result = PublishResult::failure(ErrorKind::ServerError, $e->getMessage());
             } catch (TokenRefreshException $e) {
                 $result = PublishResult::failure(ErrorKind::AuthExpired, $e->getMessage());
             }

--- a/app/Services/ConnectedAccounts/Threads/ThreadsTokenExchanger.php
+++ b/app/Services/ConnectedAccounts/Threads/ThreadsTokenExchanger.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Services\ConnectedAccounts\Threads;
 
 use App\Exceptions\TokenRefreshException;
+use App\Exceptions\TransientTokenRefreshException;
 use Carbon\CarbonImmutable;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Date;
@@ -47,13 +49,23 @@ class ThreadsTokenExchanger
      */
     public function refresh(string $longToken): array
     {
-        $response = $this->http->get(self::BASE_URL.'/refresh_access_token', [
-            'grant_type' => 'th_refresh_token',
-            'access_token' => $longToken,
-        ]);
+        try {
+            $response = $this->http->get(self::BASE_URL.'/refresh_access_token', [
+                'grant_type' => 'th_refresh_token',
+                'access_token' => $longToken,
+            ]);
+        } catch (ConnectionException $exception) {
+            throw new TransientTokenRefreshException('Threads token refresh failed: '.$exception->getMessage(), previous: $exception);
+        }
 
         if ($response->failed()) {
-            throw new TokenRefreshException('Threads token refresh failed: '.$this->errorDetail($response));
+            $message = 'Threads token refresh failed: '.$this->errorDetail($response);
+
+            if ($response->status() === 429 || $response->status() >= 500) {
+                throw new TransientTokenRefreshException($message);
+            }
+
+            throw new TokenRefreshException($message);
         }
 
         return $this->tokenPayload($response);

--- a/app/Services/Publishing/TokenManager.php
+++ b/app/Services/Publishing/TokenManager.php
@@ -8,6 +8,7 @@ use App\Enums\ConnectedAccountStatus;
 use App\Enums\Platform;
 use App\Enums\UsageCategory;
 use App\Exceptions\TokenRefreshException;
+use App\Exceptions\TransientTokenRefreshException;
 use App\Models\ConnectedAccount;
 use App\Models\ConnectedAccountSecret;
 use App\Services\Atproto\DPoP;
@@ -15,6 +16,7 @@ use App\Services\ConnectedAccounts\Threads\ThreadsTokenExchanger;
 use App\Services\Usage\Concerns\TracksUsage;
 use App\Support\UsageOperation;
 use Illuminate\Contracts\Cache\LockTimeoutException;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Cache;
@@ -26,6 +28,16 @@ class TokenManager
     use TracksUsage;
 
     private const int SKEW_SECONDS = 120;
+
+    /**
+     * Lease held while refreshing a single account. Single-use refresh tokens
+     * (X, Bluesky) rotate on every call, so a refresh that loses the lock
+     * mid-flight lets a second worker rotate concurrently and replay the
+     * consumed token. The lease must comfortably exceed one refresh — two 10s
+     * HTTP timeouts (the request plus the DPoP-nonce retry) plus metering and
+     * DB writes under load — so it never expires while a holder is still working.
+     */
+    private const int REFRESH_LOCK_SECONDS = 120;
 
     private const string BLUESKY_DEFAULT_PDS = 'https://bsky.social';
 
@@ -80,7 +92,7 @@ class TokenManager
             return ['access_token' => $secret->access_token];
         }
 
-        return Cache::lock("connected-account-token-refresh:{$account->id}", 60)
+        return Cache::lock("connected-account-token-refresh:{$account->id}", self::REFRESH_LOCK_SECONDS)
             ->block(10, function () use ($account, $force): array {
                 $freshAccount = $account->newQueryWithoutScopes()->findOrFail($account->id);
                 $freshSecret = $freshAccount->secret()->firstOrFail();
@@ -118,7 +130,7 @@ class TokenManager
         // one and 400s with invalid_grant, flipping the account to needs-attention.
         // Serialize per account and re-read the rotated state under the lock, exactly
         // as the generic OAuth path below does.
-        return Cache::lock("connected-account-token-refresh:{$account->id}", 60)
+        return Cache::lock("connected-account-token-refresh:{$account->id}", self::REFRESH_LOCK_SECONDS)
             ->block(10, function () use ($account, $force): array {
                 $freshAccount = $account->newQueryWithoutScopes()->findOrFail($account->id);
                 $freshSecret = $freshAccount->secret()->firstOrFail();
@@ -144,7 +156,7 @@ class TokenManager
             return ['access_token' => $secret->access_token];
         }
 
-        return Cache::lock("connected-account-token-refresh:{$account->id}", 60)
+        return Cache::lock("connected-account-token-refresh:{$account->id}", self::REFRESH_LOCK_SECONDS)
             ->block(10, function () use ($account, $force): array {
                 $freshAccount = $account->newQueryWithoutScopes()->findOrFail($account->id);
                 $freshSecret = $freshAccount->secret()->firstOrFail();
@@ -214,7 +226,7 @@ class TokenManager
     private function blueskyCredentials(ConnectedAccount $account): array
     {
         try {
-            return Cache::lock("connected-account-token-refresh:{$account->id}", 60)
+            return Cache::lock("connected-account-token-refresh:{$account->id}", self::REFRESH_LOCK_SECONDS)
                 ->block(10, function () use ($account): array {
                     $freshAccount = $account->newQueryWithoutScopes()->findOrFail($account->id);
                     $freshSecret = $freshAccount->secret()->firstOrFail();
@@ -394,23 +406,45 @@ class TokenManager
             $body['client_secret'] = $clientSecret;
         }
 
-        $response = $request->post((string) $endpoint, $body);
+        try {
+            $response = $request->post((string) $endpoint, $body);
 
-        if ($response->failed() && $account->platform === Platform::Bluesky) {
-            $nonce = $response->header('DPoP-Nonce');
-            if ($nonce !== '') {
-                if ($usesAssertion) {
-                    $body['client_assertion'] = $this->dpop->clientAssertion($issuer, $this->dpop->signingKey(), $clientId);
+            // Retry ONLY the DPoP nonce handshake: atproto answers the first token
+            // request with 400 use_dpop_nonce and a server nonce, and does NOT consume
+            // the refresh token on that response, so re-POSTing it is safe. Retrying on
+            // any other failure would risk re-submitting a single-use token the server
+            // may already have rotated, producing a "Refresh token replayed" error.
+            if ($response->failed() && $account->platform === Platform::Bluesky
+                && $response->json('error') === 'use_dpop_nonce') {
+                $nonce = $response->header('DPoP-Nonce');
+                if ($nonce !== '') {
+                    if ($usesAssertion) {
+                        $body['client_assertion'] = $this->dpop->clientAssertion($issuer, $this->dpop->signingKey(), $clientId);
+                    }
+                    $response = $this->http->asForm()->timeout(10)->connectTimeout(5)
+                        ->withHeader('DPoP', $this->dpop->proof('POST', $endpoint, $key, nonce: $nonce))
+                        ->post((string) $endpoint, $body);
                 }
-                $response = $this->http->asForm()->timeout(10)->connectTimeout(5)
-                    ->withHeader('DPoP', $this->dpop->proof('POST', $endpoint, $key, nonce: $nonce))
-                    ->post((string) $endpoint, $body);
             }
+        } catch (ConnectionException $exception) {
+            // A timeout/connection failure is a transient provider issue, not a bad
+            // token. Leave the account Active so the next sweep retries, and signal the
+            // caller to back off rather than flip it to needs-attention or report an
+            // error. (Uncaught, this would also abort the sweep's whole each() loop.)
+            throw new TransientTokenRefreshException("Token refresh failed for account {$account->id}.", previous: $exception);
         }
 
-        $this->meter(UsageCategory::ExternalApi, UsageOperation::TOKEN_REFRESH, $account, $response);
-
         if ($response->failed()) {
+            $this->meter(UsageCategory::ExternalApi, UsageOperation::TOKEN_REFRESH, $account, $response);
+
+            if ($this->isTransientStatus($response->status())) {
+                // Provider hiccup (429/5xx). The stored token is still valid — the sweep
+                // refreshes up to 6h ahead of expiry — so keep the account Active and let
+                // the next attempt retry instead of flipping it to needs-attention and
+                // spamming Sentry for a failure that self-heals.
+                throw new TransientTokenRefreshException("Token refresh failed for account {$account->id}.");
+            }
+
             $account->forceFill([
                 'status' => ConnectedAccountStatus::NeedsAttention->value,
                 'refresh_failed_at' => Date::now(),
@@ -424,6 +458,11 @@ class TokenManager
         $refreshToken = $response->json('refresh_token') ?? $secret->refresh_token;
         $expiresIn = (int) ($response->json('expires_in') ?? 0);
 
+        // The auth server has now consumed and rotated the single-use refresh token.
+        // Persist the rotated token FIRST — before metering or the status update — so an
+        // interruption in this window (deploy/SIGTERM, OOM, worker timeout) cannot strand
+        // the new token and force the next refresh to POST the consumed one, which the
+        // server rejects with "Refresh token replayed".
         $secret->forceFill([
             'access_token' => $accessToken,
             'refresh_token' => $refreshToken,
@@ -439,6 +478,8 @@ class TokenManager
             'refresh_failed_at' => null,
             'refresh_failure_reason' => null,
         ])->save();
+
+        $this->meter(UsageCategory::ExternalApi, UsageOperation::TOKEN_REFRESH, $account, $response);
 
         return $account->platform === Platform::Bluesky
             ? $this->blueskyOAuthPayload($secret->refresh())
@@ -459,6 +500,17 @@ class TokenManager
                 'accessJwt' => $secret->access_token,
             ],
         ];
+    }
+
+    /**
+     * A refresh failure is transient — worth retrying without flipping the account —
+     * when the token endpoint rate-limits (429) or returns a server error (5xx).
+     * Auth failures (400 invalid_grant, 401 invalid_client, 403) are permanent and
+     * require the user to reconnect. Mirrors the connectors' MapsHttpErrors trait.
+     */
+    private function isTransientStatus(int $status): bool
+    {
+        return $status === 429 || $status >= 500;
     }
 
     private function refreshFailureReason(Response $response): string

--- a/app/Services/Publishing/TokenManager.php
+++ b/app/Services/Publishing/TokenManager.php
@@ -176,6 +176,8 @@ class TokenManager
     {
         try {
             $refreshed = $this->threadsExchanger->refresh((string) $secret->access_token);
+        } catch (TransientTokenRefreshException $exception) {
+            throw $exception;
         } catch (Throwable $exception) {
             $account->forceFill([
                 'status' => ConnectedAccountStatus::NeedsAttention->value,
@@ -254,8 +256,12 @@ class TokenManager
         $session = $secret->session ?? [];
         $pds = (string) ($session['pds'] ?? self::BLUESKY_DEFAULT_PDS);
 
-        $tokens = $this->refreshBlueskySession($pds, (string) ($session['refreshJwt'] ?? ''), $account)
-            ?? $this->createBlueskySession($pds, (string) $account->remote_account_id, (string) $secret->app_password, $account);
+        try {
+            $tokens = $this->refreshBlueskySession($pds, (string) ($session['refreshJwt'] ?? ''), $account)
+                ?? $this->createBlueskySession($pds, (string) $account->remote_account_id, (string) $secret->app_password, $account);
+        } catch (ConnectionException $exception) {
+            throw new TransientTokenRefreshException("Token refresh failed for account {$account->id}.", previous: $exception);
+        }
 
         if ($tokens === null) {
             $account->forceFill([
@@ -300,6 +306,10 @@ class TokenManager
 
         $this->meter(UsageCategory::ExternalApi, UsageOperation::TOKEN_REFRESH, $account, $response);
 
+        if ($this->isTransientStatus($response->status())) {
+            throw new TransientTokenRefreshException("Token refresh failed for account {$account->id}.");
+        }
+
         return $this->blueskyTokens($response);
     }
 
@@ -322,6 +332,10 @@ class TokenManager
             ]);
 
         $this->meter(UsageCategory::ExternalApi, UsageOperation::TOKEN_REFRESH, $account, $response);
+
+        if ($this->isTransientStatus($response->status())) {
+            throw new TransientTokenRefreshException("Token refresh failed for account {$account->id}.");
+        }
 
         return $this->blueskyTokens($response);
     }

--- a/tests/Feature/Publishing/PublishPostTargetTest.php
+++ b/tests/Feature/Publishing/PublishPostTargetTest.php
@@ -210,6 +210,33 @@ test('auth expired after the recovery refresh marks the target failed without re
     Bus::assertNotDispatched(PublishPostTarget::class);
 });
 
+test('a transient refresh failure retries the publish without flipping the account', function () {
+    Bus::fake();
+    $target = publishTarget();
+    $target->account()->firstOrFail()->secret()->firstOrFail()->forceFill([
+        'refresh_token' => 'refresh-old',
+    ])->save();
+    Http::fake([
+        'https://api.twitter.com/2/oauth2/token' => Http::response([], 503),
+    ]);
+    bindConnector(PublishResult::failure(ErrorKind::AuthExpired, 'Unauthorized', 401));
+
+    (new PublishPostTarget($target))->handle(
+        app(PublishConnectorRegistry::class),
+        app(TokenManager::class),
+        app(PostStatusRollup::class),
+        app(BackoffSchedule::class),
+    );
+
+    $target->refresh();
+    expect($target->status)->toBe(PostTargetStatus::Publishing)
+        ->and($target->error_kind)->toBe(ErrorKind::ServerError)
+        ->and($target->next_attempt_at)->not->toBeNull();
+    expect($target->account()->firstOrFail()->status)->toBe(ConnectedAccountStatus::Active);
+
+    Bus::assertDispatched(PublishPostTarget::class);
+});
+
 test('retry stops after five attempts', function () {
     Bus::fake();
     $target = publishTarget();

--- a/tests/Feature/Publishing/RefreshExpiringTokensTest.php
+++ b/tests/Feature/Publishing/RefreshExpiringTokensTest.php
@@ -81,21 +81,20 @@ test('a connection timeout keeps the account active and does not abort the sweep
         'platform' => Platform::X->value,
         'token_expires_at' => now()->addMinutes(5),
     ]);
-    ConnectedAccountSecret::factory()->create(['connected_account_id' => $failing->id, 'refresh_token' => 'r']);
+    ConnectedAccountSecret::factory()->create(['connected_account_id' => $failing->id, 'refresh_token' => 'timeout-token']);
 
     $healthy = ConnectedAccount::factory()->create([
         'platform' => Platform::X->value,
         'token_expires_at' => now()->addMinutes(10),
     ]);
-    ConnectedAccountSecret::factory()->create(['connected_account_id' => $healthy->id, 'refresh_token' => 'r']);
+    ConnectedAccountSecret::factory()->create(['connected_account_id' => $healthy->id, 'refresh_token' => 'healthy-token']);
 
-    $calls = 0;
-    Http::fake(['https://api.twitter.com/2/oauth2/token' => function () use (&$calls) {
-        $calls++;
+    Http::fake(['https://api.twitter.com/2/oauth2/token' => function ($request) {
+        if ($request['refresh_token'] === 'timeout-token') {
+            throw new ConnectionException('cURL error 28: Operation timed out');
+        }
 
-        return $calls === 1
-            ? throw new ConnectionException('cURL error 28: Operation timed out')
-            : Http::response(['access_token' => 'fresh', 'expires_in' => 7200]);
+        return Http::response(['access_token' => 'fresh', 'expires_in' => 7200]);
     }]);
 
     $this->artisan('accounts:refresh-tokens')->assertExitCode(0);

--- a/tests/Feature/Publishing/RefreshExpiringTokensTest.php
+++ b/tests/Feature/Publishing/RefreshExpiringTokensTest.php
@@ -5,6 +5,7 @@ use App\Enums\Platform;
 use App\Models\ConnectedAccount;
 use App\Models\ConnectedAccountSecret;
 use App\Services\Atproto\DPoP;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 
 test('it proactively refreshes accounts expiring within six hours', function () {
@@ -42,6 +43,66 @@ test('it flips status to needs attention on refresh failure and keeps going', fu
     expect($account->fresh()->status)->toBe(ConnectedAccountStatus::NeedsAttention)
         ->and($account->fresh()->refresh_failed_at)->not->toBeNull()
         ->and($account->fresh()->refresh_failure_reason)->toContain('400');
+});
+
+test('it keeps the account active on a transient 503 without reporting', function () {
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::X->value,
+        'token_expires_at' => now()->addMinutes(5),
+    ]);
+    ConnectedAccountSecret::factory()->create(['connected_account_id' => $account->id, 'refresh_token' => 'r']);
+
+    Http::fake(['https://api.twitter.com/2/oauth2/token' => Http::response([], 503)]);
+
+    $this->artisan('accounts:refresh-tokens')->assertExitCode(0);
+
+    expect($account->fresh()->status)->toBe(ConnectedAccountStatus::Active)
+        ->and($account->fresh()->refresh_failed_at)->toBeNull()
+        ->and($account->fresh()->refresh_failure_reason)->toBeNull();
+});
+
+test('it keeps the account active on a transient 429 without reporting', function () {
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::X->value,
+        'token_expires_at' => now()->addMinutes(5),
+    ]);
+    ConnectedAccountSecret::factory()->create(['connected_account_id' => $account->id, 'refresh_token' => 'r']);
+
+    Http::fake(['https://api.twitter.com/2/oauth2/token' => Http::response([], 429)]);
+
+    $this->artisan('accounts:refresh-tokens')->assertExitCode(0);
+
+    expect($account->fresh()->status)->toBe(ConnectedAccountStatus::Active)
+        ->and($account->fresh()->refresh_failed_at)->toBeNull();
+});
+
+test('a connection timeout keeps the account active and does not abort the sweep', function () {
+    $failing = ConnectedAccount::factory()->create([
+        'platform' => Platform::X->value,
+        'token_expires_at' => now()->addMinutes(5),
+    ]);
+    ConnectedAccountSecret::factory()->create(['connected_account_id' => $failing->id, 'refresh_token' => 'r']);
+
+    $healthy = ConnectedAccount::factory()->create([
+        'platform' => Platform::X->value,
+        'token_expires_at' => now()->addMinutes(10),
+    ]);
+    ConnectedAccountSecret::factory()->create(['connected_account_id' => $healthy->id, 'refresh_token' => 'r']);
+
+    $calls = 0;
+    Http::fake(['https://api.twitter.com/2/oauth2/token' => function () use (&$calls) {
+        $calls++;
+
+        return $calls === 1
+            ? throw new ConnectionException('cURL error 28: Operation timed out')
+            : Http::response(['access_token' => 'fresh', 'expires_in' => 7200]);
+    }]);
+
+    $this->artisan('accounts:refresh-tokens')->assertExitCode(0);
+
+    expect($failing->fresh()->status)->toBe(ConnectedAccountStatus::Active)
+        ->and($failing->fresh()->refresh_failed_at)->toBeNull()
+        ->and($healthy->fresh()->secret->access_token)->toBe('fresh');
 });
 
 test('it skips accounts that expire outside the proactive refresh window', function () {

--- a/tests/Feature/Publishing/TokenManagerTest.php
+++ b/tests/Feature/Publishing/TokenManagerTest.php
@@ -270,7 +270,7 @@ test('bluesky app-password refresh serializes under the per-account lock', funct
         ->with(10, Mockery::type('Closure'))
         ->andReturnUsing(fn (int $seconds, Closure $callback) => $callback());
     Cache::partialMock()->shouldReceive('lock')->once()
-        ->with("connected-account-token-refresh:{$account->id}", 60)
+        ->with("connected-account-token-refresh:{$account->id}", 120)
         ->andReturn($lock);
 
     $creds = app(TokenManager::class)->fresh($account->fresh());
@@ -313,7 +313,7 @@ test('fresh re-reads the rotated bluesky session under the lock before refreshin
             return $callback();
         });
     Cache::partialMock()->shouldReceive('lock')->once()
-        ->with("connected-account-token-refresh:{$account->id}", 60)
+        ->with("connected-account-token-refresh:{$account->id}", 120)
         ->andReturn($lock);
 
     app(TokenManager::class)->fresh($staleAccount);

--- a/tests/Feature/Publishing/TokenManagerTest.php
+++ b/tests/Feature/Publishing/TokenManagerTest.php
@@ -3,10 +3,12 @@
 use App\Enums\ConnectedAccountStatus;
 use App\Enums\Platform;
 use App\Exceptions\TokenRefreshException;
+use App\Exceptions\TransientTokenRefreshException;
 use App\Models\ConnectedAccount;
 use App\Models\ConnectedAccountSecret;
 use App\Services\Publishing\TokenManager;
 use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
@@ -382,6 +384,44 @@ test('fresh refreshes a threads token via refresh_access_token and persists the 
         ->and($account->token_expires_at->diffInDays(now(), true))->toBeGreaterThan(59);
 });
 
+test('fresh leaves a threads account active on a transient HTTP refresh failure', function (int $status) {
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::Threads->value,
+        'token_expires_at' => now()->subMinute(),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'access_token' => 'stale-long-token',
+    ]);
+
+    Http::fake(['https://graph.threads.net/refresh_access_token*' => Http::response([], $status)]);
+
+    expect(fn () => app(TokenManager::class)->fresh($account->fresh()))
+        ->toThrow(TransientTokenRefreshException::class);
+
+    expect($account->fresh()->status)->toBe(ConnectedAccountStatus::Active)
+        ->and($account->fresh()->refresh_failed_at)->toBeNull();
+})->with([429, 503]);
+
+test('fresh leaves a threads account active on a refresh connection failure', function () {
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::Threads->value,
+        'token_expires_at' => now()->subMinute(),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'access_token' => 'stale-long-token',
+    ]);
+
+    Http::fake(['https://graph.threads.net/refresh_access_token*' => fn () => throw new ConnectionException('Timed out')]);
+
+    expect(fn () => app(TokenManager::class)->fresh($account->fresh()))
+        ->toThrow(TransientTokenRefreshException::class);
+
+    expect($account->fresh()->status)->toBe(ConnectedAccountStatus::Active)
+        ->and($account->fresh()->refresh_failed_at)->toBeNull();
+});
+
 test('fresh does not refresh a threads token that is not near expiry', function () {
     $account = ConnectedAccount::factory()->create([
         'platform' => Platform::Threads->value,
@@ -416,6 +456,71 @@ test('fresh flips a threads account to needs-attention and throws on refresh fai
         ->toThrow(TokenRefreshException::class);
 
     expect($account->fresh()->status)->toBe(ConnectedAccountStatus::NeedsAttention);
+});
+
+test('fresh leaves a bluesky app-password account active on a transient refresh failure', function (int $status) {
+    $account = ConnectedAccount::factory()->bluesky()->create([
+        'remote_account_id' => 'did:plc:abc123',
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'app_password' => 'app-pass',
+        'session' => ['accessJwt' => 'stale-jwt', 'refreshJwt' => 'refresh-jwt', 'pds' => 'https://bsky.social'],
+    ]);
+
+    Http::fake([
+        'https://bsky.social/xrpc/com.atproto.server.refreshSession' => Http::response([], $status),
+    ]);
+
+    expect(fn () => app(TokenManager::class)->fresh($account->fresh()))
+        ->toThrow(TransientTokenRefreshException::class);
+
+    expect($account->fresh()->status)->toBe(ConnectedAccountStatus::Active)
+        ->and($account->fresh()->refresh_failed_at)->toBeNull();
+    Http::assertSentCount(1);
+})->with([429, 503]);
+
+test('fresh leaves a bluesky app-password account active when refresh connection fails', function () {
+    $account = ConnectedAccount::factory()->bluesky()->create([
+        'remote_account_id' => 'did:plc:abc123',
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'app_password' => 'app-pass',
+        'session' => ['accessJwt' => 'stale-jwt', 'refreshJwt' => 'refresh-jwt', 'pds' => 'https://bsky.social'],
+    ]);
+
+    Http::fake([
+        'https://bsky.social/xrpc/com.atproto.server.refreshSession' => fn () => throw new ConnectionException('Timed out'),
+    ]);
+
+    expect(fn () => app(TokenManager::class)->fresh($account->fresh()))
+        ->toThrow(TransientTokenRefreshException::class);
+
+    expect($account->fresh()->status)->toBe(ConnectedAccountStatus::Active)
+        ->and($account->fresh()->refresh_failed_at)->toBeNull();
+});
+
+test('fresh leaves a bluesky app-password account active when fallback login fails transiently', function () {
+    $account = ConnectedAccount::factory()->bluesky()->create([
+        'remote_account_id' => 'did:plc:abc123',
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'app_password' => 'app-pass',
+        'session' => ['accessJwt' => 'stale-jwt', 'refreshJwt' => 'expired-rjwt', 'pds' => 'https://bsky.social'],
+    ]);
+
+    Http::fake([
+        'https://bsky.social/xrpc/com.atproto.server.refreshSession' => Http::response([], 400),
+        'https://bsky.social/xrpc/com.atproto.server.createSession' => Http::response([], 503),
+    ]);
+
+    expect(fn () => app(TokenManager::class)->fresh($account->fresh()))
+        ->toThrow(TransientTokenRefreshException::class);
+
+    expect($account->fresh()->status)->toBe(ConnectedAccountStatus::Active)
+        ->and($account->fresh()->refresh_failed_at)->toBeNull();
 });
 
 test('fresh flags the bluesky account for attention when both refresh and login fail', function () {

--- a/tests/Unit/Publishing/TokenManagerTest.php
+++ b/tests/Unit/Publishing/TokenManagerTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\ConnectedAccountStatus;
 use App\Enums\Platform;
+use App\Exceptions\TokenRefreshException;
 use App\Models\ConnectedAccount;
 use App\Models\ConnectedAccountSecret;
 use App\Services\Atproto\DPoP;
@@ -188,6 +189,80 @@ it('refreshes a bluesky app-password session under the lock and returns the rota
 
     Http::assertSent(fn (Request $request): bool => $request->hasHeader('Authorization', 'Bearer stale-refresh')
         && str_ends_with($request->url(), '/xrpc/com.atproto.server.refreshSession'));
+});
+
+it('retries the bluesky refresh once to complete the dpop nonce handshake', function () {
+    $key = app(DPoP::class)->generateKey();
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::Bluesky->value,
+        'auth_method' => 'oauth',
+        'token_expires_at' => now()->subMinute(),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'access_token' => 'old-access',
+        'refresh_token' => 'old-refresh',
+        'session' => [
+            'token_endpoint' => 'https://auth.example/oauth/token',
+            'client_id' => 'https://app.example/oauth/bluesky/client-metadata.json',
+            'dpop_private_jwk' => $key,
+        ],
+    ]);
+
+    // atproto answers the first token request with 400 use_dpop_nonce and a server
+    // nonce, WITHOUT consuming the refresh token, then accepts the re-POST.
+    Http::fake([
+        'https://auth.example/oauth/token' => Http::sequence()
+            ->push(['error' => 'use_dpop_nonce'], 400, ['DPoP-Nonce' => 'server-nonce'])
+            ->push(['access_token' => 'new-access', 'refresh_token' => 'new-refresh', 'expires_in' => 3600], 200, ['DPoP-Nonce' => 'final-nonce']),
+    ]);
+
+    $credentials = app(TokenManager::class)->fresh($account);
+
+    expect($credentials['session']['accessJwt'])->toBe('new-access')
+        ->and($account->secret->refresh()->refresh_token)->toBe('new-refresh')
+        ->and($account->fresh()->status)->toBe(ConnectedAccountStatus::Active);
+
+    Http::assertSentCount(2);
+});
+
+it('does not re-send a bluesky refresh token when the failure is not a nonce challenge', function () {
+    // Regression for "Refresh token replayed": retrying on any failure could re-POST a
+    // single-use token the server already rotated. Only the use_dpop_nonce handshake is
+    // safe to retry; a genuine rejection must flip the account and stop, not re-send.
+    $key = app(DPoP::class)->generateKey();
+    $account = ConnectedAccount::factory()->create([
+        'platform' => Platform::Bluesky->value,
+        'auth_method' => 'oauth',
+        'token_expires_at' => now()->subMinute(),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'access_token' => 'old-access',
+        'refresh_token' => 'old-refresh',
+        'session' => [
+            'token_endpoint' => 'https://auth.example/oauth/token',
+            'client_id' => 'https://app.example/oauth/bluesky/client-metadata.json',
+            'dpop_private_jwk' => $key,
+            'dpop_nonce' => 'old-nonce',
+        ],
+    ]);
+
+    // A real rejection that still carries a DPoP-Nonce header — the old code would have
+    // re-POSTed the token on the strength of that header alone.
+    Http::fake([
+        'https://auth.example/oauth/token' => Http::response(
+            ['error' => 'invalid_grant', 'error_description' => 'Refresh token replayed'],
+            400,
+            ['DPoP-Nonce' => 'server-nonce'],
+        ),
+    ]);
+
+    expect(fn () => app(TokenManager::class)->fresh($account))->toThrow(TokenRefreshException::class);
+
+    Http::assertSentCount(1);
+    expect($account->fresh()->status)->toBe(ConnectedAccountStatus::NeedsAttention)
+        ->and($account->fresh()->refresh_failure_reason)->toContain('Refresh token replayed');
 });
 
 it('falls back to the persisted bluesky session when the refresh lock times out', function () {


### PR DESCRIPTION
## Summary
- Add `TransientTokenRefreshException` for token-refresh failures caused by provider hiccups (429/5xx or connection timeouts) instead of bad credentials
- `RefreshExpiringTokens` sweep now logs transient failures and retries next run instead of flipping the account to needs-attention and reporting to Sentry
- `PublishPostTarget` maps a transient refresh failure to a retryable server error so the publish job backs off and retries rather than marking the account as needing reconnection
- `TokenManager` only retries the Bluesky DPoP-nonce handshake on the specific `use_dpop_nonce` response (previously retried on any failed response with a `DPoP-Nonce` header, risking replay of a single-use refresh token)
- Persist the rotated refresh token before metering/status updates so an interrupted worker can't strand a consumed single-use token
- Increase the per-account refresh lock from 60s to 120s to comfortably cover worst-case refresh latency (request + nonce retry + metering/DB writes)
