### PR TITLE
fix(publishing): stop over-rotating bluesky single-use refresh tokens

### DIFF
--- a/app/Console/Commands/RefreshExpiringTokens.php
+++ b/app/Console/Commands/RefreshExpiringTokens.php
@@ -30,13 +30,9 @@ class RefreshExpiringTokens extends Command
         ConnectedAccount::query()
             ->withoutGlobalScopes()
             ->whereIn('platform', $availablePlatforms)
-            ->where(function ($query): void {
-                $query->where('platform', '!=', Platform::Bluesky->value)
-                    ->orWhere(function ($query): void {
-                        $query->where('platform', Platform::Bluesky->value)
-                            ->where('auth_method', 'oauth');
-                    });
-            })
+            // Exclude Bluesky: its single-use tokens + ~15-30 min access tokens would
+            // rotate on every sweep. The just-in-time path refreshes it when needed.
+            ->where('platform', '!=', Platform::Bluesky->value)
             ->where('status', ConnectedAccountStatus::Active->value)
             ->whereNotNull('token_expires_at')
             ->where('token_expires_at', '<=', Date::now()->addHours(6))

--- a/app/Services/Publishing/TokenManager.php
+++ b/app/Services/Publishing/TokenManager.php
@@ -39,6 +39,10 @@ class TokenManager
      */
     private const int REFRESH_LOCK_SECONDS = 120;
 
+    // Skip a Bluesky refresh if we rotated the single-use token within this window.
+    // Keeps a burst of pollers from each rotating again; 600s ≪ the accessJwt life.
+    private const int BLUESKY_REFRESH_MIN_INTERVAL_SECONDS = 600;
+
     private const string BLUESKY_DEFAULT_PDS = 'https://bsky.social';
 
     public function __construct(
@@ -59,7 +63,7 @@ class TokenManager
         $secret = $account->secret()->firstOrFail();
 
         if ($account->platform === Platform::Bluesky && $account->auth_method === 'app_password') {
-            return $this->blueskyCredentials($account);
+            return $this->blueskyCredentials($account, $force);
         }
 
         if ($account->platform === Platform::Bluesky && $account->auth_method === 'oauth') {
@@ -112,6 +116,12 @@ class TokenManager
         }
 
         return $account->token_expires_at->lte(Date::now()->addSeconds(self::SKEW_SECONDS));
+    }
+
+    private function refreshedRecently(ConnectedAccount $account): bool
+    {
+        return $account->last_refreshed_at !== null
+            && $account->last_refreshed_at->gt(Date::now()->subSeconds(self::BLUESKY_REFRESH_MIN_INTERVAL_SECONDS));
     }
 
     /**
@@ -216,22 +226,30 @@ class TokenManager
      * churn hammers Bluesky's login rate limit until the account flips to
      * needs-attention. ATProto's guidance is to serialize refreshes per session
      * (see the XRPC spec and bluesky-social/atproto#3637); do so per account and
-     * re-read the rotated session under the lock. We refresh unconditionally rather
-     * than skipping while "still valid": the tokens are opaque per spec (their JWT
-     * fields "are not a stable part of the specification"), there is no
-     * server-provided expiry to gate on as the OAuth path has, and the spec expects
-     * a new access JWT to be fetched freely — refreshSession is cheap and, unlike
-     * createSession, not the rate-limited endpoint.
+     * re-read the rotated session under the lock. Tokens are opaque per spec, so we
+     * gate the refresh on our own last_refreshed_at, not the accessJwt's expiry;
+     * `force` (the publish's post-401 retry) skips that floor.
      *
      * @return array<string, mixed>
      */
