### PR TITLE
feat(sync): cross-platform sync pipelines (Phase 1 — publish-through fan-out)

### DIFF
--- a/app/Console/Commands/ReconcileSyncFanOut.php
+++ b/app/Console/Commands/ReconcileSyncFanOut.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\ConnectedAccountStatus;
+use App\Enums\PostTargetStatus;
+use App\Models\PostTarget;
+use App\Models\SyncPipeline;
+use App\Services\Sync\SyncFanOutService;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Date;
+
+class ReconcileSyncFanOut extends Command
+{
+    protected $signature = 'sync:reconcile';
+
+    protected $description = 'Backstop that fans out any recently published source posts missed by the publish event.';
+
+    public function handle(SyncFanOutService $fanOut): int
+    {
+        if (! config('sync.enabled')) {
+            return self::SUCCESS;
+        }
+
+        $sourceAccountIds = SyncPipeline::withoutGlobalScopes()
+            ->where('enabled', true)
+            ->pluck('source_connected_account_id')
+            ->unique()
+            ->all();
+
+        if ($sourceAccountIds === []) {
+            return self::SUCCESS;
+        }
+
+        $floor = Date::now()->subMinutes((int) config('sync.reconcile_lookback_minutes', 60));
+
+        PostTarget::query()
+            ->with([
+                'account' => fn ($query) => $query->withoutGlobalScopes(),
+                'post' => fn ($query) => $query->withoutGlobalScopes(),
+            ])
+            ->where('status', PostTargetStatus::Published->value)
+            ->whereNotNull('posted_at')
+            ->where('posted_at', '>=', $floor)
+            ->whereIn('connected_account_id', $sourceAccountIds)
+            ->whereHas('account', fn (Builder $query): Builder => $query
+                ->whereNull('disabled_at')
+                ->where('status', ConnectedAccountStatus::Active->value))
+            ->each(function (PostTarget $target) use ($fanOut): void {
+                $fanOut->fanOut($target); // idempotent via unique index
+            });
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Dto/Post/DraftData.php
+++ b/app/Dto/Post/DraftData.php
@@ -38,6 +38,13 @@ final class DraftData
          * silently reset a user's per-post choice.
          */
         public readonly bool $autoRepostProvided = false,
+        public readonly bool $skipSync = false,
+        /**
+         * Whether the payload carried a `skip_sync` key at all, so a partial
+         * update that never mentions it doesn't reset the stored opt-out. See
+         * {@see $autoRepostProvided}.
+         */
+        public readonly bool $skipSyncProvided = false,
         public readonly array $segmentBreaks = [],
         public readonly array $placements = [],
         /**
@@ -100,6 +107,8 @@ final class DraftData
             expectedUpdatedAt: $payload['expected_updated_at'] ?? null,
             autoRepost: $payload['auto_repost'] ?? null,
             autoRepostProvided: array_key_exists('auto_repost', $payload),
+            skipSync: (bool) ($payload['skip_sync'] ?? false),
+            skipSyncProvided: array_key_exists('skip_sync', $payload),
             segmentBreaks: isset($payload['segment_breaks']) && is_array($payload['segment_breaks'])
                 ? array_values(array_map(static fn (mixed $b): string => (string) $b, $payload['segment_breaks']))
                 : [],

--- a/app/Enums/PostOrigin.php
+++ b/app/Enums/PostOrigin.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum PostOrigin: string
+{
+    case Composer = 'composer';
+    case Sync = 'sync';
+    case External = 'external';
+}

--- a/app/Events/PostTargetPublished.php
+++ b/app/Events/PostTargetPublished.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\PostTarget;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class PostTargetPublished
+{
+    use Dispatchable;
+
+    public function __construct(public PostTarget $target) {}
+}

--- a/app/Http/Controllers/Settings/SyncPipelinesController.php
+++ b/app/Http/Controllers/Settings/SyncPipelinesController.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Models\ConnectedAccount;
+use App\Models\SyncPipeline;
+use App\Models\User;
+use App\Services\Billing\WorkspaceSubscriptionGate;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SyncPipelinesController extends Controller
+{
+    public function __construct(private readonly WorkspaceSubscriptionGate $gate) {}
+
+    public function index(Request $request): Response
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $workspace = $user->currentWorkspace;
+        abort_if($workspace === null, 404);
+        $this->authorizeManage($user, $workspace->id);
+
+        $accounts = ConnectedAccount::query()
+            ->where('workspace_id', $workspace->id)
+            ->enabled()
+            ->get()
+            ->map(fn (ConnectedAccount $account): array => [
+                'id' => $account->id,
+                'platform' => $account->platform->value,
+                'handle' => $account->handle,
+                'display_name' => $account->display_name,
+                'avatar_url' => $account->avatar_url,
+                'status' => $account->status->value,
+            ])->values();
+
+        $pipelines = SyncPipeline::query()
+            ->where('workspace_id', $workspace->id)
+            ->with('destinations:id')
+            ->latest()
+            ->get()
+            ->map(fn (SyncPipeline $pipeline): array => [
+                'id' => $pipeline->id,
+                'name' => $pipeline->name,
+                'enabled' => $pipeline->enabled,
+                'source_connected_account_id' => $pipeline->source_connected_account_id,
+                'destination_connected_account_ids' => $pipeline->destinations->pluck('id')->all(),
+            ]);
+
+        return Inertia::render('settings/workspace/sync-pipelines', [
+            'accounts' => $accounts,
+            'pipelines' => $pipelines,
+            'maxPipelines' => (int) config('subscriptions.max_sync_pipelines'),
+            'canCreate' => $this->gate->canCreateSyncPipeline($workspace),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $workspace = $user->currentWorkspace;
+        abort_if($workspace === null, 404);
+        $this->authorizeManage($user, $workspace->id);
+
+        if (! $this->gate->canCreateSyncPipeline($workspace)) {
+            throw ValidationException::withMessages([
+                'name' => 'You have reached your plan\'s sync pipeline limit.',
+            ]);
+        }
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'enabled' => ['sometimes', 'boolean'],
+            'source_connected_account_id' => ['required', 'string', $this->accountRule($workspace->id)],
+            'destination_connected_account_ids' => ['required', 'array', 'min:1'],
+            'destination_connected_account_ids.*' => [$this->accountRule($workspace->id), 'different:source_connected_account_id'],
+        ]);
+
+        $pipeline = SyncPipeline::create([
+            'workspace_id' => $workspace->id,
+            'source_connected_account_id' => $validated['source_connected_account_id'],
+            'name' => $validated['name'],
+            'enabled' => $validated['enabled'] ?? true,
+            'created_by' => $user->id,
+        ]);
+        $pipeline->destinations()->sync($validated['destination_connected_account_ids']);
+
+        return back()->with('success', 'Sync pipeline created.');
+    }
+
+    public function update(Request $request, SyncPipeline $syncPipeline): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        abort_unless($syncPipeline->workspace_id === $user->current_workspace_id, 404);
+        $this->authorizeManage($user, $syncPipeline->workspace_id);
+
+        $validated = $request->validate([
+            'name' => ['sometimes', 'string', 'max:255'],
+            'enabled' => ['sometimes', 'boolean'],
+            'source_connected_account_id' => ['sometimes', 'string', $this->accountRule($syncPipeline->workspace_id)],
+            'destination_connected_account_ids' => ['sometimes', 'array'],
+            'destination_connected_account_ids.*' => [$this->accountRule($syncPipeline->workspace_id)],
+        ]);
+
+        $syncPipeline->update(array_intersect_key($validated, array_flip(['name', 'enabled', 'source_connected_account_id'])));
+        if (array_key_exists('destination_connected_account_ids', $validated)) {
+            $syncPipeline->destinations()->sync($validated['destination_connected_account_ids']);
+        }
+
+        return back()->with('success', 'Sync pipeline updated.');
+    }
+
+    public function destroy(Request $request, SyncPipeline $syncPipeline): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        abort_unless($syncPipeline->workspace_id === $user->current_workspace_id, 404);
+        $this->authorizeManage($user, $syncPipeline->workspace_id);
+
+        $syncPipeline->delete();
+
+        return back()->with('success', 'Sync pipeline deleted.');
+    }
+
+    private function accountRule(string $workspaceId): Exists
+    {
+        return Rule::exists('connected_accounts', 'id')->where('workspace_id', $workspaceId);
+    }
+
+    private function authorizeManage(User $user, string $workspaceId): void
+    {
+        abort_unless($user->hasAllPermissions(['workspace.settings.manage'], $workspaceId), 403);
+    }
+}

--- a/app/Http/Requests/Post/StorePostRequest.php
+++ b/app/Http/Requests/Post/StorePostRequest.php
@@ -38,6 +38,7 @@ class StorePostRequest extends FormRequest
             'destination.ids' => ['array', 'required_if:destination.kind,accounts'],
             'destination.ids.*' => ['string'],
             'auto_repost' => ['sometimes', 'nullable', 'boolean'],
+            'skip_sync' => ['sometimes', 'boolean'],
             'segment_breaks' => ['array'],
             'segment_breaks.*' => ['string'],
             'placements' => ['array'],

--- a/app/Http/Requests/Post/UpdatePostRequest.php
+++ b/app/Http/Requests/Post/UpdatePostRequest.php
@@ -62,6 +62,7 @@ class UpdatePostRequest extends FormRequest
             'placements.*.segment_ref' => ['required', 'string'],
             'placements.*.position' => ['required', 'integer'],
             'auto_repost' => ['sometimes', 'nullable', 'boolean'],
+            'skip_sync' => ['sometimes', 'boolean'],
             'expected_updated_at' => ['nullable', 'string'],
         ];
     }

--- a/app/Jobs/PublishPostTarget.php
+++ b/app/Jobs/PublishPostTarget.php
@@ -11,6 +11,7 @@ use App\Enums\ConnectedAccountStatus;
 use App\Enums\ErrorKind;
 use App\Enums\Platform;
 use App\Enums\PostTargetStatus;
+use App\Events\PostTargetPublished;
 use App\Exceptions\TokenRefreshException;
 use App\Exceptions\TransientTokenRefreshException;
 use App\Models\PostMediaPlacement;
@@ -268,6 +269,7 @@ class PublishPostTarget implements ShouldQueue
         app(PostStatusRollup::class)->recompute($target->post()->firstOrFail());
 
         $this->notifyPublished($target);
+        PostTargetPublished::dispatch($target);
     }
 
     /**
@@ -411,6 +413,7 @@ class PublishPostTarget implements ShouldQueue
         ])->save();
 
         $this->notifyPublished($target);
+        PostTargetPublished::dispatch($target);
     }
 
     private function onFailure(PostTarget $target, PostTargetAttempt $attempt, PublishResult $result, BackoffSchedule $backoff): void

--- a/app/Listeners/TriggerSyncPipelines.php
+++ b/app/Listeners/TriggerSyncPipelines.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\PostTargetPublished;
+use App\Services\Sync\SyncFanOutService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class TriggerSyncPipelines implements ShouldQueue
+{
+    public function __construct(private readonly SyncFanOutService $fanOut) {}
+
+    public function handle(PostTargetPublished $event): void
+    {
+        $this->fanOut->fanOut($event->target);
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Concerns\HasWorkspaceScope;
+use App\Enums\PostOrigin;
 use App\Enums\PostStatus;
 use Carbon\CarbonImmutable;
 use Database\Factories\PostFactory;
@@ -41,6 +42,10 @@ use Override;
     'segments',
     'mentions',
     'status',
+    'origin',
+    'sync_pipeline_id',
+    'source_post_id',
+    'skip_sync',
     'auto_repost',
     'scheduled_at',
     'published_at',
@@ -51,11 +56,21 @@ class Post extends Model
     /** @use HasFactory<PostFactory> */
     use HasFactory, HasUuids, HasWorkspaceScope;
 
+    /**
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'origin' => 'composer',
+        'skip_sync' => false,
+    ];
+
     #[Override]
     protected function casts(): array
     {
         return [
             'status' => PostStatus::class,
+            'origin' => PostOrigin::class,
+            'skip_sync' => 'boolean',
             'auto_repost' => 'boolean',
             'mentions' => 'array',
             'segments' => 'array',
@@ -122,6 +137,22 @@ class Post extends Model
     public function replies(): HasManyThrough
     {
         return $this->hasManyThrough(PostTargetReply::class, PostTarget::class);
+    }
+
+    /**
+     * @return BelongsTo<SyncPipeline, $this>
+     */
+    public function syncPipeline(): BelongsTo
+    {
+        return $this->belongsTo(SyncPipeline::class);
+    }
+
+    /**
+     * @return BelongsTo<Post, $this>
+     */
+    public function sourcePost(): BelongsTo
+    {
+        return $this->belongsTo(Post::class, 'source_post_id');
     }
 
     /**

--- a/app/Models/SyncPipeline.php
+++ b/app/Models/SyncPipeline.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasWorkspaceScope;
+use Database\Factories\SyncPipelineFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Override;
+
+/**
+ * @property string $id
+ * @property string $workspace_id
+ * @property string $source_connected_account_id
+ * @property string $name
+ * @property bool $enabled
+ * @property string|null $created_by
+ */
+class SyncPipeline extends Model
+{
+    /** @use HasFactory<SyncPipelineFactory> */
+    use HasFactory, HasUuids, HasWorkspaceScope;
+
+    protected $fillable = [
+        'workspace_id',
+        'source_connected_account_id',
+        'name',
+        'enabled',
+        'created_by',
+    ];
+
+    #[Override]
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Workspace, $this>
+     */
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    /**
+     * @return BelongsTo<ConnectedAccount, $this>
+     */
+    public function source(): BelongsTo
+    {
+        return $this->belongsTo(ConnectedAccount::class, 'source_connected_account_id');
+    }
+
+    /**
+     * @return BelongsToMany<ConnectedAccount, $this>
+     */
+    public function destinations(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            ConnectedAccount::class,
+            'sync_pipeline_destinations',
+            'sync_pipeline_id',
+            'connected_account_id',
+        )->withTimestamps();
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -200,6 +200,14 @@ class Workspace extends Model
     }
 
     /**
+     * @return HasMany<SyncPipeline, $this>
+     */
+    public function syncPipelines(): HasMany
+    {
+        return $this->hasMany(SyncPipeline::class);
+    }
+
+    /**
      * @return HasMany<WorkspaceMention, $this>
      */
     public function mentions(): HasMany

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,9 +3,11 @@
 namespace App\Providers;
 
 use App\Enums\Platform;
+use App\Events\PostTargetPublished;
 use App\Listeners\BindWorkspaceToAccessToken;
 use App\Listeners\SetCurrentWorkspaceOnLogin;
 use App\Listeners\SetSentryUserContext;
+use App\Listeners\TriggerSyncPipelines;
 use App\Models\PostMedia;
 use App\Models\User;
 use App\Models\Workspace;
@@ -118,6 +120,7 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(Login::class, SetCurrentWorkspaceOnLogin::class);
         Event::listen(AccessTokenCreated::class, BindWorkspaceToAccessToken::class);
         Event::listen(Authenticated::class, SetSentryUserContext::class);
+        Event::listen(PostTargetPublished::class, TriggerSyncPipelines::class);
 
         Passport::authorizationView(
             /** @param array<string, mixed> $parameters */

--- a/app/Services/Billing/WorkspaceSubscriptionGate.php
+++ b/app/Services/Billing/WorkspaceSubscriptionGate.php
@@ -48,6 +48,19 @@ class WorkspaceSubscriptionGate
         return $workspace->is_initial || $workspace->subscribed('default');
     }
 
+    public function canCreateSyncPipeline(Workspace $workspace): bool
+    {
+        if (! $this->isEnabled() || $workspace->is_initial) {
+            return true;
+        }
+
+        if (! $workspace->subscribed('default')) {
+            return false;
+        }
+
+        return $workspace->syncPipelines()->count() < (int) config('subscriptions.max_sync_pipelines');
+    }
+
     public function canPublishX(Workspace $workspace): bool
     {
         if (! $this->isEnabled() || $this->isXUnlimited($workspace)) {

--- a/app/Services/Posts/DraftService.php
+++ b/app/Services/Posts/DraftService.php
@@ -50,6 +50,7 @@ class DraftService
                 'mentions' => $this->normalizeMentions($mentions),
                 'status' => PostStatus::Draft->value,
                 'auto_repost' => $autoRepost,
+                'skip_sync' => $data instanceof DraftData ? $data->skipSync : false,
             ]);
 
             $accountIds = $this->resolveDestinationAccountIds($workspaceId, $destination);
@@ -372,6 +373,9 @@ class DraftService
             // a partial update that omits `auto_repost` must not reset it to null.
             if ($data->autoRepostProvided) {
                 $attributes['auto_repost'] = $data->autoRepost;
+            }
+            if ($data->skipSyncProvided) {
+                $attributes['skip_sync'] = $data->skipSync;
             }
 
             $post->forceFill($attributes)->save();

--- a/app/Services/Posts/PostDuplicator.php
+++ b/app/Services/Posts/PostDuplicator.php
@@ -64,6 +64,29 @@ class PostDuplicator
     }
 
     /**
+     * Copy every media file + row from $source into an existing $target post.
+     * Cleans up any copied storage files if a later step throws.
+     */
+    public function copyMediaInto(Post $target, Post $source): void
+    {
+        $source->loadMissing('media');
+
+        /** @var list<array{0: string, 1: string}> $copiedPaths */
+        $copiedPaths = [];
+
+        try {
+            $plan = $this->copyMediaFiles($source, $copiedPaths);
+            $this->createMediaRows($target, $plan);
+        } catch (Throwable $e) {
+            foreach ($copiedPaths as [$disk, $path]) {
+                FileStorage::disk($disk)->delete($path);
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
      * Copy each media file (and any retained pre-edit source) to a fresh path,
      * recording every written path in $copiedPaths for rollback cleanup.
      *

--- a/app/Services/Sync/SyncFanOutService.php
+++ b/app/Services/Sync/SyncFanOutService.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Sync;
+
+use App\Enums\ConnectedAccountStatus;
+use App\Enums\PostOrigin;
+use App\Enums\PostStatus;
+use App\Models\ConnectedAccount;
+use App\Models\Post;
+use App\Models\PostTarget;
+use App\Models\SyncPipeline;
+use App\Services\Posts\DraftService;
+use App\Services\Posts\PostDuplicator;
+use App\Services\Publishing\PublishDispatcher;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class SyncFanOutService
+{
+    public function __construct(
+        private readonly PostDuplicator $duplicator,
+        private readonly DraftService $drafts,
+        private readonly PublishDispatcher $dispatcher,
+    ) {}
+
+    /**
+     * Fan a just-published source target out to every enabled pipeline whose
+     * source is that account. Idempotent per (source post, pipeline).
+     */
+    public function fanOut(PostTarget $sourceTarget): void
+    {
+        if (! config('sync.enabled')) {
+            return;
+        }
+
+        $source = Post::withoutGlobalScopes()->find($sourceTarget->post_id);
+        if ($source === null || $source->origin === PostOrigin::Sync || $source->skip_sync) {
+            return;
+        }
+
+        $pipelines = SyncPipeline::withoutGlobalScopes()
+            ->where('enabled', true)
+            ->where('source_connected_account_id', $sourceTarget->connected_account_id)
+            ->get();
+
+        foreach ($pipelines as $pipeline) {
+            $this->createSyncedPost($source, $pipeline);
+        }
+    }
+
+    private function createSyncedPost(Post $source, SyncPipeline $pipeline): void
+    {
+        $alreadyTargeted = PostTarget::withoutGlobalScopes()
+            ->where('post_id', $source->id)
+            ->pluck('connected_account_id')
+            ->all();
+
+        $destinationIds = ConnectedAccount::withoutGlobalScopes()
+            ->whereIn('id', $pipeline->destinations()->pluck('connected_accounts.id')->all())
+            ->whereNotIn('id', $alreadyTargeted)
+            ->enabled()
+            ->where('status', ConnectedAccountStatus::Active->value)
+            ->pluck('id')
+            ->map(static fn (mixed $id): string => (string) $id)
+            ->values()
+            ->all();
+
+        if ($destinationIds === []) {
+            return;
+        }
+
+        // Claim the (source, pipeline) pair first so the unique index guards the
+        // race between the immediate event and the reconcile backstop.
+        try {
+            $synced = Post::create([
+                'workspace_id' => $source->workspace_id,
+                'author_id' => $source->author_id,
+                'origin' => PostOrigin::Sync->value,
+                'sync_pipeline_id' => $pipeline->id,
+                'source_post_id' => $source->id,
+                'segments' => $source->segments,
+                'base_text' => $source->base_text,
+                'mentions' => $source->mentions,
+                'status' => PostStatus::Draft->value,
+            ]);
+        } catch (UniqueConstraintViolationException) {
+            return; // Another run already fanned this out.
+        }
+
+        try {
+            DB::transaction(function () use ($synced, $source, $destinationIds): void {
+                $this->duplicator->copyMediaInto($synced, $source);
+                // No DraftData => no per-segment placements; all media rides the head
+                // section (SegmentMediaResolver falls back to [0 => allMedia]).
+                $this->drafts->syncTargets($synced, array_values($destinationIds), $source->segments ?? [], [], [], $source->mentions ?? [], []);
+                $synced->forceFill(['status' => PostStatus::Publishing->value])->save();
+            });
+        } catch (Throwable $e) {
+            $synced->delete(); // Let the backstop retry a clean fan-out.
+
+            throw $e;
+        }
+
+        $this->dispatcher->dispatchForPost($synced->fresh(['targets', 'media']));
+    }
+}

--- a/app/Support/PostListItem.php
+++ b/app/Support/PostListItem.php
@@ -18,6 +18,8 @@ final class PostListItem
         return [
             'id' => $post->id,
             'base_text' => $post->base_text,
+            'origin' => $post->origin->value,
+            'source_post_id' => $post->source_post_id,
             'status' => $post->status->value,
             'status_label' => $post->status->label(),
             'author' => $post->author?->name,

--- a/app/Support/PostView.php
+++ b/app/Support/PostView.php
@@ -35,6 +35,7 @@ final class PostView
             'status' => $post->status->value,
             'scheduled_at' => $post->scheduled_at?->toIso8601String(),
             'auto_repost' => $post->auto_repost,
+            'skip_sync' => $post->skip_sync,
             'published_at' => $post->published_at?->toIso8601String(),
             'updated_at' => $post->updated_at->toIso8601String(),
             'destination' => self::destination($post),

--- a/config/subscriptions.php
+++ b/config/subscriptions.php
@@ -5,4 +5,7 @@ return [
     'stripe_price_id' => env('STRIPE_SUBSCRIPTION_PRICE_ID', 'price_shoutrrr_monthly_test'),
     'monthly_price_cents' => (int) env('SHOUTRRR_SUBSCRIPTION_MONTHLY_CENTS', 1000),
     'monthly_x_budget_cents' => (int) env('SHOUTRRR_X_MONTHLY_BUDGET_CENTS', 500),
+
+    // Maximum concurrent sync pipelines per workspace (inert unless enabled above).
+    'max_sync_pipelines' => (int) env('SUBSCRIPTIONS_MAX_SYNC_PIPELINES', 3),
 ];

--- a/config/sync.php
+++ b/config/sync.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // Master kill switch. SYNC_ENABLED=false makes fan-out vanish at every layer.
+    'enabled' => (bool) env('SYNC_ENABLED', true),
+
+    // Reconcile backstop lookback: only re-check source targets published within
+    // this window, so the sweep never rescans all history.
+    'reconcile_lookback_minutes' => (int) env('SYNC_RECONCILE_LOOKBACK_MINUTES', 60),
+];

--- a/database/factories/SyncPipelineFactory.php
+++ b/database/factories/SyncPipelineFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\ConnectedAccount;
+use App\Models\SyncPipeline;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SyncPipeline>
+ */
+class SyncPipelineFactory extends Factory
+{
+    protected $model = SyncPipeline::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'workspace_id' => Workspace::factory(),
+            'source_connected_account_id' => ConnectedAccount::factory(),
+            'name' => fake()->words(3, true),
+            'enabled' => true,
+            'created_by' => User::factory(),
+        ];
+    }
+}

--- a/database/migrations/2026_09_02_000001_create_sync_pipelines_tables.php
+++ b/database/migrations/2026_09_02_000001_create_sync_pipelines_tables.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sync_pipelines', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('workspace_id')->constrained('workspaces')->cascadeOnDelete();
+            $table->foreignUuid('source_connected_account_id')->constrained('connected_accounts')->cascadeOnDelete();
+            $table->string('name');
+            $table->boolean('enabled')->default(true);
+            $table->foreignUuid('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->index(['workspace_id', 'source_connected_account_id']);
+        });
+
+        Schema::create('sync_pipeline_destinations', function (Blueprint $table): void {
+            $table->foreignUuid('sync_pipeline_id')->constrained('sync_pipelines')->cascadeOnDelete();
+            $table->foreignUuid('connected_account_id')->constrained('connected_accounts')->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->primary(['sync_pipeline_id', 'connected_account_id']);
+        });
+
+        Schema::table('posts', function (Blueprint $table): void {
+            $table->string('origin')->default('composer')->after('status');
+            $table->foreignUuid('sync_pipeline_id')->nullable()->after('origin')
+                ->constrained('sync_pipelines')->nullOnDelete();
+            $table->foreignUuid('source_post_id')->nullable()->after('sync_pipeline_id')
+                ->constrained('posts')->nullOnDelete();
+            $table->boolean('skip_sync')->default(false)->after('source_post_id');
+
+            $table->unique(['source_post_id', 'sync_pipeline_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table): void {
+            $table->dropUnique(['source_post_id', 'sync_pipeline_id']);
+            $table->dropConstrainedForeignId('source_post_id');
+            $table->dropConstrainedForeignId('sync_pipeline_id');
+            $table->dropColumn(['origin', 'skip_sync']);
+        });
+
+        Schema::dropIfExists('sync_pipeline_destinations');
+        Schema::dropIfExists('sync_pipelines');
+    }
+};

--- a/resources/js/components/compose/composer-toolbar.tsx
+++ b/resources/js/components/compose/composer-toolbar.tsx
@@ -8,6 +8,7 @@ import { GifPopover } from '@/components/compose/gif-popover';
 import {
     ImagePlay,
     Paperclip,
+    Share2,
     Shuffle,
     Smile,
     Split,
@@ -58,6 +59,14 @@ type Props = {
         onChange: (value: BoostValue) => void;
         accounts: Account[];
     };
+    /**
+     * Per-post sync-pipeline opt-out; absent hides the button (read-only, or no
+     * pipeline sources are selected).
+     */
+    syncPipeline?: {
+        skip: boolean;
+        onChange: (skip: boolean) => void;
+    };
     /** Insert a chosen emoji at the editor caret. */
     onInsertEmoji: (emoji: string) => void;
     /** Recently-used emoji, newest first. */
@@ -82,6 +91,7 @@ export function ComposerToolbar({
     pending,
     handleFiles,
     boost,
+    syncPipeline,
     onInsertEmoji,
     emojiRecents,
     emojiSkinTone,
@@ -272,6 +282,18 @@ export function ComposerToolbar({
                     onChange={boost.onChange}
                     accounts={boost.accounts}
                 />
+            )}
+
+            {!readOnly && syncPipeline !== undefined && (
+                <EToolButton
+                    label="Skip sync pipelines"
+                    tooltip="Don't auto-repost this post through sync pipelines"
+                    active={syncPipeline.skip}
+                    onClick={() => syncPipeline.onChange(!syncPipeline.skip)}
+                    iconOnly
+                >
+                    <Share2 className="size-4" />
+                </EToolButton>
             )}
         </div>
     );

--- a/resources/js/components/compose/composer.tsx
+++ b/resources/js/components/compose/composer.tsx
@@ -1385,6 +1385,18 @@ export default function Composer({
                                   }
                                 : undefined
                         }
+                        syncPipeline={
+                            tabAccounts.length > 0
+                                ? {
+                                      skip: state.skipSync,
+                                      onChange: (skip) =>
+                                          dispatch({
+                                              type: 'setSkipSync',
+                                              value: skip,
+                                          }),
+                                  }
+                                : undefined
+                        }
                         media={state.media}
                         onToggleAutoSplit={() =>
                             activeAccount &&

--- a/resources/js/components/layout/app-sidebar.tsx
+++ b/resources/js/components/layout/app-sidebar.tsx
@@ -79,6 +79,7 @@ const workspaceSettingsIcons: Record<WorkspaceSettingsNavKey, IconComponent> = {
     overview: Settings,
     members: Users,
     apiKeys: KeyRound,
+    syncPipelines: Share2,
     subscription: CreditCard,
 };
 

--- a/resources/js/components/posts/post-row.tsx
+++ b/resources/js/components/posts/post-row.tsx
@@ -19,6 +19,8 @@ export type { PostStatus } from '@/types/compose';
 export type PostRowData = {
     id: string;
     base_text: string;
+    origin?: 'composer' | 'sync' | 'external';
+    source_post_id?: string | null;
     status: PostStatus;
     status_label: string;
     author: string | null;
@@ -243,6 +245,9 @@ export function PostRow({ post }: { post: PostRowData }) {
 
                 {/* Right: badge + actions */}
                 <div className="flex items-center gap-1.5">
+                    {post.origin === 'sync' && (
+                        <Badge variant="secondary">Synced</Badge>
+                    )}
                     <StatusBadge status={post.status} />
                     <PostRowActions post={post} />
                 </div>

--- a/resources/js/components/settings/create-sync-pipeline-dialog.tsx
+++ b/resources/js/components/settings/create-sync-pipeline-dialog.tsx
@@ -1,0 +1,166 @@
+import { Form } from '@inertiajs/react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import SyncPipelinesController from '@/actions/App/Http/Controllers/Settings/SyncPipelinesController';
+import InputError from '@/components/common/input-error';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { Plus } from '@/components/ui/icons';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export type SyncAccount = {
+    id: string;
+    platform: string;
+    handle: string;
+    display_name: string | null;
+    status: string;
+};
+
+type Props = {
+    accounts: SyncAccount[];
+    disabled: boolean;
+};
+
+function accountLabel(account: SyncAccount): string {
+    return `${account.display_name ?? account.handle} (${account.platform})`;
+}
+
+export default function CreateSyncPipelineDialog({
+    accounts,
+    disabled,
+}: Props) {
+    const [open, setOpen] = useState(false);
+    const [source, setSource] = useState<string>('');
+    const [destinations, setDestinations] = useState<string[]>([]);
+
+    function toggleDestination(id: string) {
+        setDestinations((current) =>
+            current.includes(id)
+                ? current.filter((d) => d !== id)
+                : [...current, id],
+        );
+    }
+
+    function reset() {
+        setSource('');
+        setDestinations([]);
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger render={<Button disabled={disabled} />}>
+                <Plus />
+                New pipeline
+            </DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>New sync pipeline</DialogTitle>
+                </DialogHeader>
+                <Form
+                    {...SyncPipelinesController.store.form()}
+                    options={{ preserveScroll: true }}
+                    onSuccess={() => {
+                        toast.success('Sync pipeline created');
+                        setOpen(false);
+                        reset();
+                    }}
+                >
+                    {({
+                        errors,
+                        processing,
+                    }: {
+                        errors: Record<string, string>;
+                        processing: boolean;
+                    }) => (
+                        <div className="grid gap-4">
+                            <div className="grid gap-2">
+                                <Label htmlFor="name">Name</Label>
+                                <Input
+                                    id="name"
+                                    name="name"
+                                    placeholder="X → LinkedIn"
+                                    required
+                                />
+                                <InputError message={errors.name} />
+                            </div>
+
+                            <div className="grid gap-2">
+                                <Label>Source account</Label>
+                                {accounts.map((account) => (
+                                    <label
+                                        key={account.id}
+                                        className="flex items-center gap-2 text-sm"
+                                    >
+                                        <input
+                                            type="radio"
+                                            name="source_connected_account_id"
+                                            value={account.id}
+                                            checked={source === account.id}
+                                            onChange={() =>
+                                                setSource(account.id)
+                                            }
+                                        />
+                                        {accountLabel(account)}
+                                    </label>
+                                ))}
+                                <InputError
+                                    message={errors.source_connected_account_id}
+                                />
+                            </div>
+
+                            <div className="grid gap-2">
+                                <Label>Destinations</Label>
+                                {accounts
+                                    .filter((account) => account.id !== source)
+                                    .map((account) => (
+                                        <label
+                                            key={account.id}
+                                            className="flex items-center gap-2 text-sm"
+                                        >
+                                            <input
+                                                type="checkbox"
+                                                checked={destinations.includes(
+                                                    account.id,
+                                                )}
+                                                onChange={() =>
+                                                    toggleDestination(
+                                                        account.id,
+                                                    )
+                                                }
+                                            />
+                                            {accountLabel(account)}
+                                        </label>
+                                    ))}
+                                {destinations.map((id) => (
+                                    <input
+                                        key={id}
+                                        type="hidden"
+                                        name="destination_connected_account_ids[]"
+                                        value={id}
+                                    />
+                                ))}
+                                <InputError
+                                    message={
+                                        errors.destination_connected_account_ids
+                                    }
+                                />
+                            </div>
+
+                            <Button type="submit" disabled={processing}>
+                                {processing ? 'Creating…' : 'Create pipeline'}
+                            </Button>
+                        </div>
+                    )}
+                </Form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/resources/js/lib/compose/composer-state.ts
+++ b/resources/js/lib/compose/composer-state.ts
@@ -59,6 +59,7 @@ export type ComposerState = {
     scheduleTray: ScheduleTray;
     conflict: PostView | null;
     autoRepost: boolean | null;
+    skipSync: boolean;
 };
 
 export type ComposerAction =
@@ -70,6 +71,7 @@ export type ComposerAction =
     | { type: 'setActiveTab'; tab: string }
     | { type: 'setDestination'; destination: Destination }
     | { type: 'setAutoRepost'; value: boolean | null }
+    | { type: 'setSkipSync'; value: boolean }
     | { type: 'toggleAutoSplit'; accountId: string }
     | { type: 'setFormat'; accountId: string; format: PostFormat }
     | { type: 'disableAutoSplit'; accountIds: string[] }
@@ -159,6 +161,7 @@ export function initialComposerState(
             : { mode: 'now', pickedAt: null },
         conflict: null,
         autoRepost: null,
+        skipSync: false,
     };
 }
 
@@ -407,6 +410,7 @@ function hydrate(post: PostView): ComposerState {
         },
         conflict: null,
         autoRepost: post.auto_repost ?? null,
+        skipSync: post.skip_sync ?? false,
     };
 }
 
@@ -492,6 +496,13 @@ export function composerReducer(
             return {
                 ...state,
                 autoRepost: action.value,
+                saveState: 'dirty',
+            };
+
+        case 'setSkipSync':
+            return {
+                ...state,
+                skipSync: action.value,
                 saveState: 'dirty',
             };
 
@@ -855,6 +866,7 @@ export type PutBody = {
     mentions: MentionPlaceholder[];
     expected_updated_at: string | null;
     auto_repost: boolean | null;
+    skip_sync: boolean;
     segment_breaks: string[];
     placements: Placement[];
 };
@@ -927,6 +939,7 @@ export function buildPutBody(
         mentions: state.mentions,
         expected_updated_at: state.baselineUpdatedAt,
         auto_repost: state.autoRepost,
+        skip_sync: state.skipSync,
         segment_breaks: state.segmentBreaks,
         placements: flattenPlacements(state.placements),
     };

--- a/resources/js/lib/navigation/workspace-settings-nav.ts
+++ b/resources/js/lib/navigation/workspace-settings-nav.ts
@@ -2,12 +2,14 @@ import type { Link } from '@inertiajs/react';
 
 import BillingController from '@/actions/App/Http/Controllers/BillingController';
 import ApiKeysController from '@/actions/App/Http/Controllers/Settings/ApiKeysController';
+import SyncPipelinesController from '@/actions/App/Http/Controllers/Settings/SyncPipelinesController';
 import WorkspaceSettingsController from '@/actions/App/Http/Controllers/Settings/WorkspaceSettingsController';
 
 export type WorkspaceSettingsNavKey =
     | 'overview'
     | 'members'
     | 'apiKeys'
+    | 'syncPipelines'
     | 'subscription';
 
 export type WorkspaceSettingsNavItem = {
@@ -44,6 +46,11 @@ export function workspaceSettingsNavItems({
             key: 'apiKeys',
             title: 'API keys',
             href: ApiKeysController.index(),
+        });
+        items.push({
+            key: 'syncPipelines',
+            title: 'Sync pipelines',
+            href: SyncPipelinesController.index(),
         });
     }
 

--- a/resources/js/pages/settings/workspace/sync-pipelines.tsx
+++ b/resources/js/pages/settings/workspace/sync-pipelines.tsx
@@ -1,0 +1,163 @@
+import { Head, router } from '@inertiajs/react';
+import { toast } from 'sonner';
+
+import SyncPipelinesController from '@/actions/App/Http/Controllers/Settings/SyncPipelinesController';
+import WorkspaceSettingsController from '@/actions/App/Http/Controllers/Settings/WorkspaceSettingsController';
+import { useConfirm } from '@/components/common/confirm-dialog';
+import CreateSyncPipelineDialog, {
+    type SyncAccount,
+} from '@/components/settings/create-sync-pipeline-dialog';
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardAction,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import {
+    Empty,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyTitle,
+} from '@/components/ui/empty';
+import { Switch } from '@/components/ui/switch';
+
+type Pipeline = {
+    id: string;
+    name: string;
+    enabled: boolean;
+    source_connected_account_id: string;
+    destination_connected_account_ids: string[];
+};
+
+type Props = {
+    accounts: SyncAccount[];
+    pipelines: Pipeline[];
+    maxPipelines: number;
+    canCreate: boolean;
+};
+
+export default function SyncPipelines({
+    accounts,
+    pipelines,
+    maxPipelines,
+    canCreate,
+}: Props) {
+    const confirm = useConfirm();
+
+    function accountLabel(id: string): string {
+        const account = accounts.find((a) => a.id === id);
+        return account
+            ? `${account.display_name ?? account.handle} (${account.platform})`
+            : id;
+    }
+
+    function toggle(pipeline: Pipeline, enabled: boolean) {
+        router.patch(
+            SyncPipelinesController.update(pipeline.id).url,
+            { enabled },
+            { preserveScroll: true },
+        );
+    }
+
+    async function remove(pipeline: Pipeline) {
+        const confirmed = await confirm({
+            title: 'Delete sync pipeline?',
+            description: `“${pipeline.name}” will stop reposting.`,
+            destructive: true,
+        });
+        if (confirmed) {
+            router.delete(SyncPipelinesController.destroy(pipeline.id).url, {
+                preserveScroll: true,
+                onSuccess: () => toast.success('Pipeline deleted'),
+            });
+        }
+    }
+
+    return (
+        <>
+            <Head title="Sync pipelines" />
+            <div className="mx-auto grid w-full max-w-3xl gap-6 p-4">
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Sync pipelines</CardTitle>
+                        <CardDescription>
+                            Automatically repost a published post to other
+                            accounts. {pipelines.length}/{maxPipelines} used.
+                        </CardDescription>
+                        <CardAction>
+                            <CreateSyncPipelineDialog
+                                accounts={accounts}
+                                disabled={!canCreate}
+                            />
+                        </CardAction>
+                    </CardHeader>
+                    <CardContent className="grid gap-3">
+                        {pipelines.length === 0 ? (
+                            <Empty>
+                                <EmptyHeader>
+                                    <EmptyTitle>No pipelines yet</EmptyTitle>
+                                    <EmptyDescription>
+                                        Create one to mirror your posts across
+                                        accounts.
+                                    </EmptyDescription>
+                                </EmptyHeader>
+                            </Empty>
+                        ) : (
+                            pipelines.map((pipeline) => (
+                                <div
+                                    key={pipeline.id}
+                                    className="flex items-center justify-between rounded-lg border p-4"
+                                >
+                                    <div>
+                                        <p className="font-medium">
+                                            {pipeline.name}
+                                        </p>
+                                        <p className="text-sm text-muted-foreground">
+                                            {accountLabel(
+                                                pipeline.source_connected_account_id,
+                                            )}{' '}
+                                            →{' '}
+                                            {pipeline.destination_connected_account_ids
+                                                .map(accountLabel)
+                                                .join(', ')}
+                                        </p>
+                                    </div>
+                                    <div className="flex items-center gap-3">
+                                        <Switch
+                                            checked={pipeline.enabled}
+                                            onCheckedChange={(v) =>
+                                                toggle(pipeline, v)
+                                            }
+                                        />
+                                        <Button
+                                            variant="ghost"
+                                            onClick={() => remove(pipeline)}
+                                        >
+                                            Delete
+                                        </Button>
+                                    </div>
+                                </div>
+                            ))
+                        )}
+                    </CardContent>
+                </Card>
+            </div>
+        </>
+    );
+}
+
+SyncPipelines.layout = {
+    breadcrumbs: [
+        {
+            title: 'Workspace settings',
+            href: WorkspaceSettingsController.showOverview().url,
+        },
+        {
+            title: 'Sync pipelines',
+            href: SyncPipelinesController.index().url,
+        },
+    ],
+};

--- a/resources/js/types/compose.ts
+++ b/resources/js/types/compose.ts
@@ -172,6 +172,7 @@ export type PostView = {
     updated_at: string;
     scheduled_at: string | null;
     auto_repost: boolean | null;
+    skip_sync?: boolean;
     destination: { kind: string; id: string | null; ids?: string[] };
     targets: TargetView[];
     media: MediaView[];

--- a/routes/console.php
+++ b/routes/console.php
@@ -8,6 +8,7 @@ use App\Console\Commands\DispatchDueReposts;
 use App\Console\Commands\PruneAbandonedUploads;
 use App\Console\Commands\PruneMcpBindings;
 use App\Console\Commands\PruneUsageEvents;
+use App\Console\Commands\ReconcileSyncFanOut;
 use App\Console\Commands\ReconcileUsageCounters;
 use App\Console\Commands\RefreshCommunityStats;
 use App\Console\Commands\RefreshExpiringTokens;
@@ -38,6 +39,10 @@ if (config('messages.enabled')) {
 
 if (config('repost.enabled')) {
     Schedule::command(DispatchDueReposts::class)->everyFifteenMinutes()->withoutOverlapping();
+}
+
+if (config('sync.enabled')) {
+    Schedule::command(ReconcileSyncFanOut::class)->everyFiveMinutes()->withoutOverlapping();
 }
 
 Schedule::command(ReconcileUsageCounters::class)->dailyAt('02:10')->withoutOverlapping();

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Settings\InstanceSettingsController;
 use App\Http\Controllers\Settings\NotificationPreferencesController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\SecurityController;
+use App\Http\Controllers\Settings\SyncPipelinesController;
 use App\Http\Controllers\Settings\WorkspaceSettingsController;
 use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Support\Facades\Route;
@@ -29,6 +30,11 @@ Route::middleware(['auth'])->group(function () {
     Route::get('settings/workspace/api-keys', [ApiKeysController::class, 'index'])->name('settings.workspace.api-keys');
     Route::post('settings/workspace/api-keys', [ApiKeysController::class, 'store'])->name('settings.workspace.api-keys.store');
     Route::delete('settings/workspace/api-keys/{apiKey}', [ApiKeysController::class, 'destroy'])->name('settings.workspace.api-keys.destroy');
+
+    Route::get('settings/workspace/sync-pipelines', [SyncPipelinesController::class, 'index'])->name('settings.workspace.sync-pipelines');
+    Route::post('settings/workspace/sync-pipelines', [SyncPipelinesController::class, 'store'])->name('settings.workspace.sync-pipelines.store');
+    Route::patch('settings/workspace/sync-pipelines/{syncPipeline}', [SyncPipelinesController::class, 'update'])->name('settings.workspace.sync-pipelines.update');
+    Route::delete('settings/workspace/sync-pipelines/{syncPipeline}', [SyncPipelinesController::class, 'destroy'])->name('settings.workspace.sync-pipelines.destroy');
 
     Route::get('settings/connections', [ConnectionsController::class, 'edit'])->name('connections.edit');
     Route::delete('settings/connections/{socialAccount}', [ConnectionsController::class, 'destroy'])->name('connections.destroy');

--- a/tests/Feature/Sync/ComposerSkipSyncTest.php
+++ b/tests/Feature/Sync/ComposerSkipSyncTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ConnectedAccount;
+use App\Models\Post;
+
+test('creating a draft persists skip_sync', function () {
+    [, $workspace] = ownerActingIn();
+    $account = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+
+    $this->postJson('/posts', [
+        'destination' => ['kind' => 'account', 'id' => $account->id],
+        'segments' => ['hello'],
+        'skip_sync' => true,
+    ])->assertCreated();
+
+    expect(Post::first()->skip_sync)->toBeTrue();
+});

--- a/tests/Feature/Sync/PostTargetPublishedEventTest.php
+++ b/tests/Feature/Sync/PostTargetPublishedEventTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\PostTargetPublished;
+use App\Listeners\TriggerSyncPipelines;
+use App\Models\PostTarget;
+use App\Services\Sync\SyncFanOutService;
+use Illuminate\Support\Facades\Event;
+
+test('the listener forwards the target to the fan-out service', function () {
+    $target = Mockery::mock(PostTarget::class);
+    $service = Mockery::mock(SyncFanOutService::class);
+    $service->shouldReceive('fanOut')->once()->with($target);
+
+    (new TriggerSyncPipelines($service))->handle(new PostTargetPublished($target));
+});
+
+test('the event is registered to the sync listener', function () {
+    Event::fake();
+    Event::assertListening(PostTargetPublished::class, TriggerSyncPipelines::class);
+});

--- a/tests/Feature/Sync/PostsListBadgeTest.php
+++ b/tests/Feature/Sync/PostsListBadgeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PostOrigin;
+use App\Models\Post;
+use App\Support\PostListItem;
+
+test('the post list item exposes origin and source post', function () {
+    [, $workspace] = ownerActingIn();
+    $source = Post::factory()->create(['workspace_id' => $workspace->id]);
+    $synced = Post::factory()->create([
+        'workspace_id' => $workspace->id,
+        'origin' => PostOrigin::Sync->value,
+        'source_post_id' => $source->id,
+    ]);
+
+    $item = PostListItem::make($synced->load(['author', 'targets', 'media']));
+
+    expect($item['origin'])->toBe('sync')
+        ->and($item['source_post_id'])->toBe($source->id);
+});
+
+test('a composer post reports composer origin and no source', function () {
+    [, $workspace] = ownerActingIn();
+    $post = Post::factory()->create(['workspace_id' => $workspace->id]);
+
+    $item = PostListItem::make($post->load(['author', 'targets', 'media']));
+
+    expect($item['origin'])->toBe('composer')
+        ->and($item['source_post_id'])->toBeNull();
+});

--- a/tests/Feature/Sync/ReconcileSyncFanOutTest.php
+++ b/tests/Feature/Sync/ReconcileSyncFanOutTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Platform;
+use App\Enums\PostOrigin;
+use App\Enums\PostStatus;
+use App\Enums\PostTargetStatus;
+use App\Models\ConnectedAccount;
+use App\Models\Post;
+use App\Models\PostTarget;
+use App\Models\SyncPipeline;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(fn () => Queue::fake());
+
+test('reconcile creates a missing synced child for a recently published source target', function () {
+    config(['sync.enabled' => true, 'sync.reconcile_lookback_minutes' => 60]);
+    [, $workspace] = ownerActingIn();
+    $source = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id, 'platform' => Platform::X->value]);
+    $dest = ConnectedAccount::factory()->linkedin()->create(['workspace_id' => $workspace->id]);
+    $pipeline = SyncPipeline::factory()->create(['workspace_id' => $workspace->id, 'source_connected_account_id' => $source->id]);
+    $pipeline->destinations()->attach($dest->id);
+
+    $post = Post::factory()->create(['workspace_id' => $workspace->id, 'origin' => PostOrigin::Composer->value, 'status' => PostStatus::Published->value, 'segments' => ['hi']]);
+    PostTarget::create([
+        'post_id' => $post->id, 'connected_account_id' => $source->id, 'platform' => Platform::X->value,
+        'sections' => ['hi'], 'status' => PostTargetStatus::Published->value, 'remote_id' => 'r1', 'posted_at' => Date::now(),
+    ]);
+
+    $this->artisan('sync:reconcile')->assertSuccessful();
+
+    expect(Post::where('source_post_id', $post->id)->count())->toBe(1);
+});
+
+test('reconcile ignores targets published outside the lookback window', function () {
+    config(['sync.enabled' => true, 'sync.reconcile_lookback_minutes' => 60]);
+    [, $workspace] = ownerActingIn();
+    $source = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id, 'platform' => Platform::X->value]);
+    $dest = ConnectedAccount::factory()->linkedin()->create(['workspace_id' => $workspace->id]);
+    $pipeline = SyncPipeline::factory()->create(['workspace_id' => $workspace->id, 'source_connected_account_id' => $source->id]);
+    $pipeline->destinations()->attach($dest->id);
+
+    $post = Post::factory()->create(['workspace_id' => $workspace->id, 'status' => PostStatus::Published->value, 'segments' => ['hi']]);
+    PostTarget::create([
+        'post_id' => $post->id, 'connected_account_id' => $source->id, 'platform' => Platform::X->value,
+        'sections' => ['hi'], 'status' => PostTargetStatus::Published->value, 'remote_id' => 'r1', 'posted_at' => Date::now()->subHours(3),
+    ]);
+
+    $this->artisan('sync:reconcile')->assertSuccessful();
+
+    expect(Post::where('source_post_id', $post->id)->count())->toBe(0);
+});

--- a/tests/Feature/Sync/ReplyDoesNotTriggerSyncTest.php
+++ b/tests/Feature/Sync/ReplyDoesNotTriggerSyncTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\PublishPostTarget;
+use App\Jobs\SendReply;
+
+test('the reply publish path does not extend PublishPostTarget', function () {
+    // Replies publish through App\Jobs\SendReply; PublishPostTarget (which fires
+    // PostTargetPublished) only handles normal post targets. If this ever changes,
+    // the sync event would fire for replies and must be guarded.
+    expect(class_exists(SendReply::class))->toBeTrue()
+        ->and(is_subclass_of(SendReply::class, PublishPostTarget::class))->toBeFalse();
+});

--- a/tests/Feature/Sync/SyncFanOutServiceTest.php
+++ b/tests/Feature/Sync/SyncFanOutServiceTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Platform;
+use App\Enums\PostOrigin;
+use App\Enums\PostStatus;
+use App\Enums\PostTargetStatus;
+use App\Jobs\PublishPostTarget;
+use App\Models\ConnectedAccount;
+use App\Models\Post;
+use App\Models\PostTarget;
+use App\Models\SyncPipeline;
+use App\Services\Sync\SyncFanOutService;
+use Illuminate\Support\Facades\Queue;
+
+/**
+ * A composer post already published to $source, plus a pipeline source->[dests].
+ *
+ * @param  list<ConnectedAccount>  $destinations
+ * @return array{0: Post, 1: PostTarget}
+ */
+function publishedSourceWithPipeline(ConnectedAccount $source, array $destinations, string $workspaceId): array
+{
+    $pipeline = SyncPipeline::factory()->create([
+        'workspace_id' => $workspaceId,
+        'source_connected_account_id' => $source->id,
+        'enabled' => true,
+    ]);
+    $pipeline->destinations()->attach(collect($destinations)->pluck('id')->all());
+
+    $post = Post::factory()->create([
+        'workspace_id' => $workspaceId,
+        'origin' => PostOrigin::Composer->value,
+        'status' => PostStatus::Published->value,
+        'segments' => ['Hello world from the source platform'],
+        'base_text' => 'Hello world from the source platform',
+    ]);
+    $target = PostTarget::create([
+        'post_id' => $post->id,
+        'connected_account_id' => $source->id,
+        'platform' => $source->platform->value,
+        'sections' => ['Hello world from the source platform'],
+        'status' => PostTargetStatus::Published->value,
+        'remote_id' => 'src-123',
+    ]);
+
+    return [$post, $target];
+}
+
+beforeEach(function () {
+    Queue::fake();
+    config(['sync.enabled' => true]);
+});
+
+test('fan-out creates one synced post with a target per destination and recomputed sections', function () {
+    [, $workspace] = ownerActingIn();
+    $source = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id, 'platform' => Platform::X->value]);
+    $dest = ConnectedAccount::factory()->linkedin()->create(['workspace_id' => $workspace->id]);
+    [$post, $target] = publishedSourceWithPipeline($source, [$dest], $workspace->id);
+
+    app(SyncFanOutService::class)->fanOut($target);
+
+    $synced = Post::where('source_post_id', $post->id)->first();
+    expect($synced)->not->toBeNull()
+        ->and($synced->origin)->toBe(PostOrigin::Sync)
+        ->and($synced->status)->toBe(PostStatus::Publishing)
+        ->and($synced->targets)->toHaveCount(1)
+        ->and($synced->targets->first()->connected_account_id)->toBe($dest->id)
+        ->and($synced->targets->first()->sections)->not->toBeEmpty();
+    Queue::assertPushed(PublishPostTarget::class);
+});
+
+test('fan-out excludes destinations already targeted by the source post', function () {
+    [, $workspace] = ownerActingIn();
+    $source = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id, 'platform' => Platform::X->value]);
+    $dest = ConnectedAccount::factory()->linkedin()->create(['workspace_id' => $workspace->id]);
+    [$post, $target] = publishedSourceWithPipeline($source, [$dest], $workspace->id);
+    PostTarget::create([
+        'post_id' => $post->id,
+        'connected_account_id' => $dest->id,
+        'platform' => $dest->platform->value,
+        'sections' => ['Hello'],
+        'status' => PostTargetStatus::Published->value,
+    ]);
+
+    app(SyncFanOutService::class)->fanOut($target);
+
+    expect(Post::where('source_post_id', $post->id)->count())->toBe(0);
+});
+
+test('fan-out is idempotent under repeated calls', function () {
+    [, $workspace] = ownerActingIn();
+    $source = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id, 'platform' => Platform::X->value]);
+    $dest = ConnectedAccount::factory()->linkedin()->create(['workspace_id' => $workspace->id]);
+    [$post, $target] = publishedSourceWithPipeline($source, [$dest], $workspace->id);
+
+    app(SyncFanOutService::class)->fanOut($target);
+    app(SyncFanOutService::class)->fanOut($target);
+
+    expect(Post::where('source_post_id', $post->id)->count())->toBe(1);
+});
+
+test('a synced post never triggers further fan-out', function () {
+    [, $workspace] = ownerActingIn();
+    $source = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id, 'platform' => Platform::X->value]);
+    $dest = ConnectedAccount::factory()->linkedin()->create(['workspace_id' => $workspace->id]);
+    $loopPipeline = SyncPipeline::factory()->create([
+        'workspace_id' => $workspace->id,
+        'source_connected_account_id' => $dest->id,
+        'enabled' => true,
+    ]);
+    $loopPipeline->destinations()->attach($source->id);
+
+    $syncedPost = Post::factory()->create([
+        'workspace_id' => $workspace->id,
+        'origin' => PostOrigin::Sync->value,
+    ]);
+    $syncedTarget = PostTarget::create([
+        'post_id' => $syncedPost->id,
+        'connected_account_id' => $dest->id,
+        'platform' => $dest->platform->value,
+        'sections' => ['x'],
+        'status' => PostTargetStatus::Published->value,
+        'remote_id' => 'dst-1',
+    ]);
+
+    app(SyncFanOutService::class)->fanOut($syncedTarget);
+
+    expect(Post::where('origin', PostOrigin::Sync->value)->where('source_post_id', $syncedPost->id)->count())->toBe(0);
+});
+
+test('skip_sync suppresses fan-out', function () {
+    [, $workspace] = ownerActingIn();
+    $source = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id, 'platform' => Platform::X->value]);
+    $dest = ConnectedAccount::factory()->linkedin()->create(['workspace_id' => $workspace->id]);
+    [$post, $target] = publishedSourceWithPipeline($source, [$dest], $workspace->id);
+    $post->update(['skip_sync' => true]);
+
+    app(SyncFanOutService::class)->fanOut($target->fresh());
+
+    expect(Post::where('source_post_id', $post->id)->count())->toBe(0);
+});
+
+test('fan-out is inert when sync.enabled is false', function () {
+    config(['sync.enabled' => false]);
+    [, $workspace] = ownerActingIn();
+    $source = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id, 'platform' => Platform::X->value]);
+    $dest = ConnectedAccount::factory()->linkedin()->create(['workspace_id' => $workspace->id]);
+    [$post, $target] = publishedSourceWithPipeline($source, [$dest], $workspace->id);
+
+    app(SyncFanOutService::class)->fanOut($target);
+
+    expect(Post::where('source_post_id', $post->id)->count())->toBe(0);
+});
+
+test('disabled destination accounts are excluded', function () {
+    [, $workspace] = ownerActingIn();
+    $source = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id, 'platform' => Platform::X->value]);
+    $dest = ConnectedAccount::factory()->linkedin()->disabled()->create(['workspace_id' => $workspace->id]);
+    [$post, $target] = publishedSourceWithPipeline($source, [$dest], $workspace->id);
+
+    app(SyncFanOutService::class)->fanOut($target);
+
+    expect(Post::where('source_post_id', $post->id)->count())->toBe(0);
+});

