### PR TITLE
fix(connected-accounts): correct Instagram DM scope identifier

### DIFF
--- a/app/Http/Controllers/ConnectedAccounts/MetaConnectionController.php
+++ b/app/Http/Controllers/ConnectedAccounts/MetaConnectionController.php
@@ -298,7 +298,7 @@ class MetaConnectionController extends Controller
     private function directMessageScopeDeltas(Platform $platform): array
     {
         return match ($platform) {
-            Platform::Instagram => ['instagram_business_manage_messages'],
+            Platform::Instagram => ['instagram_manage_messages'],
             Platform::Facebook => ['pages_messaging'],
             default => [],
         };

--- a/app/Http/Controllers/ConnectedAccounts/OAuthConnectionController.php
+++ b/app/Http/Controllers/ConnectedAccounts/OAuthConnectionController.php
@@ -285,7 +285,7 @@ class OAuthConnectionController extends Controller
     {
         return match ($platform) {
             Platform::X => ['dm.read', 'dm.write'],
-            Platform::Instagram => ['instagram_business_manage_messages'],
+            Platform::Instagram => ['instagram_manage_messages'],
             Platform::Facebook => ['pages_messaging'],
             default => [],
         };

--- a/tests/Feature/ConnectedAccounts/MetaDirectMessageOptInTest.php
+++ b/tests/Feature/ConnectedAccounts/MetaDirectMessageOptInTest.php
@@ -15,7 +15,7 @@ test('meta scopes include ig and fb dm scopes when direct messages enabled', fun
     $scopes = (fn () => $this->scopes())->call($controller);
 
     expect($scopes)
-        ->toContain('instagram_business_manage_messages')
+        ->toContain('instagram_manage_messages')
         ->toContain('pages_messaging');
 });
 
@@ -28,7 +28,7 @@ test('meta scopes exclude ig and fb dm scopes when direct messages disabled', fu
     $scopes = (fn () => $this->scopes())->call($controller);
 
     expect($scopes)
-        ->not->toContain('instagram_business_manage_messages')
+        ->not->toContain('instagram_manage_messages')
         ->not->toContain('pages_messaging');
 });
 


### PR DESCRIPTION
## Summary
- Requests the correct `instagram_manage_messages` OAuth scope (instead of the invalid `instagram_business_manage_messages`) when Instagram direct message polling is enabled, fixes #176
- Applied consistently in both `MetaConnectionController` and `OAuthConnectionController` scope resolution
- Updated feature tests to assert the corrected scope

## Breaking Changes
None.


---

Fixes #176