-    private function blueskyCredentials(ConnectedAccount $account): array
+    private function blueskyCredentials(ConnectedAccount $account, bool $force): array
     {
+        if (! $force && $this->refreshedRecently($account)) {
+            $secret = $account->secret()->firstOrFail();
+
+            return ['session' => $secret->session ?? [], 'app_password' => $secret->app_password];
+        }
+
         try {
             return Cache::lock("connected-account-token-refresh:{$account->id}", self::REFRESH_LOCK_SECONDS)
-                ->block(10, function () use ($account): array {
+                ->block(10, function () use ($account, $force): array {
                     $freshAccount = $account->newQueryWithoutScopes()->findOrFail($account->id);
                     $freshSecret = $freshAccount->secret()->firstOrFail();
+
+                    // Re-check under the lock: the winner rotated, so everyone else reuses it.
+                    if (! $force && $this->refreshedRecently($freshAccount)) {
+                        return ['session' => $freshSecret->session ?? [], 'app_password' => $freshSecret->app_password];
+                    }
 
                     return $this->refreshBlueskyCredentials($freshAccount, $freshSecret);
                 });

--- a/tests/Feature/Publishing/RefreshExpiringTokensTest.php
+++ b/tests/Feature/Publishing/RefreshExpiringTokensTest.php
@@ -122,7 +122,8 @@ test('it skips accounts that expire outside the proactive refresh window', funct
     Http::assertNothingSent();
 });
 
-test('it proactively refreshes expiring bluesky oauth accounts', function () {
+test('it does not proactively rotate bluesky oauth accounts', function () {
+    // Bluesky is excluded from the sweep; the JIT path rotates its single-use token.
     $key = app(DPoP::class)->generateKey();
     $account = ConnectedAccount::factory()->create([
         'platform' => Platform::Bluesky->value,
@@ -150,15 +151,11 @@ test('it proactively refreshes expiring bluesky oauth accounts', function () {
 
     $this->artisan('accounts:refresh-tokens')->assertExitCode(0);
 
+    // The single-use token is left untouched — no rotation request was sent.
+    Http::assertNothingSent();
     $account->refresh();
-    expect($account->secret->access_token)->toBe('fresh-access')
-        ->and($account->secret->refresh_token)->toBe('fresh-refresh')
-        ->and($account->secret->session['dpop_nonce'])->toBe('fresh-nonce')
-        ->and($account->refresh_failed_at)->toBeNull();
-
-    Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.bsky.test/oauth/token'
-        && $request->hasHeader('DPoP')
-        && $request['grant_type'] === 'refresh_token');
+    expect($account->secret->access_token)->toBe('old-access')
+        ->and($account->secret->refresh_token)->toBe('old-refresh');
 });
 
 test('token refresh health check is scheduled every fifteen minutes', function () {

--- a/tests/Feature/Publishing/TokenManagerTest.php
+++ b/tests/Feature/Publishing/TokenManagerTest.php
@@ -354,6 +354,52 @@ test('fresh falls back to an app-password login when the refresh token has lapse
         && $request['password'] === 'app-pass');
 });
 
+test('fresh reuses a recently refreshed bluesky session instead of rotating again', function () {
+    // The interval floor stops a burst of pollers each rotating the single-use token.
+    $account = ConnectedAccount::factory()->bluesky()->create([
+        'token_expires_at' => null,
+        'last_refreshed_at' => now()->subMinute(),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'app_password' => 'app-pass',
+        'session' => ['accessJwt' => 'current-jwt', 'refreshJwt' => 'rjwt', 'pds' => 'https://bsky.social'],
+    ]);
+
+    Http::fake();
+
+    $creds = app(TokenManager::class)->fresh($account->fresh());
+
+    expect($creds['session']['accessJwt'])->toBe('current-jwt')
+        ->and($creds['app_password'])->toBe('app-pass');
+    Http::assertNothingSent();
+});
+
+test('fresh forces a bluesky refresh past the interval floor when the publish retries', function () {
+    // The publish retry after a 401 must bypass the floor, not reuse the rejected session.
+    $account = ConnectedAccount::factory()->bluesky()->create([
+        'token_expires_at' => null,
+        'last_refreshed_at' => now()->subMinute(),
+    ]);
+    ConnectedAccountSecret::factory()->create([
+        'connected_account_id' => $account->id,
+        'app_password' => 'app-pass',
+        'session' => ['accessJwt' => 'stale-jwt', 'refreshJwt' => 'rjwt', 'pds' => 'https://bsky.social'],
+    ]);
+
+    Http::fake([
+        'https://bsky.social/xrpc/com.atproto.server.refreshSession' => Http::response([
+            'accessJwt' => 'fresh-jwt',
+            'refreshJwt' => 'fresh-rjwt',
+        ]),
+    ]);
+
+    $creds = app(TokenManager::class)->fresh($account->fresh(), force: true);
+
+    expect($creds['session']['accessJwt'])->toBe('fresh-jwt');
+    Http::assertSent(fn ($request) => $request->url() === 'https://bsky.social/xrpc/com.atproto.server.refreshSession');
+});
+
 test('fresh refreshes a threads token via refresh_access_token and persists the new expiry', function () {
     $account = ConnectedAccount::factory()->create([
         'platform' => Platform::Threads->value,


### PR DESCRIPTION
## Problem

Bluesky accounts kept flipping to **needs_attention** (manual reconnect) — on **OAuth and app_password**, even after #158 (lock) and #173 (transient handling).

Root cause: **over-rotation of single-use refresh tokens.** atproto OAuth access tokens live only ~15-30 min, so `needsRefresh()` trips almost constantly. Up to five jobs per 15-min tick call `TokenManager::fresh()` on the same account — publish, `CaptureAccountMetrics`, `FetchAccountReplies`, `FetchAccountMessages` (DM inbox, #131), `RepostPostTarget` (auto-repost, #124) — plus the proactive sweep force-refreshed OAuth every run. Each refresh rotates the single-use token: ~300-480 rotations/account/day.

The #158 `Cache::lock` removed the *simultaneous* race but not the *volume*. Every rotation exposes a crash window (worker dies after atproto returns 200 and rotates the token, before we persist it). A lost rotation strands the token → next refresh replays the consumed one → `invalid_grant` (hard 400) → account flipped.

## Fix

1. **Minimum-refresh-interval floor (600s)** in `TokenManager` — skip the rotation and reuse the still-valid session when we refreshed within the window. Keyed on our own `last_refreshed_at` (tokens are opaque per spec, so not the accessJwt); 600s ≪ the accessJwt lifetime, so a reused session is never stale. The publish's post-401 `force` retry bypasses it.
2. **Drop Bluesky from `RefreshExpiringTokens`** — force-refreshing a 15-min token "6h ahead" only added rotations. The JIT path (and publish retry) refresh it exactly when needed.

Cuts rotations ~2-5× (both paths). This substantially reduces the flips; it does not eliminate the crash window itself (inherent to single-use tokens — full removal would need an idempotent/two-phase refresh, out of scope here).

## Tests

- `TokenManagerTest`: a recently-refreshed app_password account reuses its session (no rotation); `force: true` still refreshes past the floor.
- `RefreshExpiringTokensTest`: the sweep no longer rotates Bluesky OAuth (inverted the prior "proactively refreshes" test).
- Pint + Larastan (level 7) clean; 40 token/sweep tests green.

Related (closed): #50 (reverse-proxy HTTPS drift, same OAuth-flip family).