--- a/tests/Feature/Sync/SyncPipelineGateTest.php
+++ b/tests/Feature/Sync/SyncPipelineGateTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\SyncPipeline;
+use App\Models\Workspace;
+use App\Services\Billing\WorkspaceSubscriptionGate;
+
+function syncGate(): WorkspaceSubscriptionGate
+{
+    return app(WorkspaceSubscriptionGate::class);
+}
+
+test('subscriptions disabled means unlimited pipelines', function () {
+    config(['subscriptions.enabled' => false, 'subscriptions.max_sync_pipelines' => 3]);
+    $workspace = Workspace::factory()->create();
+    SyncPipeline::factory()->count(5)->create(['workspace_id' => $workspace->id]);
+
+    expect(syncGate()->canCreateSyncPipeline($workspace))->toBeTrue();
+});
+
+test('initial workspace is unlimited even with subscriptions enabled', function () {
+    config(['subscriptions.enabled' => true, 'subscriptions.max_sync_pipelines' => 3]);
+    $workspace = Workspace::factory()->create(['is_initial' => true]);
+    SyncPipeline::factory()->count(5)->create(['workspace_id' => $workspace->id]);
+
+    expect(syncGate()->canCreateSyncPipeline($workspace))->toBeTrue();
+});
+
+test('a subscribed workspace is blocked at the cap', function () {
+    config(['subscriptions.enabled' => true, 'subscriptions.max_sync_pipelines' => 3]);
+    $workspace = Workspace::factory()->create(['is_initial' => false]);
+    $workspace->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_'.fake()->uuid(),
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_test',
+        'quantity' => 1,
+    ]);
+
+    expect(syncGate()->canCreateSyncPipeline($workspace))->toBeTrue();
+    SyncPipeline::factory()->count(3)->create(['workspace_id' => $workspace->id]);
+    expect(syncGate()->canCreateSyncPipeline($workspace->fresh()))->toBeFalse();
+});

--- a/tests/Feature/Sync/SyncPipelineModelTest.php
+++ b/tests/Feature/Sync/SyncPipelineModelTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PostOrigin;
+use App\Models\ConnectedAccount;
+use App\Models\Post;
+use App\Models\SyncPipeline;
+use Illuminate\Database\UniqueConstraintViolationException;
+
+test('a post defaults to composer origin', function () {
+    $post = Post::factory()->create();
+
+    expect($post->origin)->toBe(PostOrigin::Composer)
+        ->and($post->skip_sync)->toBeFalse();
+});
+
+test('a sync pipeline has a source and destinations and cascades on delete', function () {
+    [, $workspace] = ownerActingIn();
+    $source = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+    $destA = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+    $destB = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+
+    $pipeline = SyncPipeline::factory()->create([
+        'workspace_id' => $workspace->id,
+        'source_connected_account_id' => $source->id,
+    ]);
+    $pipeline->destinations()->attach([$destA->id, $destB->id]);
+
+    expect($pipeline->source->id)->toBe($source->id)
+        ->and($pipeline->destinations->pluck('id')->all())->toEqualCanonicalizing([$destA->id, $destB->id]);
+
+    $pipeline->delete();
+    $this->assertDatabaseMissing('sync_pipeline_destinations', ['sync_pipeline_id' => $pipeline->id]);
+});
+
+test('two synced posts cannot share the same source post and pipeline', function () {
+    [, $workspace] = ownerActingIn();
+    $source = Post::factory()->create(['workspace_id' => $workspace->id]);
+    $pipeline = SyncPipeline::factory()->create(['workspace_id' => $workspace->id]);
+
+    Post::factory()->create([
+        'workspace_id' => $workspace->id,
+        'origin' => PostOrigin::Sync->value,
+        'source_post_id' => $source->id,
+        'sync_pipeline_id' => $pipeline->id,
+    ]);
+
+    expect(fn () => Post::factory()->create([
+        'workspace_id' => $workspace->id,
+        'origin' => PostOrigin::Sync->value,
+        'source_post_id' => $source->id,
+        'sync_pipeline_id' => $pipeline->id,
+    ]))->toThrow(UniqueConstraintViolationException::class);
+});

--- a/tests/Feature/Sync/SyncPipelinesCrudTest.php
+++ b/tests/Feature/Sync/SyncPipelinesCrudTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\WorkspaceRole;
+use App\Models\ConnectedAccount;
+use App\Models\SyncPipeline;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\WorkspaceMembership;
+
+test('an owner can create a pipeline', function () {
+    [, $workspace] = ownerActingIn();
+    $source = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+    $dest = ConnectedAccount::factory()->linkedin()->create(['workspace_id' => $workspace->id]);
+
+    $this->post('/settings/workspace/sync-pipelines', [
+        'name' => 'X to LinkedIn',
+        'source_connected_account_id' => $source->id,
+        'destination_connected_account_ids' => [$dest->id],
+    ])->assertRedirect();
+
+    $pipeline = SyncPipeline::first();
+    expect($pipeline->name)->toBe('X to LinkedIn')
+        ->and($pipeline->destinations->pluck('id')->all())->toBe([$dest->id]);
+});
+
+test('creation is blocked at the cap of 3 when subscriptions are enabled', function () {
+    config(['subscriptions.enabled' => true, 'subscriptions.max_sync_pipelines' => 3]);
+    [, $workspace] = ownerActingIn();
+    $workspace->forceFill(['is_initial' => false])->save();
+    $workspace->subscriptions()->create([
+        'type' => 'default', 'stripe_id' => 'sub_'.fake()->uuid(),
+        'stripe_status' => 'active', 'stripe_price' => 'price_test', 'quantity' => 1,
+    ]);
+    $source = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+    $dest = ConnectedAccount::factory()->linkedin()->create(['workspace_id' => $workspace->id]);
+    SyncPipeline::factory()->count(3)->create(['workspace_id' => $workspace->id]);
+
+    $this->post('/settings/workspace/sync-pipelines', [
+        'name' => 'Over cap',
+        'source_connected_account_id' => $source->id,
+        'destination_connected_account_ids' => [$dest->id],
+    ])->assertSessionHasErrors('name');
+
+    expect(SyncPipeline::count())->toBe(3);
+});
+
+test('a member without settings.manage cannot create a pipeline', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create();
+    WorkspaceMembership::factory()->create(['workspace_id' => $workspace->id, 'user_id' => $user->id, 'role' => WorkspaceRole::Member]);
+    $user->forceFill(['current_workspace_id' => $workspace->id])->save();
+    $source = ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+
+    $this->actingAs($user)->post('/settings/workspace/sync-pipelines', [
+        'name' => 'x', 'source_connected_account_id' => $source->id, 'destination_connected_account_ids' => [],
+    ])->assertForbidden();
+});
+
+test('an owner can toggle and delete a pipeline', function () {
+    [, $workspace] = ownerActingIn();
+    $pipeline = SyncPipeline::factory()->create(['workspace_id' => $workspace->id, 'enabled' => true]);
+
+    $this->patch("/settings/workspace/sync-pipelines/{$pipeline->id}", ['enabled' => false])->assertRedirect();
+    expect($pipeline->fresh()->enabled)->toBeFalse();
+
+    $this->delete("/settings/workspace/sync-pipelines/{$pipeline->id}")->assertRedirect();
+    $this->assertDatabaseMissing('sync_pipelines', ['id' => $pipeline->id]);
+});
+
+test('pipelines from another workspace are not manageable', function () {
+    ownerActingIn();
+    $foreign = SyncPipeline::factory()->create();
+
+    $this->delete("/settings/workspace/sync-pipelines/{$foreign->id}")->assertNotFound();
+});
+
+test('the settings page renders', function () {
+    [, $workspace] = ownerActingIn();
+    ConnectedAccount::factory()->create(['workspace_id' => $workspace->id]);
+
+    $this->get('/settings/workspace/sync-pipelines')
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->component('settings/workspace/sync-pipelines')->has('accounts'));
+});


### PR DESCRIPTION
## What

Adds **sync pipelines**: a standing rule that auto-reposts a post published to a **source** account onto chosen **destination** accounts (`1 source → N destinations`), workspace-scoped, capped at 3.

This is **Phase 1 — publish-through fan-out**: when a post is published *through Shoutrrr* to the source account, it clones and fans out to the destinations, reusing the existing per-platform content adaptation and publish/retry machinery.

Phase 2 (native detection of posts made outside the app — Bluesky/Threads/IG-Business/FB-Pages/YouTube/X-metered) is designed and deferred; the `origin` enum (`Composer`/`Sync`/`External`) is already in place for it.

## How it works

- `PostTargetPublished` event fires from `PublishPostTarget` (both the happy path and crash-recovery), → queued `TriggerSyncPipelines` listener → `SyncFanOutService`.
- Fan-out clones the source post (text + media) and rebuilds destination targets via `DraftService::syncTargets` (per-platform re-split), then dispatches through the normal `PublishDispatcher`.
- **Loop-safe:** `origin=Sync` posts never re-trigger. **Idempotent:** unique index `posts(source_post_id, sync_pipeline_id)` + a `sync:reconcile` backstop (every 5 min).
- Skips destinations already targeted by the original post; excludes disabled/needs-attention accounts.
- Cap of 3 via `WorkspaceSubscriptionGate::canCreateSyncPipeline`; instance kill-switch `config/sync.php`.

## UI

- Settings → Workspace → **Sync pipelines** CRUD page + nav entry.
- Composer **"Skip sync pipelines"** per-post opt-out toggle.
- **"Synced"** badge on synced posts in the posts list.

## Tradeoffs

- Content adaptation is fully automatic (no review queue); can be lossy (a long LinkedIn post → a long X thread) — intended.
- Synced posts place all media on the head segment (no per-segment placement fidelity) — acceptable v1 tradeoff.

## Testing

- New `tests/Feature/Sync/*` (27 tests): model/schema, cap gate, fan-out (loop/idempotency/skip/exclusion/disabled/kill-switch), event+listener, reply-path guard, reconcile backstop, CRUD+authz, composer skip_sync, posts-list badge.
- Full suite green: **backend 1966 passed**, **frontend vitest 905 passed**, tsc/oxlint/oxfmt clean, Larastan L7 clean.

## How to test manually

- Create an `X → LinkedIn` pipeline in Settings; publish to X → a "Synced" LinkedIn post appears and publishes.
- Composer "Skip sync pipelines" toggle → no fan-out for that post.
- Manual X+LinkedIn post with an X→LinkedIn pipeline → LinkedIn is not double-posted.
- 4th pipeline blocked at the cap (with subscriptions enabled).
- `SYNC_ENABLED=false` → pipelines dormant.